### PR TITLE
Account for the renaming in the wellsManager

### DIFF
--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -75,7 +75,7 @@ namespace Opm
                 mapentry_t& wellMapEntry = wellMap_[ name ];
                 wellMapEntry[ 0 ] = w ;
                 wellMapEntry[ 1 ] = wells->well_connpos[w ] ;
-                if (well_controls_well_is_shut(ctrl)) {
+                if (well_controls_well_is_stopped(ctrl)) {
                     // Shut well: perfphaserates_ are all zero.
                 } else {
                     // Open well: Initialize perfphaserates_ to well


### PR DESCRIPTION
Shut is renamed to stopped in the wellsManager in order to better
reflect the name logic in the deck. This PR implements the nessesary
change in opm-autodiff

This PR depends on OPM/opm-core#709