### PR TITLE
BUGFIX: Avoid inclusion of disgas in the vapoil contribution

### DIFF
--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -613,8 +613,12 @@ namespace {
             const int po = pu.phase_pos[ Oil ];
             const int pg = pu.phase_pos[ Gas ];
 
+            // Temporary copy to avoid contribution of dissolved gas in the vaporized oil
+            // when both dissolved gas and vaporized oil are present.
+            const ADB accum_gas_copy =rq_[pg].accum[aix];
+
             rq_[pg].accum[aix] += state.rs * rq_[po].accum[aix];
-            rq_[po].accum[aix] += state.rv * rq_[pg].accum[aix];
+            rq_[po].accum[aix] += state.rv * accum_gas_copy;
             //DUMP(rq_[pg].accum[aix]);
         }
     }


### PR DESCRIPTION
A temporary copy is added to avoid inclusion of dissolved gas when the
vaporized oil contribution is added in the accumulation term for the oil
phase.

This PR adress the issue raised by @bska in #267. 

