### PR TITLE
Adds free function to access the face tag to UgGridHelpers.

### DIFF
--- a/opm/autodiff/GridHelpers.cpp
+++ b/opm/autodiff/GridHelpers.cpp
@@ -196,6 +196,12 @@ double faceArea(const Dune::CpGrid& grid, int face_index)
 {
     return grid.faceArea(face_index);
 }
+
+int faceTag(const Dune::CpGrid& grid,
+            const Opm::AutoDiffGrid::Cell2FacesRow::iterator& cell_face)
+{
+    return grid.faceTag(cell_face);
+}
 } // end namespace UgGridHelpers
 
 namespace AutoDiffGrid

--- a/opm/autodiff/GridHelpers.hpp
+++ b/opm/autodiff/GridHelpers.hpp
@@ -178,8 +178,8 @@ public:
     {
     public:
         iterator(const Dune::cpgrid::OrientedEntityTable<0,1>::row_type* row,
-                 int index)
-            : row_(row), index_(index)
+                 int index, int cell_index)
+            : row_(row), index_(index), cell_index_(cell_index)
         {}
 
         void increment()
@@ -210,31 +210,39 @@ public:
         {
             return index_==o.index_;
         }
+        int getCellIndex()const
+        {
+            return cell_index_;
+        }
         
     private:
         const Dune::cpgrid::OrientedEntityTable<0,1>::row_type* row_;
         int index_;
+        int cell_index_;
     };
     
     typedef iterator const_iterator;
 
-    Cell2FacesRow(const Dune::cpgrid::OrientedEntityTable<0,1>::row_type row)
-        : row_(row)
+    Cell2FacesRow(const Dune::cpgrid::OrientedEntityTable<0,1>::row_type row,
+                  const int cell_index)
+        : row_(row), cell_index_(cell_index)
     {}
 
     const_iterator begin() const
     {
-        return const_iterator(&row_, 0);
+        return const_iterator(&row_, 0, cell_index_);
     }
 
     const_iterator end() const
     {
-        return const_iterator(&row_, row_.size());
+        return const_iterator(&row_, row_.size(), cell_index_);
     }
     
 private:
     const Dune::cpgrid::OrientedEntityTable<0,1>::row_type row_;
+    const int cell_index_;
 };
+
 
 class Cell2FacesContainer
 {
@@ -247,7 +255,8 @@ public:
     
     Cell2FacesRow operator[](int cell_index) const
     {
-        return Cell2FacesRow(grid_->cellFaceRow(cell_index));
+        auto& row=grid_->cellFaceRow(cell_index);
+        return Cell2FacesRow(row, cell_index);
     }
     
         /// \brief Get the number of non-zero entries.
@@ -386,6 +395,13 @@ faceCells(const Dune::CpGrid& grid);
 const double* faceNormal(const Dune::CpGrid& grid, int face_index);
 
 double faceArea(const Dune::CpGrid& grid, int face_index);
+
+/// \brief Get Eclipse Cartesian tag of a face
+/// \param grid The grid that the face is part of.
+/// \param cell_face The face attached to a cell. Usually obtained from face2Cells.
+/// \return 0, 1, 2, 3, 4, 5 for I-, I+, J-, J+, K-, K+
+int faceTag(const Dune::CpGrid& grid,
+            const Opm::AutoDiffGrid::Cell2FacesRow::iterator& cell_face);
 } // end namespace UgGridHelperHelpers
 
 namespace AutoDiffGrid


### PR DESCRIPTION
It uses the iterator over the cell faces to identify the face tag in constant time. As CpGrid also needs the cell index we add it to the face cell iterator.

This is similar to pull request OPM/opm-core#720 and adds the funtionality for CpGrid. It needs OPM/dune-cornerpoint#121.

It supersedes #271 which will be closed.