### PR TITLE
Ports transmissibilities test to grid helpers

### DIFF
--- a/tests/test_transmissibilitymultipliers.cpp
+++ b/tests/test_transmissibilitymultipliers.cpp
@@ -295,7 +295,7 @@ BOOST_AUTO_TEST_CASE(TransmissibilityMultipliersCpGrid)
 
     auto ntgProps = std::make_shared<Opm::BlackoilPropsAdFromDeck>(ntgDeck, ntgEclipseState, *ntgGrid);
 
-    Opm::DerivedGeology ntgGeology(*ntgGrid, *ntgProps, ntgEclipseState);
+    Opm::DerivedGeology ntgGeology(*ntgGrid, *ntgProps, ntgEclipseState, false);
     /////
 
     // compare the transmissibilities (note that for this we assume that the multipliers


### PR DESCRIPTION
Previously, there were a completely different check for `UnstructuredGrid` and `CpGrid`. The latter probably not working properly due to missing support in the DUNE grid interface.

This commit resorts the code to use the `UgGridHelpers` abstraction instead of `UnstructuredGrid`'s legacy grid interface. Thus one code can be used to do the checks for both grids. For UG the code compiles and the test is successful. For `CpGrid` it compiles but of course the test still fails due to missing
transmissibility multiplier support. Therefore it is still deactivated.

This PR does not rely on any other one.

Once this and #272 is merged I will create a PR that makes calculation of transmissibilities possible for `CpGrid`.