### PR TITLE
Allow sim_fibo_ad to run without wells.

### DIFF
--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -20,6 +20,8 @@
 #ifndef OPM_FULLYIMPLICITBLACKOILSOLVER_HEADER_INCLUDED
 #define OPM_FULLYIMPLICITBLACKOILSOLVER_HEADER_INCLUDED
 
+#include <cassert>
+
 #include <opm/autodiff/AutoDiffBlock.hpp>
 #include <opm/autodiff/AutoDiffHelpers.hpp>
 #include <opm/autodiff/BlackoilPropsAdInterface.hpp>
@@ -198,7 +200,7 @@ namespace Opm {
         // return true if wells are available
         bool wellsActive() const { return wells_ ? wells_->number_of_wells > 0 : false ; }
         // return wells object
-        const Wells& wells () const { assert( wells_ ); return *wells_; }
+        const Wells& wells () const { assert( bool(wells_ != 0) ); return *wells_; }
 
         SolutionState
         constantState(const BlackoilState& x,

--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -90,7 +90,7 @@ namespace Opm {
                                     const BlackoilPropsAdInterface& fluid,
                                     const DerivedGeology&           geo  ,
                                     const RockCompressibility*      rock_comp_props,
-                                    const Wells&                    wells,
+                                    const Wells*                    wells,
                                     const NewtonIterationBlackoilInterface& linsolver,
                                     const bool has_disgas,
                                     const bool has_vapoil );
@@ -147,11 +147,11 @@ namespace Opm {
             ADB              rs;
             ADB              rv;
             ADB              qs;
-            ADB              bhp;       
+            ADB              bhp;
         };
 
         struct WellOps {
-            WellOps(const Wells& wells);
+            WellOps(const Wells* wells);
             M w2p;              // well -> perf (scatter)
             M p2w;              // perf -> well (gather)
         };
@@ -169,7 +169,7 @@ namespace Opm {
         const BlackoilPropsAdInterface& fluid_;
         const DerivedGeology&           geo_;
         const RockCompressibility*      rock_comp_props_;
-        const Wells&                    wells_;
+        const Wells*                    wells_;
         const NewtonIterationBlackoilInterface&    linsolver_;
         // For each canonical phase -> true if active
         const std::vector<bool>         active_;
@@ -194,6 +194,12 @@ namespace Opm {
         std::vector<int>         primalVariable_;
 
         // Private methods.
+
+        // return true if wells are available
+        bool wellsActive() const { return wells_ ? wells_->number_of_wells > 0 : false ; }
+        // return wells object
+        const Wells& wells () const { assert( wells_ ); return *wells_; }
+
         SolutionState
         constantState(const BlackoilState& x,
                       const WellStateFullyImplicitBlackoil& xw);

--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -62,12 +62,14 @@ namespace Opm
                 return;
             }
 
+            const int nw = wells->number_of_wells;
+            if( nw == 0 ) return ;
+
             // We use the WellState::init() function to do bhp and well rates init.
             // The alternative would be to copy that function wholesale.
             BaseType :: init(wells, state);
 
             // Initialize perfphaserates_, which must be done here.
-            const int nw = wells->number_of_wells;
             const int np = wells->number_of_phases;
             const int nperf = wells->well_connpos[nw];
             perfphaserates_.resize(nperf * np, 0.0);


### PR DESCRIPTION
This PR fixes all places where the code was not acknowledging that the wells pointer could be zero when no wells were specified in the deck. The results for SPE9 are identical. From that I deduct that also Norne still runs ;-). I would appreciate  if somebody could take a look at this.