### PR TITLE
Unifies the phase indices with the ones in opm-core.

### DIFF
--- a/opm/autodiff/BlackoilPropsAd.hpp
+++ b/opm/autodiff/BlackoilPropsAd.hpp
@@ -84,12 +84,6 @@ namespace Opm
         /// \return   Object describing the active phases.
         virtual PhaseUsage phaseUsage() const;
 
-        // ------ Canonical named indices for each phase ------
-
-        /// Canonical named indices for each phase.
-        enum PhaseIndex { Water = 0, Oil = 1, Gas = 2 };
-
-
         // ------ Density ------
 
         /// Densities of stock components at surface conditions.

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -41,9 +41,6 @@ namespace Opm
     typedef BlackoilPropsAdFromDeck::ADB ADB;
     typedef BlackoilPropsAdFromDeck::V V;
     typedef Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> Block;
-    enum { Aqua = BlackoilPhases::Aqua,
-           Liquid = BlackoilPhases::Liquid,
-           Vapour = BlackoilPhases::Vapour };
 
     /// Constructor wrapping an opm-core black oil interface.
     BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(Opm::DeckConstPtr deck,

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -109,12 +109,6 @@ namespace Opm
         /// \return   Object describing the active phases.
         PhaseUsage phaseUsage() const;
 
-        // ------ Canonical named indices for each phase ------
-
-        /// Canonical named indices for each phase.
-        enum PhaseIndex { Water = 0, Oil = 1, Gas = 2 };
-
-
         // ------ Density ------
 
         /// Densities of stock components at surface conditions.

--- a/opm/autodiff/BlackoilPropsAdInterface.hpp
+++ b/opm/autodiff/BlackoilPropsAdInterface.hpp
@@ -78,7 +78,12 @@ namespace Opm
         // ------ Canonical named indices for each phase ------
 
         /// Canonical named indices for each phase.
-        enum PhaseIndex { Water = 0, Oil = 1, Gas = 2 };
+        enum PhaseIndex { Water = BlackoilPhases::Aqua, Oil = BlackoilPhases::Liquid,
+                          Gas = BlackoilPhases::Vapour,
+                          Aqua = BlackoilPhases::Aqua,
+                          Liquid = BlackoilPhases::Liquid,
+                          Vapour = BlackoilPhases::Vapour,
+                          MaxNumPhases = BlackoilPhases::MaxNumPhases};
 
         // ------ Density ------
 

--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -156,9 +156,11 @@ namespace Opm {
             M p2w;              // perf -> well (gather)
         };
 
-        enum { Water = BlackoilPropsAdInterface::Water,
-               Oil   = BlackoilPropsAdInterface::Oil  ,
-               Gas   = BlackoilPropsAdInterface::Gas  };
+        enum { Water        = BlackoilPropsAdInterface::Water,
+               Oil          = BlackoilPropsAdInterface::Oil  ,
+               Gas          = BlackoilPropsAdInterface::Gas  ,
+               MaxNumPhases = BlackoilPropsAdInterface::MaxNumPhases
+         };
 
         enum PrimalVariables { Sg = 0, RS = 1, RV = 2 };
 


### PR DESCRIPTION
The initial definition of the phase indices seems to be in
opm/core/props/BlackoilPhases.hpp. Nevertheless there were
several redefinitions of the same or similar enums (either
Aqua, Liquid, and Vapor, or Water, Oil, and Gas). Surprisingly
most often these definitions did not use the original values.
This is bound to break if there is a change upstream.

This patch limits the definition to one place in opm-autodiff,
namely opm/autodiff/BlackoilPropsAdInterface.hpp. To avoid
downstream confusion we define both the Water and Aqua triplets.
In addition we define the maximum number of phases to use at compile
time.