### PR TITLE
remove template keyword.

### DIFF
--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -1279,7 +1279,7 @@ namespace {
         double infinityNorm( const ADB& a )
         {
             if( a.value().size() > 0 ) {
-                return a.value().matrix().template lpNorm<Eigen::Infinity> ();
+                return a.value().matrix().lpNorm<Eigen::Infinity> ();
             }
             else { // this situation can occur when no wells are present
                 return 0.0;


### PR DESCRIPTION
This PR fixes the gcc 4.4 issue. I have stopped using gcc 4.4 around 2010. So these things will occur in the future.