### PR TITLE
Restart solver when residual is nan or to large.

### DIFF
--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -67,6 +67,7 @@ namespace Opm {
             double                          relax_max_;
             double                          relax_increment_;
             double                          relax_rel_tol_;
+            double                          max_residual_allowed_;
             int                             max_iter_;
 
             SolverParameter( const parameter::ParameterGroup& param );
@@ -363,7 +364,8 @@ namespace Opm {
         double relaxMax() const { return param_.relax_max_; };
         double relaxIncrement() const { return param_.relax_increment_; };
         double relaxRelTol() const { return param_.relax_rel_tol_; };
-        double maxIter() const { return param_.max_iter_; }
+        double maxIter() const     { return param_.max_iter_; }
+        double maxResidualAllowed() const { return param_.max_residual_allowed_; }
 
     };
 } // namespace Opm

--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -41,6 +41,7 @@
 #include <cmath>
 #include <iostream>
 #include <iomanip>
+#include <limits>
 //#include <fstream>
 
 // A debugging utility.
@@ -169,6 +170,7 @@ namespace {
         relax_increment_ = 0.1;
         relax_rel_tol_   = 0.2;
         max_iter_        = 15;
+        max_residual_allowed_  = std::numeric_limits< double >::max();
     }
 
     template<class T>
@@ -192,6 +194,7 @@ namespace {
         dr_max_rel_  = param.getDefault("dr_max_rel", dr_max_rel_);
         relax_max_   = param.getDefault("relax_max", relax_max_);
         max_iter_    = param.getDefault("max_iter", max_iter_);
+        max_residual_allowed_ = param.getDefault("max_residual_allowed",max_residual_allowed_);
 
         std::string relaxation_type = param.getDefault("relax_type", std::string("dampen"));
         if (relaxation_type == "dampen") {
@@ -1964,16 +1967,16 @@ namespace {
         bool converged = converged_MB && converged_CNV && converged_Well;
 
         // if one of the residuals is NaN, throw exception, so that the solver can be restarted
-        if( std::isnan(mass_balance_residual_water) ||
-            std::isnan(mass_balance_residual_oil)   ||
-            std::isnan(mass_balance_residual_gas)   ||
-            std::isnan(CNVW) ||
-            std::isnan(CNVO) ||
-            std::isnan(CNVG) ||
-            std::isnan(residualWellFlux) ||
-            std::isnan(residualWell) )
+        if( std::isnan(mass_balance_residual_water) || mass_balance_residual_water > maxResidualAllowed() ||
+            std::isnan(mass_balance_residual_oil)   || mass_balance_residual_oil   > maxResidualAllowed() ||
+            std::isnan(mass_balance_residual_gas)   || mass_balance_residual_gas   > maxResidualAllowed() ||
+            std::isnan(CNVW) || CNVW > maxResidualAllowed() ||
+            std::isnan(CNVO) || CNVO > maxResidualAllowed() ||
+            std::isnan(CNVG) || CNVG > maxResidualAllowed() ||
+            std::isnan(residualWellFlux) || residualWellFlux > maxResidualAllowed() ||
+            std::isnan(residualWell)     || residualWell     > maxResidualAllowed() )
         {
-            OPM_THROW(Opm::NumericalProblem,"One of the residuals is NaN");
+            OPM_THROW(Opm::NumericalProblem,"One of the residuals is NaN or to large!");
         }
 
         if (iteration == 0) {

--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -194,7 +194,7 @@ namespace {
         dr_max_rel_  = param.getDefault("dr_max_rel", dr_max_rel_);
         relax_max_   = param.getDefault("relax_max", relax_max_);
         max_iter_    = param.getDefault("max_iter", max_iter_);
-        max_residual_allowed_ = param.getDefault("max_residual_allowed",max_residual_allowed_);
+        max_residual_allowed_ = param.getDefault("max_residual_allowed", max_residual_allowed_);
 
         std::string relaxation_type = param.getDefault("relax_type", std::string("dampen"));
         if (relaxation_type == "dampen") {


### PR DESCRIPTION
This PR introduces a small change that throws an Opm::NumericalProblem exception when one of the residuals is either NaN or to large. The tolerance for "to large" is numeric_limits<double>::max() by default but can by user specified. 