### PR TITLE
Use original grid cell volume to compute pore volume.

### DIFF
--- a/opm/autodiff/GeoProps.hpp
+++ b/opm/autodiff/GeoProps.hpp
@@ -27,7 +27,7 @@
 #include <opm/core/pressure/tpfa/TransTpfa.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-
+#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/core/utility/platform_dependent/disable_warnings.h>
 
 #include <Eigen/Eigen>
@@ -90,6 +90,10 @@ namespace Opm
                 ntg = eclState->getDoubleGridProperty("NTG")->getData();
             }
 
+            // get grid from parser.
+            
+            // Get original grid cell volume.
+            EclipseGridConstPtr eclgrid = eclState->getEclipseGrid();
             // Pore volume
             for (int cellIdx = 0; cellIdx < numCells; ++cellIdx) {
                 int cartesianCellIdx = AutoDiffGrid::globalCell(grid)[cellIdx];
@@ -97,7 +101,8 @@ namespace Opm
                     props.porosity()[cellIdx]
                     * multpv[cartesianCellIdx]
                     * ntg[cartesianCellIdx]
-                    * AutoDiffGrid::cellVolume(grid, cellIdx);
+                    * eclgrid->getCellVolume(cartesianCellIdx);
+                //                    * AutoDiffGrid::cellVolume(grid, cellIdx);
             }
 
             // Transmissibility


### PR DESCRIPTION
The results of this PR is showed in https://github.com/OPM/opm-core/pull/734#issuecomment-71953906 .

*Note*: this PR doesn't change the results of full NORNE case, maybe even improve it a little bit, the full test hasn't been done.