### PR TITLE
Fixes raisal of assertion in Eigen because of empty vector and matrices. Fixes #290

### DIFF
--- a/opm/autodiff/AutoDiffBlock.hpp
+++ b/opm/autodiff/AutoDiffBlock.hpp
@@ -148,9 +148,21 @@ namespace Opm
             }
             // ... then set the one corrresponding to this variable to identity.
             assert(blocksizes[index] == num_elem);
-            jac[index].reserve(Eigen::VectorXi::Constant(val.size(), 1));
-            for (typename M::Index row = 0; row < val.size(); ++row) {
-                jac[index].insert(row, row) = Scalar(1.0);
+            if(val.size()>0)
+            {
+                // if val is empty the following will run into an assertion
+                // with Eigen
+                jac[index].reserve(Eigen::VectorXi::Constant(val.size(), 1));
+                for (typename M::Index row = 0; row < val.size(); ++row) {
+                    jac[index].insert(row, row) = Scalar(1.0);
+                }
+            }
+            else
+            {
+                // Do some check. Empty jacobian only make sense for empty val.
+                for (int i = 0; i < num_blocks; ++i) {
+                    assert(jac[i].size()==0);
+            }
             }
             return AutoDiffBlock(val, jac);
         }


### PR DESCRIPTION
Apparently Eigen cannot handle empty containers during reserve correctly.
Therfore we check for the size of the vector and if it is zero simply create
empty jacobians.

Closes #290