### PR TITLE
support MINPVF.

### DIFF
--- a/opm/autodiff/GeoProps.hpp
+++ b/opm/autodiff/GeoProps.hpp
@@ -94,15 +94,20 @@ namespace Opm
             
             // Get original grid cell volume.
             EclipseGridConstPtr eclgrid = eclState->getEclipseGrid();
-            // Pore volume
+            // Pore volume.
+            // New keywords MINPVF will add some PV due to OPM cpgrid process algorithm.
+            // But the default behavior is to get the comparable pore volume with ECLIPSE.
             for (int cellIdx = 0; cellIdx < numCells; ++cellIdx) {
                 int cartesianCellIdx = AutoDiffGrid::globalCell(grid)[cellIdx];
                 pvol_[cellIdx] =
                     props.porosity()[cellIdx]
                     * multpv[cartesianCellIdx]
-                    * ntg[cartesianCellIdx]
-                    * eclgrid->getCellVolume(cartesianCellIdx);
-                //                    * AutoDiffGrid::cellVolume(grid, cellIdx);
+                    * ntg[cartesianCellIdx];
+                if (eclgrid->isMinpvfActive()) {
+                    pvol_[cellIdx] *= AutoDiffGrid::cellVolume(grid, cellIdx);
+                } else {
+                    pvol_[cellIdx] *= eclgrid->getCellVolume(cartesianCellIdx);
+                }                
             }
 
             // Transmissibility

--- a/opm/autodiff/GeoProps.hpp
+++ b/opm/autodiff/GeoProps.hpp
@@ -103,7 +103,7 @@ namespace Opm
                     props.porosity()[cellIdx]
                     * multpv[cartesianCellIdx]
                     * ntg[cartesianCellIdx];
-                if (eclgrid->isMinpvfActive()) {
+                if (eclgrid->getMinpvMode() == MinpvMode::ModeEnum::OpmFIL) {
                     pvol_[cellIdx] *= AutoDiffGrid::cellVolume(grid, cellIdx);
                 } else {
                     pvol_[cellIdx] *= eclgrid->getCellVolume(cartesianCellIdx);


### PR DESCRIPTION
PR https://github.com/OPM/opm-parser/pull/416 and https://github.com/OPM/opm-core/pull/750 should go first,

Note: the default behavior is to get the "same" PV as ECLIPSE,  only if the user set MINPVF in the deck, the total PV will be different with ECLIPSE within an acceptable tolerance.