### PR TITLE
[bugfix] Fixes dependency clause of #296

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -3,5 +3,5 @@ Description: Utilities for automatic differentiation and simulators based on AD
 Version: 0.9
 Label: 2013.10
 Maintainer: atgeirr@sintef.no
-Depends: opm-core, dune-istl
+Depends: opm-core dune-istl (>=2.2)
 Suggests: dune-cornerpoint


### PR DESCRIPTION
It caused dunecontrol to abort because of using a comma as a separator.
This commit removes the erroneous comma and adds a required version.

I apologize for the lack of testing the previous PR.