### PR TITLE
Adds data redistribution capabilities and makes sim_fibo_ad_cp parallel.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -113,6 +113,7 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/autodiff/NewtonIterationBlackoilSimple.hpp
 	opm/autodiff/LinearisedBlackoilResidual.hpp
 	opm/autodiff/RateConverter.hpp
+        opm/autodiff/RedistributeDataHandles.hpp
 	opm/autodiff/SimulatorCompressibleAd.hpp
 	opm/autodiff/SimulatorFullyImplicitBlackoil.hpp
 	opm/autodiff/SimulatorFullyImplicitBlackoil_impl.hpp

--- a/examples/sim_fibo_ad_cp.cpp
+++ b/examples/sim_fibo_ad_cp.cpp
@@ -233,8 +233,8 @@ try
         Opm::BlackoilStateDataHandle state_handle(global_grid, distributed_grid,
                                                   state, distributed_state);
         Opm::BlackoilPropsDataHandle props_handle(global_grid, distributed_grid,
-                                                  static_cast<BlackoilPropsAdFromDeck&>(*new_props),
-                                                  static_cast<BlackoilPropsAdFromDeck&>(*distributed_props));
+                                                  *new_props,
+                                                  *distributed_props);
         grid->scatterData(state_handle);
         grid->scatterData(props_handle);
     }

--- a/examples/sim_fibo_ad_cp.cpp
+++ b/examples/sim_fibo_ad_cp.cpp
@@ -219,7 +219,7 @@ try
         {
             OPM_THROW(std::logic_error, "We only support vtk output during parallel runs");
         }
-        grid->loadBalance(2);
+        grid->loadBalance();
         Dune::CpGrid global_grid      = *grid;
         distributed_grid = *grid;
         global_grid.switchToGlobalView();

--- a/examples/sim_fibo_ad_cp.cpp
+++ b/examples/sim_fibo_ad_cp.cpp
@@ -216,9 +216,11 @@ try
     bool must_distribute = ( grid->comm().size()>=1 );
     if( must_distribute )
     {
-        if(!param.getDefault("output_vtk", true))
+        if( param.getDefault("output_matlab", false) || param.getDefault("output_ecl", true) )
         {
-            OPM_THROW(std::logic_error, "We only support vtk output during parallel runs");
+            OPM_THROW(std::logic_error, "We only support vtk output during parallel runs. "
+                      <<"Please use \"output_matlab=false output_ecl=false\" to deactivate the "
+                      <<"other outputs!");
         }
         grid->loadBalance();
         Dune::CpGrid global_grid      = *grid;

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -77,6 +77,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         OPM_THROW(std::runtime_error, "The number of cells is has to be larger than 0.");
     // Copy properties that do not depend on the postion within the grid.
     rock_             = props.rock_;
+    satprops_         = props.satprops_;
     phase_usage_      = props.phase_usage_;
     props_            = props.props_;
     densities_        = props.densities_;
@@ -87,7 +88,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
     // and initialize with obviously bogus numbers.
     cellPvtRegionIdx_.resize(number_of_cells, std::numeric_limits<int>::min());
     pvtTableIdx_.resize(number_of_cells, std::numeric_limits<int>::min());
-    satOilMax_.resize(number_of_cells, -std::numeric_limits<double>::max());
 }
 
     /// Initializes the properties.

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -1,5 +1,7 @@
 /*
   Copyright 2013 SINTEF ICT, Applied Mathematics.
+  Copyright 2015 Dr. Blatt - HPC-Simulation-Software & Services.
+  Copyright 2015 NTNU.
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -64,6 +66,29 @@ namespace Opm
              grid.beginCellCentroids(), Dune::CpGrid::dimension, init_rock);
     }
 #endif
+
+/// Constructor for properties on a subgrid
+BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& props,
+                                                 const int number_of_cells)
+{
+    if(number_of_cells>props.cellPvtRegionIdx_.size())
+        OPM_THROW(std::runtime_error, "The number of cells is larger than the one of the original grid!");
+    if(number_of_cells<0)
+        OPM_THROW(std::runtime_error, "The number of cells is has to be larger than 0.");
+    // Copy properties that do not depend on the postion within the grid.
+    rock_             = props.rock_;
+    phase_usage_      = props.phase_usage_;
+    props_            = props.props_;
+    densities_        = props.densities_;
+    vap1_             = props.vap1_;
+    vap2_             = props.vap2_;
+    vap_satmax_guard_ = props.vap_satmax_guard_;
+    // For data that is dependant on the subgrid we simply allocate space
+    // and initialize with obviously bogus numbers.
+    cellPvtRegionIdx_.resize(number_of_cells, std::numeric_limits<int>::min());
+    pvtTableIdx_.resize(number_of_cells, std::numeric_limits<int>::min());
+    satOilMax_.resize(number_of_cells, -std::numeric_limits<double>::max());
+}
 
     /// Initializes the properties.
     template <class CentroidIterator>

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -1,5 +1,7 @@
 /*
   Copyright 2013 SINTEF ICT, Applied Mathematics.
+  Copyright 2015 Dr. Blatt - HPC-Simulation-Software & Services.
+  Copyright 2015 NTNU.
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -69,6 +71,19 @@ namespace Opm
                                 const Dune::CpGrid& grid,
                                 const bool init_rock = true );
 #endif
+
+        /// \brief Constructor to create properties for a subgrid
+        ///
+        /// This copies all properties that are not dependant on the
+        /// grid size from an existing properties object
+        /// and the number of cells. All properties that do not depend
+        /// on the grid dimension will be copied. For the rest will have
+        /// the correct size but the values will be undefined.
+        ///
+        /// \param props            The property object to copy from.
+        /// \paramm number_of_cells The number of cells of the subgrid.
+        BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& props,
+                                const int number_of_cells);
 
 
         ////////////////////////////
@@ -433,7 +448,9 @@ namespace Opm
                       const double vap) const;
 
         RockFromDeck rock_;
-        std::unique_ptr<SaturationPropsInterface> satprops_;
+        // This has to be a shared pointer as we must
+        // be able to make a copy of *this in the parallel case.
+        std::shared_ptr<SaturationPropsInterface> satprops_;
 
         PhaseUsage phase_usage_;
         // bool has_vapoil_;

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -57,6 +57,7 @@ namespace Opm
     /// version of the methods.
     class BlackoilPropsAdFromDeck : public BlackoilPropsAdInterface
     {
+        friend class BlackoilPropsDataHandle;
     public:
         /// Constructor wrapping an opm-core black oil interface.
         BlackoilPropsAdFromDeck(Opm::DeckConstPtr deck,

--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -1906,6 +1906,7 @@ namespace {
         {
             const ParallelISTLInformation& info =
                 boost::any_cast<const ParallelISTLInformation&>(linsolver_.parallelInformation());
+
             // Compute the global number of cells and porevolume
             std::vector<int> v(nc, 1);
             auto nc_and_pv = std::tuple<int, double>(0, 0.0);
@@ -1913,7 +1914,7 @@ namespace {
                                                         Opm::Reduction::makeGlobalSumFunctor<double>());
             auto nc_and_pv_containers  = std::make_tuple(v, geo_.poreVolume());
             info.computeReduction(nc_and_pv_containers, nc_and_pv_operators, nc_and_pv);
-            
+
             for ( int idx=0; idx<MaxNumPhases; ++idx )
             {
                 if (active_[idx]) {

--- a/opm/autodiff/NewtonIterationBlackoilCPR.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilCPR.hpp
@@ -91,6 +91,7 @@ namespace Opm
             // Construct preconditioner.
             // typedef Dune::SeqILU0<Mat,Vector,Vector> Preconditioner;
             typedef Opm::CPRPreconditioner<Mat,Vector,Vector,P> Preconditioner;
+            parallelInformation.copyOwnerToAll(istlb, istlb);
             Preconditioner precond(opA.getmat(), istlAe, cpr_relax_, cpr_ilu_n_, cpr_use_amg_, cpr_use_bicgstab_, parallelInformation);
 
             // Construct linear solver.

--- a/opm/autodiff/RedistributeDataHandles.hpp
+++ b/opm/autodiff/RedistributeDataHandles.hpp
@@ -1,0 +1,226 @@
+/*
+  Copyright 2015 Dr. Blatt - HPC-Simulation-Software & Services.
+  Coypright 2015 NTNU
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <opm/autodiff/BlackoilPropsAdFromDeck.hpp>
+#include <opm/core/simulator/BlackoilState.hpp>
+
+namespace Opm
+{
+/// \brief a data handle to distribute the BlackoilState
+class BlackoilStateDataHandle
+{
+public:
+    /// \brief The data that we send.
+    typedef double DataType;
+    /// \brief Constructor.
+    /// \param sendGrid   The grid that the data is attached to when sending.
+    /// \param recvGrid   The grid that the data is attached to when receiving.
+    /// \param sendState  The state where we will retieve the values to be sent.
+    /// \parame recvState The state where we will store the received values.
+    BlackoilStateDataHandle(const Dune::CpGrid& sendGrid,
+                            const Dune::CpGrid& recvGrid,
+                            const BlackoilState& sendState,
+                            BlackoilState& recvState)
+        : sendGrid_(sendGrid), recvGrid_(recvGrid), sendState_(sendState), recvState_(recvState)
+    {}
+
+    bool fixedsize(int /*dim*/, int /*codim*/)
+    {
+        return false;
+    }
+
+    template<class T>
+    std::size_t size(const T& e)
+    {
+        if ( T::codimension == 0)
+        {
+            return 2 * sendState_.numPhases() +4+2*sendGrid_.numCellFaces(e.index());
+        }
+        else
+        {
+            OPM_THROW(std::logic_error, "Data handle can only be used for elements");
+        }
+    }
+
+    template<class B, class T>
+    void gather(B& buffer, const T& e)
+    {
+        assert( T::codimension == 0);
+
+        for ( int i=0; i<sendState_.numPhases(); ++i )
+        {
+            buffer.write(sendState_.surfacevol()[e.index()*sendState_.numPhases()+i]);
+        }
+        buffer.write(sendState_.gasoilratio()[e.index()]);
+        buffer.write(sendState_.rv()[e.index()]);
+        buffer.write(sendState_.pressure()[e.index()]);
+        buffer.write(sendState_.temperature()[e.index()]);
+        buffer.write(sendState_.saturation()[e.index()]);
+
+        for ( int i=0; i<sendGrid_.numCellFaces(e.index()); ++i )
+        {
+            buffer.write(sendState_.facepressure()[sendGrid_.cellFace(e.index(), i)]);
+        }
+        for ( int i=0; i<sendGrid_.numCellFaces(e.index()); ++i )
+        {
+            buffer.write(recvState_.faceflux()[sendGrid_.cellFace(e.index(), i)]);
+        }
+    }
+    template<class B, class T>
+    void scatter(B& buffer, const T& e, std::size_t size)
+    {
+        assert( T::codimension == 0);
+        assert( size == 2 * recvState_.numPhases() +4+2*recvGrid_.numCellFaces(e.index()));
+        (void) size;
+
+        for ( int i=0; i<recvState_.numPhases(); ++i )
+        {
+            double val;
+            buffer.read(val);
+            recvState_.surfacevol()[e.index()]=val;
+        }
+        double val;
+        buffer.read(val);
+        recvState_.gasoilratio()[e.index()]=val;
+        buffer.read(val);
+        recvState_.rv()[e.index()]=val;
+        buffer.read(val);
+        recvState_.pressure()[e.index()]=val;
+        buffer.read(val);
+        recvState_.temperature()[e.index()]=val;
+        buffer.read(val);
+        recvState_.saturation()[e.index()]=val;
+
+        for ( int i=0; i<recvGrid_.numCellFaces(e.index()); ++i )
+        {
+            double val;
+            buffer.read(val);
+            recvState_.facepressure()[recvGrid_.cellFace(e.index(), i)]=val;
+        }
+        for ( int i=0; i<recvGrid_.numCellFaces(e.index()); ++i )
+        {
+            double val;
+            buffer.read(val);
+            recvState_.faceflux()[recvGrid_.cellFace(e.index(), i)]=val;
+        }
+    }
+    bool contains(int dim, int codim)
+    {
+        return dim==3 && codim==0;
+    }
+private:
+    /// \brief The grid that the data is attached to when sending
+    const Dune::CpGrid& sendGrid_;
+    /// \brief The grid that the data is attached to when receiving
+    const Dune::CpGrid& recvGrid_;
+    /// \brief The state where we will retieve the values to be sent.
+    const BlackoilState& sendState_;
+    // \brief The state where we will store the received values.
+    BlackoilState& recvState_;
+};
+
+class BlackoilPropsDataHandle
+{
+public:
+    /// \brief The data that we send.
+    typedef double DataType;
+    /// \brief Constructor.
+    /// \param sendGrid   The grid that the data is attached to when sending.
+    /// \param recvGrid   The grid that the data is attached to when receiving.
+    /// \param sendProps  The properties where we will retieve the values to be sent.
+    /// \parame recvProps The properties where we will store the received values.
+    BlackoilPropsDataHandle(const Dune::CpGrid& sendGrid,
+                            const Dune::CpGrid& recvGrid,
+                            const BlackoilPropsAdFromDeck& sendProps,
+                            BlackoilPropsAdFromDeck& recvProps)
+        : sendGrid_(sendGrid), recvGrid_(recvGrid), sendProps_(sendProps), recvProps_(recvProps),
+          size_(2)
+    {
+        // satOilMax might be non empty. In this case we will need to send it, too.
+        if ( sendProps.satOilMax_.size()>0 )
+        {
+            recvProps_.satOilMax_.resize(recvGrid.numCells(),
+                                         -std::numeric_limits<double>::max());
+            ++size_;
+        }
+    }
+
+    bool fixedsize(int /*dim*/, int /*codim*/)
+    {
+        return true;
+    }
+
+    template<class T>
+    std::size_t size(const T&)
+    {
+        if ( T::codimension == 0)
+        {
+            // We only send pvtTableIdx_, cellPvtRegionIdx_, and maybe satOilMax_
+            return size_;
+        }
+        else
+        {
+            OPM_THROW(std::logic_error, "Data handle can only be used for elements");
+        }
+    }
+    template<class B, class T>
+    void gather(B& buffer, const T& e)
+    {
+        assert( T::codimension == 0);
+
+        buffer.write(sendProps_.cellPvtRegionIndex()[e.index()]);
+        buffer.write(sendProps_.pvtTableIdx_[e.index()]);
+        if ( size_==2 )
+            return;
+        buffer.write(sendProps_.satOilMax_[e.index()]);
+    }
+    template<class B, class T>
+    void scatter(B& buffer, const T& e, std::size_t size)
+    {
+        assert( T::codimension == 0);
+        assert( size==size_ ); (void) size;
+        double val;
+        buffer.read(val);
+        recvProps_.cellPvtRegionIdx_[e.index()]=val;
+        buffer.read(val);
+        recvProps_.pvtTableIdx_[e.index()]=val;
+        if ( size_==2 )
+            return;
+        buffer.read(val);
+        recvProps_.satOilMax_[e.index()]=val;
+    }
+    bool contains(int dim, int codim)
+    {
+        return dim==3 && codim==0;
+    }
+private:
+    /// \brief The grid that the data is attached to when sending
+    const Dune::CpGrid& sendGrid_;
+    /// \brief The grid that the data is attached to when receiving
+    const Dune::CpGrid& recvGrid_;
+    /// \brief The properties where we will retieve the values to be sent.
+    const BlackoilPropsAdFromDeck& sendProps_;
+    // \brief The properties where we will store the received values.
+    BlackoilPropsAdFromDeck& recvProps_;
+    std::size_t size_;
+};
+
+} // end namespace Opm

--- a/opm/autodiff/RedistributeDataHandles.hpp
+++ b/opm/autodiff/RedistributeDataHandles.hpp
@@ -189,7 +189,9 @@ public:
         buffer.write(sendProps_.cellPvtRegionIndex()[e.index()]);
         buffer.write(sendProps_.pvtTableIdx_[e.index()]);
         if ( size_==2 )
+        {
             return;
+        }
         buffer.write(sendProps_.satOilMax_[e.index()]);
     }
     template<class B, class T>

--- a/tests/test_boprops_ad.cpp
+++ b/tests/test_boprops_ad.cpp
@@ -27,6 +27,7 @@
 #define BOOST_TEST_MODULE FluidPropertiesTest
 
 #include <opm/autodiff/BlackoilPropsAd.hpp>
+#include <opm/autodiff/BlackoilPropsAdFromDeck.hpp>
 
 #include <boost/test/unit_test.hpp>
 
@@ -82,13 +83,35 @@ struct TestFixture : public Setup
     Opm::BlackoilPropertiesFromDeck props;
 };
 
+template <class Setup>
+struct TestFixtureAd : public Setup
+{
+    TestFixtureAd()
+        : Setup()
+        , grid (deck)
+        , props(deck, eclState, *grid.c_grid(),
+                param.getDefault("init_rock", false))
+    {
+    }
+
+    using Setup::param;
+    using Setup::deck;
+    using Setup::eclState;
+
+    Opm::GridManager             grid;
+    Opm::BlackoilPropsAdFromDeck props;
+};
+
 
 BOOST_FIXTURE_TEST_CASE(Construction, TestFixture<SetupSimple>)
 {
     Opm::BlackoilPropsAd boprops_ad(props);
 }
 
-
+BOOST_FIXTURE_TEST_CASE(SubgridConstruction, TestFixtureAd<SetupSimple>)
+{
+    Opm::BlackoilPropsAdFromDeck subgrid_props(props);
+}
 
 BOOST_FIXTURE_TEST_CASE(SurfaceDensity, TestFixture<SetupSimple>)
 {


### PR DESCRIPTION
With this PR we add the possibility to start with a global representation
of a simulator that is read on each process and afterwards this presentation
is redistributed among the processors together with the properties and
state data needed to initialize the simulation.

There still is no parallel well handling and no parallel output. But with the
equilibrium example of @dr-robertk and deactivated output we can already
perform parallel runs.

We still need two levels of overlap cells to get correct results.