### PR TITLE
Store the boost::any of ParallelIstlInformation by value. (Alternative to #303)

### DIFF
--- a/opm/autodiff/NewtonIterationBlackoilCPR.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilCPR.hpp
@@ -109,7 +109,7 @@ namespace Opm
         unsigned int cpr_ilu_n_;
         bool cpr_use_amg_;
         bool cpr_use_bicgstab_;
-        const boost::any& parallelInformation_;
+        boost::any parallelInformation_;
     };
 
 } // namespace Opm

--- a/opm/autodiff/NewtonIterationBlackoilSimple.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilSimple.hpp
@@ -61,7 +61,7 @@ namespace Opm
     private:
         std::unique_ptr<LinearSolverInterface> linsolver_;
         mutable int iterations_;
-        const boost::any& parallelInformation_;
+        boost::any parallelInformation_;
     };
 
 } // namespace Opm


### PR DESCRIPTION
This an alternative to PR #303
During the constructor the underlying object only holds smart
pointers and an empty vector. The FullyImplicitBlackoilSolver
obtains  a reference to it from the NewtInterationInterface instances.
Therefore copying boost::any and storing it by value should be cheap
and safe.