### PR TITLE
The stream::open() functions require c_str()

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -292,7 +292,7 @@ namespace Opm
             const std::string& filename,
             const int desiredResportStep )
     {
-        std::ifstream restorefile( filename );
+        std::ifstream restorefile( filename.c_str() );
         if( restorefile )
         {
             std::cout << "============================================================================"<<std::endl;

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -263,7 +263,7 @@ namespace Opm
             std::string backupfilename = param.getDefault("backupfile", std::string("") );
             if( ! backupfilename.empty() )
             {
-                backupfile_.open( backupfilename );
+                backupfile_.open( backupfilename.c_str() );
             }
         }
     }


### PR DESCRIPTION
This quirk is required to build in Statoil (gcc44?)