### PR TITLE
opm-166: Fix due to signature change in method thresholdPressures

### DIFF
--- a/examples/sim_fibo_ad.cpp
+++ b/examples/sim_fibo_ad.cpp
@@ -208,7 +208,7 @@ try
     bool use_local_perm = param.getDefault("use_local_perm", true);
     Opm::DerivedGeology geology(*grid->c_grid(), *new_props, eclipseState, use_local_perm, grav);
 
-    std::vector<double> threshold_pressures = thresholdPressures(deck, eclipseState, *grid->c_grid());
+    std::vector<double> threshold_pressures = thresholdPressures(eclipseState, *grid->c_grid());
 
     SimulatorFullyImplicitBlackoil<UnstructuredGrid> simulator(param,
                                              *grid->c_grid(),

--- a/examples/sim_fibo_ad_cp.cpp
+++ b/examples/sim_fibo_ad_cp.cpp
@@ -281,7 +281,7 @@ try
 
     Opm::DerivedGeology geology(distributed_grid, *distributed_props, eclipseState, false, grav);
 
-    std::vector<double> threshold_pressures = thresholdPressures(deck, eclipseState, distributed_grid);
+    std::vector<double> threshold_pressures = thresholdPressures(eclipseState, distributed_grid);
 
     SimulatorFullyImplicitBlackoil<Dune::CpGrid> simulator(param,
                                                            distributed_grid,


### PR DESCRIPTION
The signature of the opm-core thresholdPressures(...) method is changed  - changed parameter list in call to thresholdPressures in sim_fibo_ad.cpp

 