### PR TITLE
Remove the unsused grid members from BlackoilPropsDataHandle.

### DIFF
--- a/examples/sim_fibo_ad_cp.cpp
+++ b/examples/sim_fibo_ad_cp.cpp
@@ -234,8 +234,7 @@ try
                                              std::numeric_limits<double>::max());
         Opm::BlackoilStateDataHandle state_handle(global_grid, distributed_grid,
                                                   state, distributed_state);
-        Opm::BlackoilPropsDataHandle props_handle(global_grid, distributed_grid,
-                                                  *new_props,
+        Opm::BlackoilPropsDataHandle props_handle(*new_props,
                                                   *distributed_props);
         grid->scatterData(state_handle);
         grid->scatterData(props_handle);

--- a/opm/autodiff/RedistributeDataHandles.hpp
+++ b/opm/autodiff/RedistributeDataHandles.hpp
@@ -140,21 +140,17 @@ public:
     /// \brief The data that we send.
     typedef double DataType;
     /// \brief Constructor.
-    /// \param sendGrid   The grid that the data is attached to when sending.
-    /// \param recvGrid   The grid that the data is attached to when receiving.
     /// \param sendProps  The properties where we will retieve the values to be sent.
     /// \parame recvProps The properties where we will store the received values.
-    BlackoilPropsDataHandle(const Dune::CpGrid& sendGrid,
-                            const Dune::CpGrid& recvGrid,
-                            const BlackoilPropsAdFromDeck& sendProps,
+    BlackoilPropsDataHandle(const BlackoilPropsAdFromDeck& sendProps,
                             BlackoilPropsAdFromDeck& recvProps)
-        : sendGrid_(sendGrid), recvGrid_(recvGrid), sendProps_(sendProps), recvProps_(recvProps),
+        : sendProps_(sendProps), recvProps_(recvProps),
           size_(2)
     {
         // satOilMax might be non empty. In this case we will need to send it, too.
         if ( sendProps.satOilMax_.size()>0 )
         {
-            recvProps_.satOilMax_.resize(recvGrid.numCells(),
+            recvProps_.satOilMax_.resize(recvProps_.pvtTableIdx_.size(),
                                          -std::numeric_limits<double>::max());
             ++size_;
         }
@@ -211,10 +207,6 @@ public:
         return dim==3 && codim==0;
     }
 private:
-    /// \brief The grid that the data is attached to when sending
-    const Dune::CpGrid& sendGrid_;
-    /// \brief The grid that the data is attached to when receiving
-    const Dune::CpGrid& recvGrid_;
     /// \brief The properties where we will retieve the values to be sent.
     const BlackoilPropsAdFromDeck& sendProps_;
     // \brief The properties where we will store the received values.


### PR DESCRIPTION
Previously BlackoilPropsDataHandle did hold a grid for sending
and receiving that were either not used or we could prevent their
usage. Therefore this commit removes them from the class and queries
all needed information from the property objects.