### PR TITLE
Print status output only on rank 0 for parallel runs.

### DIFF
--- a/examples/sim_fibo_ad_cp.cpp
+++ b/examples/sim_fibo_ad_cp.cpp
@@ -265,8 +265,8 @@ try
         fis_solver.reset(new NewtonIterationBlackoilSimple(param, parallel_information));
     }
 
-    // Write parameters used for later reference.
-    bool output = param.getDefault("output", true);
+    // Write parameters used for later reference. (only if rank is zero)
+    bool output = param.getDefault("output", true) && ( grid->comm().rank()==0 );
     std::string output_dir;
     if (output) {
         // Create output directory if needed.
@@ -306,13 +306,19 @@ try
                                                            outputWriter,
                                                            threshold_pressures);
 
-    std::cout << "\n\n================ Starting main simulation loop ===============\n"
-              << std::flush;
+    if( grid->comm().rank()==0 )
+    {
+        std::cout << "\n\n================ Starting main simulation loop ===============\n"
+                  << std::flush;
+    }
 
     SimulatorReport fullReport = simulator.run(simtimer, must_distribute ? distributed_state : state);
 
+    if( grid->comm().rank()==0 )
+    {
     std::cout << "\n\n================    End of simulation     ===============\n\n";
     fullReport.report(std::cout);
+    }
 
     if (output) {
         std::string filename = output_dir + "/walltime.txt";

--- a/examples/sim_fibo_ad_cp.cpp
+++ b/examples/sim_fibo_ad_cp.cpp
@@ -266,7 +266,7 @@ try
     }
 
     // Write parameters used for later reference. (only if rank is zero)
-    bool output = param.getDefault("output", true) && ( grid->comm().rank()==0 );
+    bool output = ( grid->comm().rank() == 0 ) && param.getDefault("output", true);
     std::string output_dir;
     if (output) {
         // Create output directory if needed.

--- a/examples/sim_fibo_ad_cp.cpp
+++ b/examples/sim_fibo_ad_cp.cpp
@@ -316,8 +316,8 @@ try
 
     if( grid->comm().rank()==0 )
     {
-    std::cout << "\n\n================    End of simulation     ===============\n\n";
-    fullReport.report(std::cout);
+        std::cout << "\n\n================    End of simulation     ===============\n\n";
+        fullReport.report(std::cout);
     }
 
     if (output) {

--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -196,7 +196,7 @@ namespace Opm {
 
         LinearisedBlackoilResidual residual_;
 
-        /// \brief Wether we print something to std::cout
+        /// \brief Whether we print something to std::cout
         bool terminal_output_;
 
         std::vector<int>         primalVariable_;

--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -196,6 +196,9 @@ namespace Opm {
 
         LinearisedBlackoilResidual residual_;
 
+        /// \brief Wether we print something to std::cout
+        bool verbosity_;
+
         std::vector<int>         primalVariable_;
 
         // Private methods.

--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -197,7 +197,7 @@ namespace Opm {
         LinearisedBlackoilResidual residual_;
 
         /// \brief Wether we print something to std::cout
-        bool verbosity_;
+        bool terminal_output_;
 
         std::vector<int>         primalVariable_;
 

--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -212,7 +212,7 @@ namespace detail {
         , residual_ ( { std::vector<ADB>(fluid.numPhases(), ADB::null()),
                         ADB::null(),
                         ADB::null() } )
-        , verbosity_ (true)
+        , terminal_output_ (true)
     {
 #if HAVE_MPI
         if(linsolver_.parallelInformation().type()==typeid(ParallelISTLInformation))
@@ -220,7 +220,7 @@ namespace detail {
             const ParallelISTLInformation& info =
                 boost::any_cast<const ParallelISTLInformation&>(linsolver_.parallelInformation());
             // Only rank 0 does print to std::cout
-            verbosity_= (info.communicator().rank()==0);
+            terminal_output_ = (info.communicator().rank()==0);
         }
 #endif
     }
@@ -299,7 +299,7 @@ namespace detail {
             if (isOscillate) {
                 omega -= relaxIncrement();
                 omega = std::max(omega, relaxMax());
-                if (verbosity_)
+                if (terminal_output_)
                 {
                     std::cout << " Oscillating behavior detected: Relaxation set to " << omega << std::endl;
                 }
@@ -1126,7 +1126,7 @@ namespace detail {
             }
             if (ctrl_index != nwc) {
                 // Constraint number ctrl_index was broken, switch to it.
-                if (verbosity_)
+                if (terminal_output_)
                 {
                     std::cout << "Switching control mode for well " << wells().name[w]
                               << " from " << modestring[well_controls_iget_type(wc, current)]
@@ -2009,7 +2009,7 @@ namespace detail {
             OPM_THROW(Opm::NumericalProblem,"One of the residuals is NaN or to large!");
         }
 
-        if ( verbosity_ )
+        if ( terminal_output_ )
         {
             // Only rank 0 does print to std::cout
             if (iteration == 0) {

--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -215,7 +215,7 @@ namespace detail {
         , terminal_output_ (true)
     {
 #if HAVE_MPI
-        if(linsolver_.parallelInformation().type()==typeid(ParallelISTLInformation))
+        if ( linsolver_.parallelInformation().type() == typeid(ParallelISTLInformation) )
         {
             const ParallelISTLInformation& info =
                 boost::any_cast<const ParallelISTLInformation&>(linsolver_.parallelInformation());
@@ -1887,7 +1887,7 @@ namespace detail {
     {
         // Do the global reductions
 #if HAVE_MPI
-        if(linsolver_.parallelInformation().type()==typeid(ParallelISTLInformation))
+        if ( linsolver_.parallelInformation().type() == typeid(ParallelISTLInformation) )
         {
             const ParallelISTLInformation& info =
                 boost::any_cast<const ParallelISTLInformation&>(linsolver_.parallelInformation());
@@ -1997,7 +1997,7 @@ namespace detail {
         const bool   converged        = converged_MB && converged_CNV && converged_Well;
 
         // if one of the residuals is NaN, throw exception, so that the solver can be restarted
-        if( std::isnan(mass_balance_residual[Water]) || mass_balance_residual[Water] > maxResidualAllowed() ||
+        if ( std::isnan(mass_balance_residual[Water]) || mass_balance_residual[Water] > maxResidualAllowed() ||
             std::isnan(mass_balance_residual[Oil])   || mass_balance_residual[Oil]   > maxResidualAllowed() ||
             std::isnan(mass_balance_residual[Gas])   || mass_balance_residual[Gas]   > maxResidualAllowed() ||
             std::isnan(CNV[Water]) || CNV[Water] > maxResidualAllowed() ||

--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -296,10 +296,13 @@ namespace detail {
 
             detectNewtonOscillations(residual_norms_history, it, relaxRelTol(), isOscillate, isStagnate);
 
-            if (isOscillate && verbosity_) {
+            if (isOscillate) {
                 omega -= relaxIncrement();
                 omega = std::max(omega, relaxMax());
-                std::cout << " Oscillating behavior detected: Relaxation set to " << omega << std::endl;
+                if (verbosity_)
+                {
+                    std::cout << " Oscillating behavior detected: Relaxation set to " << omega << std::endl;
+                }
             }
 
             stablizeNewton(dx, dxOld, omega, relaxtype);

--- a/opm/autodiff/SimulatorFullyImplicitBlackoil_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoil_impl.hpp
@@ -112,7 +112,7 @@ namespace Opm
         std::vector<int> allcells_;
         const bool has_disgas_;
         const bool has_vapoil_;
-        bool       verbosity_;
+        bool       terminal_output_;
         // eclipse_state
         std::shared_ptr<EclipseState> eclipse_state_;
         // output_writer
@@ -185,7 +185,7 @@ namespace Opm
           solver_(linsolver),
           has_disgas_(has_disgas),
           has_vapoil_(has_vapoil),
-          verbosity_(true),
+          terminal_output_(true),
           eclipse_state_(eclipse_state),
           output_writer_(output_writer),
           rateConverter_(props_, std::vector<int>(AutoDiffGrid::numCells(grid_), 0)),
@@ -203,7 +203,7 @@ namespace Opm
             const ParallelISTLInformation& info =
                 boost::any_cast<const ParallelISTLInformation&>(solver_.parallelInformation());
             // Only rank 0 does print to std::cout
-            verbosity_= (info.communicator().rank()==0);
+            terminal_output_= (info.communicator().rank()==0);
         }
 #endif
     }
@@ -250,7 +250,7 @@ namespace Opm
         while (!timer.done()) {
             // Report timestep.
             step_timer.start();
-            if ( verbosity_ )
+            if ( terminal_output_ )
             {
                 timer.report(std::cout);
             }
@@ -307,7 +307,7 @@ namespace Opm
             // Report timing.
             const double st = solver_timer.secsSinceStart();
 
-            if ( verbosity_ )
+            if ( terminal_output_ )
             {
                 std::cout << "Fully implicit solver took: " << st << " seconds." << std::endl;
             }

--- a/opm/autodiff/SimulatorFullyImplicitBlackoil_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoil_impl.hpp
@@ -112,6 +112,7 @@ namespace Opm
         std::vector<int> allcells_;
         const bool has_disgas_;
         const bool has_vapoil_;
+        bool       verbosity_;
         // eclipse_state
         std::shared_ptr<EclipseState> eclipse_state_;
         // output_writer
@@ -184,6 +185,7 @@ namespace Opm
           solver_(linsolver),
           has_disgas_(has_disgas),
           has_vapoil_(has_vapoil),
+          verbosity_(true),
           eclipse_state_(eclipse_state),
           output_writer_(output_writer),
           rateConverter_(props_, std::vector<int>(AutoDiffGrid::numCells(grid_), 0)),
@@ -195,6 +197,15 @@ namespace Opm
         for (int cell = 0; cell < num_cells; ++cell) {
             allcells_[cell] = cell;
         }
+#if HAVE_MPI
+        if(solver_.parallelInformation().type()==typeid(ParallelISTLInformation))
+        {
+            const ParallelISTLInformation& info =
+                boost::any_cast<const ParallelISTLInformation&>(solver_.parallelInformation());
+            // Only rank 0 does print to std::cout
+            verbosity_= (info.communicator().rank()==0);
+        }
+#endif
     }
 
 
@@ -239,7 +250,10 @@ namespace Opm
         while (!timer.done()) {
             // Report timestep.
             step_timer.start();
-            timer.report(std::cout);
+            if ( verbosity_ )
+            {
+                timer.report(std::cout);
+            }
 
             // Create wells and well state.
             WellsManager wells_manager(eclipse_state_,
@@ -292,7 +306,12 @@ namespace Opm
 
             // Report timing.
             const double st = solver_timer.secsSinceStart();
-            std::cout << "Fully implicit solver took: " << st << " seconds." << std::endl;
+
+            if ( verbosity_ )
+            {
+                std::cout << "Fully implicit solver took: " << st << " seconds." << std::endl;
+            }
+
             stime += st;
             if ( output_writer_.output() ) {
                 SimulatorReport step_report;

--- a/opm/autodiff/SimulatorFullyImplicitBlackoil_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoil_impl.hpp
@@ -198,7 +198,7 @@ namespace Opm
             allcells_[cell] = cell;
         }
 #if HAVE_MPI
-        if(solver_.parallelInformation().type()==typeid(ParallelISTLInformation))
+        if ( solver_.parallelInformation().type() == typeid(ParallelISTLInformation) )
         {
             const ParallelISTLInformation& info =
                 boost::any_cast<const ParallelISTLInformation&>(solver_.parallelInformation());


### PR DESCRIPTION
Before this PR each rank would print status about the simulation to the terminal. This duplicate information did clutter the screen quite a bit. Now only rank 0 is responsible for the output.