### PR TITLE
Modified sim_fibo_ad_cp to also allow running with EQUIL keyword.

### DIFF
--- a/examples/sim_fibo_ad_cp.cpp
+++ b/examples/sim_fibo_ad_cp.cpp
@@ -198,7 +198,10 @@ try
             }
         }
     } else if (deck->hasKeyword("EQUIL") && props->numPhases() == 3) {
-        OPM_THROW(std::logic_error, "sim_fibo_ad_cp does not support EQUIL initialization.");
+        state.init(grid->numCells(), grid->numFaces(), props->numPhases());
+        const double grav = param.getDefault("gravity", unit::gravity);
+        initStateEquil(*grid, *props, deck, eclipseState, grav, state);
+        state.faceflux().resize(grid->numFaces(), 0.0);
     } else {
         initBlackoilStateFromDeck(grid->numCells(), &(grid->globalCell())[0],
                                   grid->numFaces(), UgGridHelpers::faceCells(*grid),

--- a/opm/autodiff/GridHelpers.cpp
+++ b/opm/autodiff/GridHelpers.cpp
@@ -1,6 +1,7 @@
 /*
-  Copyright 2014 Dr. Markus Blatt - HPC-Simulation-Software & Services.
+  Copyright 2014, 2015 Dr. Markus Blatt - HPC-Simulation-Software & Services.
   Copyright 2014 Statoil AS
+  Copyright 2015 NTNU
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -185,6 +186,17 @@ FaceCellTraits<Dune::CpGrid>::Type
 faceCells(const Dune::CpGrid& grid)
 {
     return Opm::AutoDiffGrid::FaceCellsContainerProxy(&grid);
+}
+
+Face2VerticesTraits<Dune::CpGrid>::Type
+face2Vertices(const Dune::CpGrid& grid)
+{
+    return Opm::AutoDiffGrid::FaceVerticesContainerProxy(&grid);
+}
+
+const double* vertexCoordinates(const Dune::CpGrid& grid, int index)
+{
+    return &(grid.vertexPosition(index)[0]);
 }
 
 const double* faceNormal(const Dune::CpGrid& grid, int face_index)

--- a/opm/autodiff/GridHelpers.hpp
+++ b/opm/autodiff/GridHelpers.hpp
@@ -149,7 +149,7 @@ public:
     
     /// \brief Constructor.
     /// \param grid The grid whose information we represent.
-    FaceCellsContainerProxy(const Dune::CpGrid* grid)
+    explicit FaceCellsContainerProxy(const Dune::CpGrid* grid)
         : grid_(grid)
     {}
     /// \brief Get the mapping for a cell.
@@ -175,7 +175,7 @@ private:
     class IndexIterator
     {
     public:
-        IndexIterator(int index)
+        explicit IndexIterator(int index)
         : index_(index)
         {}
 
@@ -275,7 +275,7 @@ public:
     typedef LocalIndexProxy<AccessMethod, SizeMethod> row_type;
     /// \brief Constructor.
     /// \param grid The grid whose information we represent.
-    LocalIndexContainerProxy(const Dune::CpGrid* grid)
+    explicit LocalIndexContainerProxy(const Dune::CpGrid* grid)
         : grid_(grid)
     {}
     /// \brief Get the mapping for a cell.
@@ -368,7 +368,7 @@ class Cell2FacesContainer
 public:
     typedef  Cell2FacesRow row_type;
     
-    Cell2FacesContainer(const Dune::CpGrid* grid)
+    explicit Cell2FacesContainer(const Dune::CpGrid* grid)
         : grid_(grid)
     {};
     


### PR DESCRIPTION
With now generic implementation of the initStateEquil in opm-core
we added the necessary grid helper functionlality for CpGrid and activated
the processing if the EQUIL keyword is there.

This PR is based on OPM/opm-core#761