### PR TITLE
Fix pvt regions

### DIFF
--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -135,14 +135,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             }
         }
 
-        // first, calculate the PVT table index for each compressed
-        // cell. This array is required to construct the PVT classes
-        // below.
-        Opm::extractPvtTableIndex(cellPvtRegionIdx_,
-                                  deck,
-                                  number_of_cells,
-                                  global_cell);
-
         const int numSamples = 0;
 
         // Resize the property objects container

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -333,13 +333,14 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             OPM_THROW(std::runtime_error, "Cannot call muWat(): water phase not present.");
         }
         const int n = cells.size();
+        mapPvtRegions(cells);
         assert(pw.size() == n);
         V mu(n);
         V dmudp(n);
         V dmudr(n);
         const double* rs = 0;
 
-        props_[phase_usage_.phase_pos[Water]]->mu(n, &pvtTableIdx_[0], pw.data(), T.data(), rs,
+        props_[phase_usage_.phase_pos[Water]]->mu(n, pvt_region_.data(), pw.data(), T.data(), rs,
                                                   mu.data(), dmudp.data(), dmudr.data());
         return mu;
     }
@@ -361,12 +362,13 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             OPM_THROW(std::runtime_error, "Cannot call muOil(): oil phase not present.");
         }
         const int n = cells.size();
+        mapPvtRegions(cells);
         assert(po.size() == n);
         V mu(n);
         V dmudp(n);
         V dmudr(n);
 
-        props_[phase_usage_.phase_pos[Oil]]->mu(n, &pvtTableIdx_[0], po.data(), T.data(), rs.data(), &cond[0],
+        props_[phase_usage_.phase_pos[Oil]]->mu(n, pvt_region_.data(), po.data(), T.data(), rs.data(), &cond[0],
                                                 mu.data(), dmudp.data(), dmudr.data());
         return mu;
     }
@@ -384,13 +386,14 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             OPM_THROW(std::runtime_error, "Cannot call muGas(): gas phase not present.");
         }
         const int n = cells.size();
+        mapPvtRegions(cells);
         assert(pg.size() == n);
         V mu(n);
         V dmudp(n);
         V dmudr(n);
         const double* rs = 0;
 
-        props_[phase_usage_.phase_pos[Gas]]->mu(n, &pvtTableIdx_[0], pg.data(), T.data(), rs,
+        props_[phase_usage_.phase_pos[Gas]]->mu(n, pvt_region_.data(), pg.data(), T.data(), rs,
                                                 mu.data(), dmudp.data(), dmudr.data());
         return mu;
     }
@@ -410,12 +413,13 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             OPM_THROW(std::runtime_error, "Cannot call muGas(): gas phase not present.");
         }
         const int n = cells.size();
+        mapPvtRegions(cells);
         assert(pg.size() == n);
         V mu(n);
         V dmudp(n);
         V dmudr(n);
 
-        props_[phase_usage_.phase_pos[Gas]]->mu(n, &pvtTableIdx_[0], pg.data(), T.data(), rv.data(),&cond[0],
+        props_[phase_usage_.phase_pos[Gas]]->mu(n, pvt_region_.data(), pg.data(), T.data(), rv.data(),&cond[0],
                                                 mu.data(), dmudp.data(), dmudr.data());
         return mu;
     }
@@ -433,13 +437,14 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             OPM_THROW(std::runtime_error, "Cannot call muWat(): water phase not present.");
         }
         const int n = cells.size();
+        mapPvtRegions(cells);
         assert(pw.size() == n);
         V mu(n);
         V dmudp(n);
         V dmudr(n);
         const double* rs = 0;
 
-        props_[phase_usage_.phase_pos[Water]]->mu(n, &pvtTableIdx_[0], pw.value().data(), T.value().data(), rs,
+        props_[phase_usage_.phase_pos[Water]]->mu(n, pvt_region_.data(), pw.value().data(), T.value().data(), rs,
                                                   mu.data(), dmudp.data(), dmudr.data());
         ADB::M dmudp_diag = spdiag(dmudp);
         const int num_blocks = pw.numBlocks();
@@ -467,12 +472,13 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             OPM_THROW(std::runtime_error, "Cannot call muOil(): oil phase not present.");
         }
         const int n = cells.size();
+        mapPvtRegions(cells);
         assert(po.size() == n);
         V mu(n);
         V dmudp(n);
         V dmudr(n);
 
-        props_[phase_usage_.phase_pos[Oil]]->mu(n, &pvtTableIdx_[0], po.value().data(), T.value().data(), rs.value().data(),
+        props_[phase_usage_.phase_pos[Oil]]->mu(n, pvt_region_.data(), po.value().data(), T.value().data(), rs.value().data(),
                                                 &cond[0], mu.data(), dmudp.data(), dmudr.data());
 
         ADB::M dmudp_diag = spdiag(dmudp);
@@ -501,13 +507,14 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             OPM_THROW(std::runtime_error, "Cannot call muGas(): gas phase not present.");
         }
         const int n = cells.size();
+        mapPvtRegions(cells);
         assert(pg.value().size() == n);
         V mu(n);
         V dmudp(n);
         V dmudr(n);
         const double* rv = 0;
 
-        props_[phase_usage_.phase_pos[Gas]]->mu(n, &pvtTableIdx_[0], pg.value().data(), T.value().data(), rv,
+        props_[phase_usage_.phase_pos[Gas]]->mu(n, pvt_region_.data(), pg.value().data(), T.value().data(), rv,
                                                   mu.data(), dmudp.data(), dmudr.data());
 
         ADB::M dmudp_diag = spdiag(dmudp);
@@ -536,12 +543,13 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             OPM_THROW(std::runtime_error, "Cannot call muGas(): gas phase not present.");
         }
         const int n = cells.size();
+        mapPvtRegions(cells);
         assert(pg.value().size() == n);
         V mu(n);
         V dmudp(n);
         V dmudr(n);
 
-        props_[phase_usage_.phase_pos[Gas]]->mu(n, &pvtTableIdx_[0], pg.value().data(), T.value().data(), rv.value().data(),&cond[0],
+        props_[phase_usage_.phase_pos[Gas]]->mu(n, pvt_region_.data(), pg.value().data(), T.value().data(), rv.value().data(),&cond[0],
                                                   mu.data(), dmudp.data(), dmudr.data());
 
         ADB::M dmudp_diag = spdiag(dmudp);
@@ -588,6 +596,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             OPM_THROW(std::runtime_error, "Cannot call bWat(): water phase not present.");
         }
         const int n = cells.size();
+        mapPvtRegions(cells);
         assert(pw.size() == n);
 
         V b(n);
@@ -595,7 +604,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         V dbdr(n);
         const double* rs = 0;
 
-        props_[phase_usage_.phase_pos[Water]]->b(n, &pvtTableIdx_[0], pw.data(), T.data(), rs,
+        props_[phase_usage_.phase_pos[Water]]->b(n, pvt_region_.data(), pw.data(), T.data(), rs,
                                                  b.data(), dbdp.data(), dbdr.data());
 
         return b;
@@ -618,13 +627,14 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             OPM_THROW(std::runtime_error, "Cannot call bOil(): oil phase not present.");
         }
         const int n = cells.size();
+        mapPvtRegions(cells);
         assert(po.size() == n);
 
         V b(n);
         V dbdp(n);
         V dbdr(n);
 
-        props_[phase_usage_.phase_pos[Oil]]->b(n, &pvtTableIdx_[0], po.data(), T.data(), rs.data(), &cond[0],
+        props_[phase_usage_.phase_pos[Oil]]->b(n, pvt_region_.data(), po.data(), T.data(), rs.data(), &cond[0],
                                                b.data(), dbdp.data(), dbdr.data());
 
         return b;
@@ -643,6 +653,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             OPM_THROW(std::runtime_error, "Cannot call bGas(): gas phase not present.");
         }
         const int n = cells.size();
+        mapPvtRegions(cells);
         assert(pg.size() == n);
 
         V b(n);
@@ -650,7 +661,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         V dbdr(n);
         const double* rs = 0;
 
-        props_[phase_usage_.phase_pos[Gas]]->b(n, &pvtTableIdx_[0], pg.data(), T.data(), rs,
+        props_[phase_usage_.phase_pos[Gas]]->b(n, pvt_region_.data(), pg.data(), T.data(), rs,
                                                b.data(), dbdp.data(), dbdr.data());
 
         return b;
@@ -673,13 +684,14 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             OPM_THROW(std::runtime_error, "Cannot call muGas(): gas phase not present.");
         }
         const int n = cells.size();
+        mapPvtRegions(cells);
         assert(pg.size() == n);
 
         V b(n);
         V dbdp(n);
         V dbdr(n);
 
-        props_[phase_usage_.phase_pos[Gas]]->b(n, &pvtTableIdx_[0], pg.data(), T.data(), rv.data(), &cond[0],
+        props_[phase_usage_.phase_pos[Gas]]->b(n, pvt_region_.data(), pg.data(), T.data(), rv.data(), &cond[0],
                                                b.data(), dbdp.data(), dbdr.data());
 
         return b;
@@ -698,6 +710,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             OPM_THROW(std::runtime_error, "Cannot call muWat(): water phase not present.");
         }
         const int n = cells.size();
+        mapPvtRegions(cells);
         assert(pw.size() == n);
 
         V b(n);
@@ -705,7 +718,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         V dbdr(n);
         const double* rs = 0;
 
-        props_[phase_usage_.phase_pos[Water]]->b(n, &pvtTableIdx_[0], pw.value().data(), T.value().data(), rs,
+        props_[phase_usage_.phase_pos[Water]]->b(n, pvt_region_.data(), pw.value().data(), T.value().data(), rs,
                                                  b.data(), dbdp.data(), dbdr.data());
 
         ADB::M dbdp_diag = spdiag(dbdp);
@@ -734,13 +747,14 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             OPM_THROW(std::runtime_error, "Cannot call muOil(): oil phase not present.");
         }
         const int n = cells.size();
+        mapPvtRegions(cells);
         assert(po.size() == n);
 
         V b(n);
         V dbdp(n);
         V dbdr(n);
 
-        props_[phase_usage_.phase_pos[Oil]]->b(n, &pvtTableIdx_[0], po.value().data(), T.value().data(), rs.value().data(),
+        props_[phase_usage_.phase_pos[Oil]]->b(n, pvt_region_.data(), po.value().data(), T.value().data(), rs.value().data(),
                                                &cond[0], b.data(), dbdp.data(), dbdr.data());
 
         ADB::M dbdp_diag = spdiag(dbdp);
@@ -769,6 +783,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             OPM_THROW(std::runtime_error, "Cannot call muGas(): gas phase not present.");
         }
         const int n = cells.size();
+        mapPvtRegions(cells);
         assert(pg.size() == n);
 
         V b(n);
@@ -776,7 +791,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         V dbdr(n);
         const double* rv = 0;
 
-        props_[phase_usage_.phase_pos[Gas]]->b(n, &pvtTableIdx_[0], pg.value().data(), T.value().data(), rv,
+        props_[phase_usage_.phase_pos[Gas]]->b(n, pvt_region_.data(), pg.value().data(), T.value().data(), rv,
                                                b.data(), dbdp.data(), dbdr.data());
 
         ADB::M dbdp_diag = spdiag(dbdp);
@@ -805,13 +820,14 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             OPM_THROW(std::runtime_error, "Cannot call muGas(): gas phase not present.");
         }
         const int n = cells.size();
+        mapPvtRegions(cells);
         assert(pg.size() == n);
 
         V b(n);
         V dbdp(n);
         V dbdr(n);
 
-        props_[phase_usage_.phase_pos[Gas]]->b(n, &pvtTableIdx_[0], pg.value().data(), T.value().data(), rv.value().data(), &cond[0],
+        props_[phase_usage_.phase_pos[Gas]]->b(n, pvt_region_.data(), pg.value().data(), T.value().data(), rv.value().data(), &cond[0],
                                                b.data(), dbdp.data(), dbdr.data());
 
         ADB::M dbdp_diag = spdiag(dbdp);
@@ -842,10 +858,11 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             OPM_THROW(std::runtime_error, "Cannot call rsMax(): oil phase not present.");
         }
         const int n = cells.size();
+        mapPvtRegions(cells);
         assert(po.size() == n);
         V rbub(n);
         V drbubdp(n);
-        props_[phase_usage_.phase_pos[Oil]]->rsSat(n, &pvtTableIdx_[0], po.data(), rbub.data(), drbubdp.data());
+        props_[phase_usage_.phase_pos[Oil]]->rsSat(n, pvt_region_.data(), po.data(), rbub.data(), drbubdp.data());
         return rbub;
     }
 
@@ -874,10 +891,11 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             OPM_THROW(std::runtime_error, "Cannot call rsMax(): oil phase not present.");
         }
         const int n = cells.size();
+        mapPvtRegions(cells);
         assert(po.size() == n);
         V rbub(n);
         V drbubdp(n);
-        props_[phase_usage_.phase_pos[Oil]]->rsSat(n, &pvtTableIdx_[0], po.value().data(), rbub.data(), drbubdp.data());
+        props_[phase_usage_.phase_pos[Oil]]->rsSat(n, pvt_region_.data(), po.value().data(), rbub.data(), drbubdp.data());
         ADB::M drbubdp_diag = spdiag(drbubdp);
         const int num_blocks = po.numBlocks();
         std::vector<ADB::M> jacs(num_blocks);
@@ -914,10 +932,11 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             OPM_THROW(std::runtime_error, "Cannot call rvMax(): gas phase not present.");
         }
         const int n = cells.size();
+        mapPvtRegions(cells);
         assert(po.size() == n);
         V rv(n);
         V drvdp(n);
-        props_[phase_usage_.phase_pos[Gas]]->rvSat(n, &pvtTableIdx_[0], po.data(), rv.data(), drvdp.data());
+        props_[phase_usage_.phase_pos[Gas]]->rvSat(n, pvt_region_.data(), po.data(), rv.data(), drvdp.data());
         return rv;
     }
 
@@ -946,10 +965,11 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             OPM_THROW(std::runtime_error, "Cannot call rvMax(): gas phase not present.");
         }
         const int n = cells.size();
+        mapPvtRegions(cells);
         assert(po.size() == n);
         V rv(n);
         V drvdp(n);
-        props_[phase_usage_.phase_pos[Gas]]->rvSat(n, &pvtTableIdx_[0], po.value().data(), rv.data(), drvdp.data());
+        props_[phase_usage_.phase_pos[Gas]]->rvSat(n, pvt_region_.data(), po.value().data(), rv.data(), drvdp.data());
         ADB::M drvdp_diag = spdiag(drvdp);
         const int num_blocks = po.numBlocks();
         std::vector<ADB::M> jacs(num_blocks);
@@ -1240,6 +1260,21 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             r = ADB::function(factor, jacs)*r;
         }
     }
+
+
+
+
+
+    // Fills pvt_region_ with cellPvtRegionIdx_[cells].
+    void BlackoilPropsAdFromDeck::mapPvtRegions(const std::vector<int>& cells) const
+    {
+        const int n = cells.size();
+        pvt_region_.resize(n);
+        for (int ii = 0; ii < n; ++ii) {
+            pvt_region_[ii] = cellPvtRegionIdx_[cells[ii]];
+        }
+    }
+
 
 } // namespace Opm
 

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -90,7 +90,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
     // For data that is dependant on the subgrid we simply allocate space
     // and initialize with obviously bogus numbers.
     cellPvtRegionIdx_.resize(number_of_cells, std::numeric_limits<int>::min());
-    pvtTableIdx_.resize(number_of_cells, std::numeric_limits<int>::min());
 }
 
     /// Initializes the properties.
@@ -139,7 +138,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         // first, calculate the PVT table index for each compressed
         // cell. This array is required to construct the PVT classes
         // below.
-        Opm::extractPvtTableIndex(pvtTableIdx_,
+        Opm::extractPvtTableIndex(cellPvtRegionIdx_,
                                   deck,
                                   number_of_cells,
                                   global_cell);

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -477,15 +477,7 @@ namespace Opm
         // The PVT properties. One object per active fluid phase.
         std::vector<std::shared_ptr<Opm::PvtInterface> > props_;
 
-        // The index of the PVT table which ought to be used for each
-        // cell. Eclipse does not seem to allow specifying fluid-phase
-        // specific table indices, so for the sake of simplicity, we
-        // don't do this either. (if it turns out that Eclipes does in
-        // fact support it or if it by some miracle gains this feature
-        // in the future, this attribute needs to become a vector of
-        // vectors of ints.)
-        std::vector<int> pvtTableIdx_;
-
+        // Densities, one std::array per PVT region.
         std::vector<std::array<double, BlackoilPhases::MaxNumPhases> > densities_;
         
         // VAPPARS

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -455,6 +455,9 @@ namespace Opm
                       const std::vector<int>& cells,
                       const double vap) const;
 
+        // Fills pvt_region_ with cellPvtRegionIdx_[cells].
+        void mapPvtRegions(const std::vector<int>& cells) const;
+
         RockFromDeck rock_;
         // This has to be a shared pointer as we must
         // be able to make a copy of *this in the parallel case.
@@ -466,6 +469,10 @@ namespace Opm
 
         // The PVT region which is to be used for each cell
         std::vector<int> cellPvtRegionIdx_;
+
+        // Used for storing the region-per-cell array computed in calls
+        // to pvt functions.
+        mutable std::vector<int> pvt_region_;
 
         // The PVT properties. One object per active fluid phase.
         std::vector<std::shared_ptr<Opm::PvtInterface> > props_;

--- a/tests/fluid.data
+++ b/tests/fluid.data
@@ -49,8 +49,9 @@ PVCDO
 /
 
 PVDG
--- Pg Bg(Pg) mug
-    1   1     1
+-- Pg       Bg(Pg)  mug
+    1            1    1
+  800   0.99999999    1
 /
 
 SWOF

--- a/tests/test_rateconverter.cpp
+++ b/tests/test_rateconverter.cpp
@@ -94,7 +94,7 @@ BOOST_FIXTURE_TEST_CASE(Construction, TestFixture<SetupSimple>)
 }
 
 
-BOOST_FIXTURE_TEST_CASE(TwoPhaseII, TestFixture<SetupSimple>)
+BOOST_FIXTURE_TEST_CASE(ThreePhase, TestFixture<SetupSimple>)
 {
     // Immiscible and incompressible two-phase fluid
     typedef std::vector<int>                     Region;
@@ -106,11 +106,11 @@ BOOST_FIXTURE_TEST_CASE(TwoPhaseII, TestFixture<SetupSimple>)
     RCvrt  cvrt(ad_props, reg);
 
     Opm::BlackoilState x;
-    x.init(*grid.c_grid(), 2);
+    x.init(*grid.c_grid(), 3);
 
     cvrt.defineState(x);
 
-    std::vector<double> qs{1.0e3, 1.0e1};
+    std::vector<double> qs{1.0e3, 1.0e1, 1.0e-1};
     std::vector<double> coeff(qs.size(), 0.0);
 
     // Immiscible and incompressible: All coefficients are one (1),
@@ -118,4 +118,5 @@ BOOST_FIXTURE_TEST_CASE(TwoPhaseII, TestFixture<SetupSimple>)
     cvrt.calcCoeff(qs, 0, coeff);
     BOOST_CHECK_CLOSE(coeff[0], 1.0, 1.0e-6);
     BOOST_CHECK_CLOSE(coeff[1], 1.0, 1.0e-6);
+    BOOST_CHECK_CLOSE(coeff[2], 1.0, 1.0e-6);
 }


### PR DESCRIPTION
This PR is based on #318 and therefore at the moment it is hard to tell apart the additional content in this, I may rebase it if #318 is merged to improve readability.

It contains two basic fixes:
 - The `pvtTableIdx_` member is removed from `BlackoilPropsAdFromDeck`, and a bug fixed (initialisation of `cellPvtRegionIdx_`, the `pvtTableIdx_` received the data instead).
 - Make the `test_rateconverter` test succeed again.

Edit: I forgot to list the most important fix in this PR:
 - Fix pvt region behaviour. The existing code did not pass an array of regions (with the same size as the requested number of data points) to underlying classes, but the array of cell's region indices.