### PR TITLE
[bugfix] read only from the sendState in BlackoilStateDataHandle.

### DIFF
--- a/opm/autodiff/RedistributeDataHandles.hpp
+++ b/opm/autodiff/RedistributeDataHandles.hpp
@@ -81,7 +81,7 @@ public:
         }
         for ( int i=0; i<sendGrid_.numCellFaces(e.index()); ++i )
         {
-            buffer.write(recvState_.faceflux()[sendGrid_.cellFace(e.index(), i)]);
+            buffer.write(sendState_.faceflux()[sendGrid_.cellFace(e.index(), i)]);
         }
     }
     template<class B, class T>


### PR DESCRIPTION
During BlackoilStateDataHandle::gather we did read values from the
state where we should only receive values to. With this commit we
read from the state where we should send values.

Kudos to Bard for noticing this.