### PR TITLE
Allow for dynamically changed tolerances for the solvers.

### DIFF
--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -70,6 +70,8 @@ namespace Opm {
             double                          relax_increment_;
             double                          relax_rel_tol_;
             double                          max_residual_allowed_;
+            double                          tolerance_mb_;
+            double                          tolerance_cnv_;
             int                             max_iter_;
 
             SolverParameter( const parameter::ParameterGroup& param );

--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -145,6 +145,8 @@ namespace detail {
         relax_rel_tol_   = 0.2;
         max_iter_        = 15;
         max_residual_allowed_  = std::numeric_limits< double >::max();
+        tolerance_mb_    = 1.0e-7;
+        tolerance_cnv_   = 1.0e-3;
     }
 
     template<class T>
@@ -169,6 +171,9 @@ namespace detail {
         relax_max_   = param.getDefault("relax_max", relax_max_);
         max_iter_    = param.getDefault("max_iter", max_iter_);
         max_residual_allowed_ = param.getDefault("max_residual_allowed", max_residual_allowed_);
+
+        tolerance_mb_  = param.getDefault("tolerance_mb", tolerance_mb_);
+        tolerance_cnv_ = param.getDefault("tolerance_cnv", tolerance_cnv_);
 
         std::string relaxation_type = param.getDefault("relax_type", std::string("dampen"));
         if (relaxation_type == "dampen") {
@@ -1965,8 +1970,8 @@ namespace detail {
     bool
     FullyImplicitBlackoilSolver<T>::getConvergence(const double dt, const int iteration)
     {
-        const double tol_mb = 1.0e-7;
-        const double tol_cnv = 1.0e-3;
+        const double tol_mb  = param_.tolerance_mb_;
+        const double tol_cnv = param_.tolerance_cnv_;
 
         const int nc = Opm::AutoDiffGrid::numCells(grid_);
         const Opm::PhaseUsage& pu = fluid_.phaseUsage();

--- a/opm/autodiff/NewtonIterationBlackoilCPR.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilCPR.cpp
@@ -105,6 +105,11 @@ namespace Opm
         cpr_ilu_n_        = param.getDefault("cpr_ilu_n", 0);
         cpr_use_amg_      = param.getDefault("cpr_use_amg", false);
         cpr_use_bicgstab_ = param.getDefault("cpr_use_bicgstab", true);
+
+        linear_solver_reduction_ = param.getDefault("linear_solver_reduction", 1e-3 );
+        linear_solver_maxiter_   = param.getDefault("linear_solver_maxiter", 150 );
+        linear_solver_restart_   = param.getDefault("linear_solver_restart", 40 );
+        linear_solver_verbosity_ = param.getDefault("linear_solver_verbosity", 0 );
     }
 
 
@@ -170,7 +175,7 @@ namespace Opm
 
         // Create ISTL matrix for elliptic part.
         DuneMatrix istlAe( A.topLeftCorner(nc, nc) );
-        
+
         // Right hand side.
         Vector istlb(istlA.N());
         std::copy_n(b.data(), istlb.size(), istlb.begin());
@@ -201,7 +206,7 @@ namespace Opm
             Dune::Amg::SequentialInformation info;
             constructPreconditionerAndSolve(opA, istlAe, x, istlb, info, result);
         }
-            
+
         // store number of iterations
         iterations_ = result.iterations;
 

--- a/opm/autodiff/NewtonIterationBlackoilCPR.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilCPR.hpp
@@ -46,7 +46,7 @@ namespace Opm
         typedef Dune::BCRSMatrix <MatrixBlockType>        Mat;
         typedef Dune::BlockVector<VectorBlockType>        Vector;
     public:
-        
+
         /// Construct a system solver.
         /// \param[in] param   parameters controlling the behaviour of
         ///                    the preconditioning and choice of
@@ -79,14 +79,14 @@ namespace Opm
         /// \brief construct the CPR preconditioner and the solver.
         /// \tparam P The type of the parallel information.
         /// \param parallelInformation the information about the parallelization.
-        template<int category=Dune::SolverCategory::sequential, class O, class P>   
+        template<int category=Dune::SolverCategory::sequential, class O, class P>
         void constructPreconditionerAndSolve(O& opA, DuneMatrix& istlAe,
                                              Vector& x, Vector& istlb,
                                              const P& parallelInformation,
                                              Dune::InverseOperatorResult& result) const
         {
             typedef Dune::ScalarProductChooser<Vector,P,category> ScalarProductChooser;
-            std::unique_ptr<typename ScalarProductChooser::ScalarProduct> 
+            std::unique_ptr<typename ScalarProductChooser::ScalarProduct>
                 sp(ScalarProductChooser::construct(parallelInformation));
             // Construct preconditioner.
             // typedef Dune::SeqILU0<Mat,Vector,Vector> Preconditioner;
@@ -95,12 +95,9 @@ namespace Opm
             Preconditioner precond(opA.getmat(), istlAe, cpr_relax_, cpr_ilu_n_, cpr_use_amg_, cpr_use_bicgstab_, parallelInformation);
 
             // Construct linear solver.
-            const double tolerance = 1e-3;
-            const int maxit = 150;
-            const int verbosity = 0;
-            const int restart = 40;
-            Dune::RestartedGMResSolver<Vector> linsolve(opA, *sp, precond, tolerance, restart, maxit, verbosity);
-            
+            Dune::RestartedGMResSolver<Vector> linsolve(opA, *sp, precond,
+                           linear_solver_reduction_, linear_solver_restart_, linear_solver_maxiter_, linear_solver_verbosity_);
+
             // Solve system.
             linsolve.apply(x, istlb, result);
         }
@@ -111,6 +108,11 @@ namespace Opm
         bool cpr_use_amg_;
         bool cpr_use_bicgstab_;
         boost::any parallelInformation_;
+
+        double linear_solver_reduction_;
+        int    linear_solver_maxiter_;
+        int    linear_solver_restart_;
+        int    linear_solver_verbosity_;
     };
 
 } // namespace Opm


### PR DESCRIPTION
With the PR it should be able to specify different tolerances for the Newton and linear solver. 
This is needed to compare CPU time with ecl.
