### PR TITLE
Simplify properties

### DIFF
--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -312,85 +312,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
     // ------ Viscosity ------
 
 
-    /// Oil viscosity.
-    /// \param[in]  po     Array of n oil pressure values.
-    /// \param[in]  T      Array of n temperature values.
-    /// \param[in]  rs     Array of n gas solution factor values.
-    /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
-    /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-    /// \return            Array of n viscosity values.
-    V BlackoilPropsAdFromDeck::muOil(const V& po,
-                                     const V& T,
-                                     const V& rs,
-                                     const std::vector<PhasePresence>& cond,
-                                     const Cells& cells) const
-    {
-        if (!phase_usage_.phase_used[Oil]) {
-            OPM_THROW(std::runtime_error, "Cannot call muOil(): oil phase not present.");
-        }
-        const int n = cells.size();
-        mapPvtRegions(cells);
-        assert(po.size() == n);
-        V mu(n);
-        V dmudp(n);
-        V dmudr(n);
-
-        props_[phase_usage_.phase_pos[Oil]]->mu(n, pvt_region_.data(), po.data(), T.data(), rs.data(), &cond[0],
-                                                mu.data(), dmudp.data(), dmudr.data());
-        return mu;
-    }
-
-    /// Gas viscosity.
-    /// \param[in]  pg     Array of n gas pressure values.
-    /// \param[in]  T      Array of n temperature values.
-    /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-    /// \return            Array of n viscosity values.
-    V BlackoilPropsAdFromDeck::muGas(const V& pg,
-                                     const V& T,
-                                     const Cells& cells) const
-    {
-        if (!phase_usage_.phase_used[Gas]) {
-            OPM_THROW(std::runtime_error, "Cannot call muGas(): gas phase not present.");
-        }
-        const int n = cells.size();
-        mapPvtRegions(cells);
-        assert(pg.size() == n);
-        V mu(n);
-        V dmudp(n);
-        V dmudr(n);
-        const double* rs = 0;
-
-        props_[phase_usage_.phase_pos[Gas]]->mu(n, pvt_region_.data(), pg.data(), T.data(), rs,
-                                                mu.data(), dmudp.data(), dmudr.data());
-        return mu;
-    }
-
-    /// Gas viscosity.
-    /// \param[in]  pg     Array of n gas pressure values.
-    /// \param[in]  T      Array of n temperature values.
-    /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-    /// \return            Array of n viscosity values.
-    V BlackoilPropsAdFromDeck::muGas(const V& pg,
-                                     const V& T,
-                                     const V& rv,
-                                     const std::vector<PhasePresence>& cond,
-                                     const Cells& cells) const
-    {
-        if (!phase_usage_.phase_used[Gas]) {
-            OPM_THROW(std::runtime_error, "Cannot call muGas(): gas phase not present.");
-        }
-        const int n = cells.size();
-        mapPvtRegions(cells);
-        assert(pg.size() == n);
-        V mu(n);
-        V dmudp(n);
-        V dmudr(n);
-
-        props_[phase_usage_.phase_pos[Gas]]->mu(n, pvt_region_.data(), pg.data(), T.data(), rv.data(),&cond[0],
-                                                mu.data(), dmudp.data(), dmudr.data());
-        return mu;
-    }
-
     /// Water viscosity.
     /// \param[in]  pw     Array of n water pressure values.
     /// \param[in]  T      Array of n temperature values.
@@ -461,38 +382,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             ADB::M temp;
             fastSparseProduct(dmudr_diag, rs.derivative()[block], temp);
             jacs[block] += temp;
-        }
-        return ADB::function(mu, jacs);
-    }
-
-    /// Gas viscosity.
-    /// \param[in]  pg     Array of n gas pressure values.
-    /// \param[in]  T      Array of n temperature values.
-    /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-    /// \return            Array of n viscosity values.
-    ADB BlackoilPropsAdFromDeck::muGas(const ADB& pg,
-                                       const ADB& T,
-                                       const Cells& cells) const
-    {
-        if (!phase_usage_.phase_used[Gas]) {
-            OPM_THROW(std::runtime_error, "Cannot call muGas(): gas phase not present.");
-        }
-        const int n = cells.size();
-        mapPvtRegions(cells);
-        assert(pg.value().size() == n);
-        V mu(n);
-        V dmudp(n);
-        V dmudr(n);
-        const double* rv = 0;
-
-        props_[phase_usage_.phase_pos[Gas]]->mu(n, pvt_region_.data(), pg.value().data(), T.value().data(), rv,
-                                                  mu.data(), dmudp.data(), dmudr.data());
-
-        ADB::M dmudp_diag = spdiag(dmudp);
-        const int num_blocks = pg.numBlocks();
-        std::vector<ADB::M> jacs(num_blocks);
-        for (int block = 0; block < num_blocks; ++block) {
-            fastSparseProduct(dmudp_diag, pg.derivative()[block], jacs[block]);
         }
         return ADB::function(mu, jacs);
     }

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -428,21 +428,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
 
     // ------ Formation volume factor (b) ------
 
-    // These methods all call the matrix() method, after which the variable
-    // (also) called 'matrix' contains, in each row, the A = RB^{-1} matrix for
-    // a cell. For three-phase black oil:
-    //  A = [  bw       0       0
-    //          0       bo      0
-    //          0      b0*rs   bw ]
-    // Where b = B^{-1}.
-    // Therefore, we extract the correct diagonal element, and are done.
-    // When we need the derivatives (w.r.t. p, since we don't do w.r.t. rs),
-    // we also get the following derivative matrix:
-    //  A = [  dbw       0       0
-    //          0       dbo      0
-    //          0      db0*rs   dbw ]
-    // Again, we just extract a diagonal element.
-
     /// Water formation volume factor.
     /// \param[in]  pw     Array of n water pressure values.
     /// \param[in]  T      Array of n temperature values.

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -176,50 +176,6 @@ namespace Opm
         /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
-        V bWat(const V& pw,
-               const V& T,
-               const Cells& cells) const;
-
-        /// Oil formation volume factor.
-        /// \param[in]  po     Array of n oil pressure values.
-        /// \param[in]  T      Array of n temperature values.
-        /// \param[in]  rs     Array of n gas solution factor values.
-        /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n formation volume factor values.
-        V bOil(const V& po,
-               const V& T,
-               const V& rs,
-               const std::vector<PhasePresence>& cond,
-               const Cells& cells) const;
-
-        /// Gas formation volume factor.
-        /// \param[in]  pg     Array of n gas pressure values.
-        /// \param[in]  T      Array of n temperature values.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n formation volume factor values.
-        V bGas(const V& pg,
-               const V& T,
-               const Cells& cells) const;
-
-        /// Gas formation volume factor.
-        /// \param[in]  pg     Array of n gas pressure values.
-        /// \param[in]  T      Array of n temperature values.
-        /// \param[in]  rv     Array of n vapor oil/gas ratio
-        /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n formation volume factor values.
-        V bGas(const V& pg,
-               const V& T,
-               const V& rv,
-               const std::vector<PhasePresence>& cond,
-               const Cells& cells) const;
-
-        /// Water formation volume factor.
-        /// \param[in]  pw     Array of n water pressure values.
-        /// \param[in]  T      Array of n temperature values.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n formation volume factor values.
         ADB bWat(const ADB& pw,
                  const ADB& T,
                  const Cells& cells) const;
@@ -240,24 +196,15 @@ namespace Opm
         /// Gas formation volume factor.
         /// \param[in]  pg     Array of n gas pressure values.
         /// \param[in]  T      Array of n temperature values.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n formation volume factor values.
-        ADB bGas(const ADB& pg,
-                 const ADB& T,
-                 const Cells& cells) const;
-
-        /// Gas formation volume factor.
-        /// \param[in]  pg     Array of n gas pressure values.
-        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  rv     Array of n vapor oil/gas ratio
         /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         ADB bGas(const ADB& pg,
                  const ADB& T,
-               const ADB& rv,
-               const std::vector<PhasePresence>& cond,
-               const Cells& cells) const;
+                 const ADB& rv,
+                 const std::vector<PhasePresence>& cond,
+                 const Cells& cells) const;
 
         // ------ Rs bubble point curve ------
 

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -134,15 +134,6 @@ namespace Opm
 
         // ------ Viscosity ------
 
-        /// Water viscosity.
-        /// \param[in]  pw     Array of n water pressure values.
-        /// \param[in]  T      Array of n temperature values.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n viscosity values.
-        V muWat(const V& pw,
-                const V& T,
-                const Cells& cells) const;
-
         /// Oil viscosity.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  T      Array of n temperature values.

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -134,41 +134,6 @@ namespace Opm
 
         // ------ Viscosity ------
 
-        /// Oil viscosity.
-        /// \param[in]  po     Array of n oil pressure values.
-        /// \param[in]  T      Array of n temperature values.
-        /// \param[in]  rs     Array of n gas solution factor values.
-        /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n viscosity values.
-        V muOil(const V& po,
-                const V& T,
-                const V& rs,
-                const std::vector<PhasePresence>& cond,
-                const Cells& cells) const;
-
-        /// Gas viscosity.
-        /// \param[in]  pg     Array of n gas pressure values.
-        /// \param[in]  T      Array of n temperature values.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n viscosity values.
-        V muGas(const V& pg,
-                const V& T,
-                const Cells& cells) const;
-
-        /// Oil viscosity.
-        /// \param[in]  po     Array of n oil pressure values.
-        /// \param[in]  T      Array of n temperature values.
-        /// \param[in]  rv     Array of n vapor oil/gas ratio
-        /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n viscosity values.
-        V muGas(const V& po,
-                const V& T,
-                const V& rv,
-                const std::vector<PhasePresence>& cond,
-                const Cells& cells) const;
-
         /// Water viscosity.
         /// \param[in]  pw     Array of n water pressure values.
         /// \param[in]  T      Array of n temperature values.
@@ -194,15 +159,8 @@ namespace Opm
         /// Gas viscosity.
         /// \param[in]  pg     Array of n gas pressure values.
         /// \param[in]  T      Array of n temperature values.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n viscosity values.
-        ADB muGas(const ADB& pg,
-                  const ADB& T,
-                  const Cells& cells) const;
-
-        /// Gas viscosity.
-        /// \param[in]  pg     Array of n gas pressure values.
-        /// \param[in]  T      Array of n temperature values.
+        /// \param[in]  rv     Array of n vapor oil/gas ratios.
+        /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         ADB muGas(const ADB& pg,

--- a/opm/autodiff/BlackoilPropsAdInterface.hpp
+++ b/opm/autodiff/BlackoilPropsAdInterface.hpp
@@ -94,30 +94,6 @@ namespace Opm
 
         // ------ Viscosity ------
 
-        /// Oil viscosity.
-        /// \param[in]  po     Array of n oil pressure values.
-        /// \param[in]  T      Array of n temperature values.
-        /// \param[in]  rs     Array of n gas solution factor values.
-        /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n viscosity values.
-        virtual
-        V muOil(const V& po,
-                const V& T,
-                const V& rs,
-                const std::vector<PhasePresence>& cond,
-                const Cells& cells) const = 0;
-
-        /// Gas viscosity.
-        /// \param[in]  pg     Array of n gas pressure values.
-        /// \param[in]  T      Array of n temperature values.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n viscosity values.
-        virtual
-        V muGas(const V& pg,
-                const V& T,
-                const Cells& cells) const = 0;
-
         /// Water viscosity.
         /// \param[in]  pw     Array of n water pressure values.
         /// \param[in]  T      Array of n temperature values.
@@ -145,16 +121,8 @@ namespace Opm
         /// Gas viscosity.
         /// \param[in]  pg     Array of n gas pressure values.
         /// \param[in]  T      Array of n temperature values.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n viscosity values.
-        virtual
-        ADB muGas(const ADB& pg,
-                  const ADB& T,
-                  const Cells& cells) const = 0;
-
-        /// Gas viscosity.
-        /// \param[in]  pg     Array of n gas pressure values.
-        /// \param[in]  T      Array of n temperature values.
+        /// \param[in]  rv     Array of n vapor oil/gas ratios.
+        /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         virtual

--- a/opm/autodiff/BlackoilPropsAdInterface.hpp
+++ b/opm/autodiff/BlackoilPropsAdInterface.hpp
@@ -140,54 +140,6 @@ namespace Opm
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         virtual
-        V bWat(const V& pw,
-               const V& T,
-               const Cells& cells) const = 0;
-
-        /// Oil formation volume factor.
-        /// \param[in]  po     Array of n oil pressure values.
-        /// \param[in]  T      Array of n temperature values.
-        /// \param[in]  rs     Array of n gas solution factor values.
-        /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n formation volume factor values.
-        virtual
-        V bOil(const V& po,
-               const V& T,
-               const V& rs,
-               const std::vector<PhasePresence>& cond,
-               const Cells& cells) const = 0;
-
-        /// Gas formation volume factor.
-        /// \param[in]  pg     Array of n gas pressure values.
-        /// \param[in]  T      Array of n temperature values.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n formation volume factor values.
-        virtual
-        V bGas(const V& pg,
-               const V& T,
-               const Cells& cells) const = 0;
-
-        /// Gas formation volume factor.
-        /// \param[in]  pg     Array of n gas pressure values.
-        /// \param[in]  T      Array of n temperature values.
-        /// \param[in]  rv     Array of n vapor oil/gas ratio
-        /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n formation volume factor values.
-        virtual
-        V bGas(const V& pg,
-               const V& T,
-               const V& rv,
-               const std::vector<PhasePresence>& cond,
-               const Cells& cells) const = 0;
-
-        /// Water formation volume factor.
-        /// \param[in]  pw     Array of n water pressure values.
-        /// \param[in]  T      Array of n temperature values.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n formation volume factor values.
-        virtual
         ADB bWat(const ADB& pw,
                  const ADB& T,
                  const Cells& cells) const = 0;
@@ -209,26 +161,16 @@ namespace Opm
         /// Gas formation volume factor.
         /// \param[in]  pg     Array of n gas pressure values.
         /// \param[in]  T      Array of n temperature values.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n formation volume factor values.
-        virtual
-        ADB bGas(const ADB& pg,
-                 const ADB& T,
-                 const Cells& cells) const = 0;
-
-        /// Gas formation volume factor.
-        /// \param[in]  pg     Array of n gas pressure values.
-        /// \param[in]  T      Array of n temperature values.
-        /// \param[in]  rv     Array of n vapor oil/gas ratio
+        /// \param[in]  rv     Array of n vapor oil/gas ratios.
         /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         virtual
         ADB bGas(const ADB& pg,
                  const ADB& T,
-               const ADB& rv,
-               const std::vector<PhasePresence>& cond,
-               const Cells& cells) const = 0;
+                 const ADB& rv,
+                 const std::vector<PhasePresence>& cond,
+                 const Cells& cells) const = 0;
 
         // ------ Rs bubble point curve ------
 

--- a/opm/autodiff/BlackoilPropsAdInterface.hpp
+++ b/opm/autodiff/BlackoilPropsAdInterface.hpp
@@ -94,16 +94,6 @@ namespace Opm
 
         // ------ Viscosity ------
 
-        /// Water viscosity.
-        /// \param[in]  pw     Array of n water pressure values.
-        /// \param[in]  T      Array of n temperature values.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n viscosity values.
-        virtual
-        V muWat(const V& pw,
-                const V& T,
-                const Cells& cells) const = 0;
-
         /// Oil viscosity.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  T      Array of n temperature values.

--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -658,11 +658,12 @@ namespace detail {
         }
 
         // Use cell values for the temperature as the wells don't knows its temperature yet.
-        const V perf_temp = subset(state.temperature.value(), well_cells);
+        const ADB perf_temp = subset(state.temperature, well_cells);
 
         // Compute b, rsmax, rvmax values for perforations.
         // Evaluate the properties using average well block pressures
         // and cell values for rs, rv, phase condition and temperature.
+        const ADB avg_press_ad = ADB::constant(avg_press);
         std::vector<PhasePresence> perf_cond(nperf);
         const std::vector<PhasePresence>& pc = phaseCondition();
         for (int perf = 0; perf < nperf; ++perf) {
@@ -673,21 +674,21 @@ namespace detail {
         std::vector<double> rsmax_perf(nperf, 0.0);
         std::vector<double> rvmax_perf(nperf, 0.0);
         if (pu.phase_used[BlackoilPhases::Aqua]) {
-            const V bw = fluid_.bWat(avg_press, perf_temp, well_cells);
+            const V bw = fluid_.bWat(avg_press_ad, perf_temp, well_cells).value();
             b.col(pu.phase_pos[BlackoilPhases::Aqua]) = bw;
         }
         assert(active_[Oil]);
         const V perf_so =  subset(state.saturation[pu.phase_pos[Oil]].value(), well_cells);
         if (pu.phase_used[BlackoilPhases::Liquid]) {
-            const V perf_rs = subset(state.rs.value(), well_cells);
-            const V bo = fluid_.bOil(avg_press, perf_temp, perf_rs, perf_cond, well_cells);
+            const ADB perf_rs = subset(state.rs, well_cells);
+            const V bo = fluid_.bOil(avg_press_ad, perf_temp, perf_rs, perf_cond, well_cells).value();
             b.col(pu.phase_pos[BlackoilPhases::Liquid]) = bo;
             const V rssat = fluidRsSat(avg_press, perf_so, well_cells);
             rsmax_perf.assign(rssat.data(), rssat.data() + nperf);
         }
         if (pu.phase_used[BlackoilPhases::Vapour]) {
-            const V perf_rv = subset(state.rv.value(), well_cells);
-            const V bg = fluid_.bGas(avg_press, perf_temp, perf_rv, perf_cond, well_cells);
+            const ADB perf_rv = subset(state.rv, well_cells);
+            const V bg = fluid_.bGas(avg_press_ad, perf_temp, perf_rv, perf_cond, well_cells).value();
             b.col(pu.phase_pos[BlackoilPhases::Vapour]) = bg;
             const V rvsat = fluidRvSat(avg_press, perf_so, well_cells);
             rvmax_perf.assign(rvsat.data(), rvsat.data() + nperf);

--- a/opm/autodiff/ImpesTPFAAD.cpp
+++ b/opm/autodiff/ImpesTPFAAD.cpp
@@ -553,20 +553,7 @@ namespace {
 
     V ImpesTPFAAD::fluidMu(const int phase, const V& p, const V& T, const std::vector<int>& cells) const
     {
-        switch (phase) {
-        case Water:
-            return fluid_.muWat(p, T, cells);
-        case Oil: {
-            V dummy_rs = V::Zero(p.size(), 1) * p;
-            std::vector<PhasePresence> cond(dummy_rs.size());
-
-            return fluid_.muOil(p, T, dummy_rs, cond, cells);
-        }
-        case Gas:
-            return fluid_.muGas(p, T, cells);
-        default:
-            OPM_THROW(std::runtime_error, "Unknown phase index " << phase);
-        }
+        return fluidMu(phase, ADB::constant(p), ADB::constant(T), cells).value();
     }
 
 

--- a/opm/autodiff/ImpesTPFAAD.cpp
+++ b/opm/autodiff/ImpesTPFAAD.cpp
@@ -568,11 +568,13 @@ namespace {
         case Oil: {
             ADB dummy_rs = V::Zero(p.size(), 1) * p;
             std::vector<PhasePresence> cond(dummy_rs.size());
-
             return fluid_.muOil(p, T, dummy_rs, cond, cells);
         }
-        case Gas:
-            return fluid_.muGas(p, T, cells);
+        case Gas: {
+            ADB dummy_rv = V::Zero(p.size(), 1) * p;
+            std::vector<PhasePresence> cond(dummy_rv.size());
+            return fluid_.muGas(p, T, dummy_rv, cond, cells);
+        }
         default:
             OPM_THROW(std::runtime_error, "Unknown phase index " << phase);
         }

--- a/opm/autodiff/ImpesTPFAAD.cpp
+++ b/opm/autodiff/ImpesTPFAAD.cpp
@@ -586,20 +586,7 @@ namespace {
 
     V ImpesTPFAAD::fluidFvf(const int phase, const V& p, const V& T, const std::vector<int>& cells) const
     {
-        switch (phase) {
-        case Water:
-            return fluid_.bWat(p, T, cells);
-        case Oil: {
-            V dummy_rs = V::Zero(p.size(), 1) * p;
-            std::vector<PhasePresence> cond(dummy_rs.size());
-
-            return fluid_.bOil(p, T, dummy_rs, cond, cells);
-        }
-        case Gas:
-            return fluid_.bGas(p, T, cells);
-        default:
-            OPM_THROW(std::runtime_error, "Unknown phase index " << phase);
-        }
+        return fluidFvf(phase, ADB::constant(p), ADB::constant(T), cells).value();
     }
 
 
@@ -614,11 +601,13 @@ namespace {
         case Oil: {
             ADB dummy_rs = V::Zero(p.size(), 1) * p;
             std::vector<PhasePresence> cond(dummy_rs.size());
-
             return fluid_.bOil(p, T, dummy_rs, cond, cells);
         }
-        case Gas:
-            return fluid_.bGas(p, T, cells);
+        case Gas: {
+            ADB dummy_rv = V::Zero(p.size(), 1) * p;
+            std::vector<PhasePresence> cond(dummy_rv.size());
+            return fluid_.bGas(p, T, dummy_rv, cond, cells);
+        }
         default:
             OPM_THROW(std::runtime_error, "Unknown phase index " << phase);
         }

--- a/opm/autodiff/RateConverter.hpp
+++ b/opm/autodiff/RateConverter.hpp
@@ -326,6 +326,7 @@ namespace Opm {
             calcCoeff(const Input& in, const RegionId r, Coeff& coeff)
             {
                 typedef typename Property::V V;
+                typedef typename Property::ADB ADB;
 
                 const PhaseUsage&               pu = props_.phaseUsage();
                 const V&                        p  = getRegPress(r);
@@ -341,7 +342,7 @@ namespace Opm {
                 if (Details::PhaseUsed::water(pu)) {
                     // q[w]_r = q[w]_s / bw
 
-                    const V& bw = props_.bWat(p, T, c);
+                    const V& bw = props_.bWat(ADB::constant(p), ADB::constant(T), c).value();
 
                     coeff[iw] = 1.0 / bw(0);
                 }
@@ -354,7 +355,7 @@ namespace Opm {
                 if (Details::PhaseUsed::oil(pu)) {
                     // q[o]_r = 1/(bo * (1 - rs*rv)) * (q[o]_s - rv*q[g]_s)
 
-                    const V&     bo  = props_.bOil(p, T, m.rs, m.cond, c);
+                    const V&     bo  = props_.bOil(ADB::constant(p), ADB::constant(T), ADB::constant(m.rs), m.cond, c).value();
                     const double den = bo(0) * detR;
 
                     coeff[io] += 1.0 / den;
@@ -367,7 +368,7 @@ namespace Opm {
                 if (Details::PhaseUsed::gas(pu)) {
                     // q[g]_r = 1/(bg * (1 - rs*rv)) * (q[g]_s - rs*q[o]_s)
 
-                    const V&     bg  = props_.bGas(p, T, m.rv, m.cond, c);
+                    const V&     bg  = props_.bGas(ADB::constant(p), ADB::constant(T), ADB::constant(m.rv), m.cond, c).value();
                     const double den = bg(0) * detR;
 
                     coeff[ig] += 1.0 / den;

--- a/tests/test_boprops_ad.cpp
+++ b/tests/test_boprops_ad.cpp
@@ -129,6 +129,7 @@ BOOST_FIXTURE_TEST_CASE(ViscosityValue, TestFixture<SetupSimple>)
     const Opm::BlackoilPropsAdFromDeck::Cells cells(5, 0);
 
     typedef Opm::BlackoilPropsAdFromDeck::V V;
+    typedef Opm::BlackoilPropsAdFromDeck::ADB ADB;
 
     V Vpw;
     Vpw.resize(cells.size());
@@ -143,7 +144,7 @@ BOOST_FIXTURE_TEST_CASE(ViscosityValue, TestFixture<SetupSimple>)
 
     BOOST_REQUIRE_EQUAL(Vpw.size(), cells.size());
 
-    const Opm::BlackoilPropsAdFromDeck::V VmuWat = boprops_ad.muWat(Vpw, T, cells);
+    const V VmuWat = boprops_ad.muWat(ADB::constant(Vpw), ADB::constant(T), cells).value();
 
     BOOST_REQUIRE_EQUAL(Vpw.size(), cells.size());
 
@@ -159,6 +160,7 @@ BOOST_FIXTURE_TEST_CASE(ViscosityAD, TestFixture<SetupSimple>)
     const Opm::BlackoilPropsAdFromDeck::Cells cells(5, 0);
 
     typedef Opm::BlackoilPropsAdFromDeck::V V;
+    typedef Opm::BlackoilPropsAdFromDeck::ADB ADB;
 
     V Vpw;
     Vpw.resize(cells.size());
@@ -173,7 +175,7 @@ BOOST_FIXTURE_TEST_CASE(ViscosityAD, TestFixture<SetupSimple>)
 
     typedef Opm::BlackoilPropsAdFromDeck::ADB ADB;
 
-    const V VmuWat = boprops_ad.muWat(Vpw, T, cells);
+    const V VmuWat = boprops_ad.muWat(ADB::constant(Vpw), ADB::constant(T), cells).value();
     for (V::Index i = 0, n = Vpw.size(); i < n; ++i) {
         const std::vector<int> bp(1, grid.c_grid()->number_of_cells);
 


### PR DESCRIPTION
This PR simplifies the viscosity and formation volume factor interfaces: only a single function for each phase remains, the one that takes AD objects. This results in a massive reduction of copy-and-pasted almost-identical functions, making it much easier to get a grip on the property classes and their interface.

The downsides are:
 - Potential for a slight performance degradation in places where no derivatives are needed, see the commit message of fbf06c0, If a problem, this can be handled by making the `bOil()`, `muGas()` etc. functions explicitly use a simpler treatment for input with no derivatives, this has so far only been done in `BlackoilPropsAdFromDeck::muWat()`.
 - Slight increase in code complexity in those same few places. One way to deal with this is to make convenience functions in `BlackoilPropsAdInterface` taking non-AD variables that forward the call to the AD-taking ones. Only the AD-taking ones are virtual and required by subclasses.

I hope that @dr-robertk or @totto82 can see if they get performance degradation on the Norne case with this PR, I do not have existing timing data for comparison on my system.