### PR TITLE
Output Newton and Lienar solver iterations

### DIFF
--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -101,7 +101,8 @@ namespace Opm {
                                     const Wells*                    wells,
                                     const NewtonIterationBlackoilInterface& linsolver,
                                     const bool has_disgas,
-                                    const bool has_vapoil );
+                                    const bool has_vapoil,
+                                    const bool terminal_output);
 
         /// \brief Set threshold pressures that prevent or reduce flow.
         /// This prevents flow across faces if the potential

--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -129,6 +129,9 @@ namespace Opm {
              BlackoilState& state ,
              WellStateFullyImplicitBlackoil&     wstate);
 
+        unsigned int newtonIterations () const { return newtonIterations_; }
+        unsigned int linearIterations () const { return linearIterations_; }
+
     private:
         // Types and enums
         typedef AutoDiffBlock<double> ADB;
@@ -202,6 +205,8 @@ namespace Opm {
 
         /// \brief Whether we print something to std::cout
         bool terminal_output_;
+        unsigned int newtonIterations_;
+        unsigned int linearIterations_;
 
         std::vector<int>         primalVariable_;
 

--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -72,6 +72,7 @@ namespace Opm {
             double                          max_residual_allowed_;
             double                          tolerance_mb_;
             double                          tolerance_cnv_;
+            double                          tolerance_wells_;
             int                             max_iter_;
 
             SolverParameter( const parameter::ParameterGroup& param );

--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -198,7 +198,8 @@ namespace detail {
                                 const Wells*                    wells,
                                 const NewtonIterationBlackoilInterface&    linsolver,
                                 const bool has_disgas,
-                                const bool has_vapoil)
+                                const bool has_vapoil,
+                                const bool terminal_output)
         : grid_  (grid)
         , fluid_ (fluid)
         , geo_   (geo)
@@ -219,15 +220,18 @@ namespace detail {
         , residual_ ( { std::vector<ADB>(fluid.numPhases(), ADB::null()),
                         ADB::null(),
                         ADB::null() } )
-        , terminal_output_ (true)
+        , terminal_output_ (terminal_output)
     {
 #if HAVE_MPI
-        if ( linsolver_.parallelInformation().type() == typeid(ParallelISTLInformation) )
+        if( terminal_output_ )
         {
-            const ParallelISTLInformation& info =
-                boost::any_cast<const ParallelISTLInformation&>(linsolver_.parallelInformation());
-            // Only rank 0 does print to std::cout
-            terminal_output_ = (info.communicator().rank()==0);
+            if ( linsolver_.parallelInformation().type() == typeid(ParallelISTLInformation) )
+            {
+                const ParallelISTLInformation& info =
+                    boost::any_cast<const ParallelISTLInformation&>(linsolver_.parallelInformation());
+                // Only rank 0 does print to std::cout if terminal_output is enabled
+                terminal_output_ = (info.communicator().rank()==0);
+            }
         }
 #endif
     }

--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -225,8 +225,7 @@ namespace detail {
         , linearIterations_( 0 )
     {
 #if HAVE_MPI
-        if( terminal_output_ )
-        {
+        if ( terminal_output_ ) {
             if ( linsolver_.parallelInformation().type() == typeid(ParallelISTLInformation) )
             {
                 const ParallelISTLInformation& info =

--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -221,6 +221,8 @@ namespace detail {
                         ADB::null(),
                         ADB::null() } )
         , terminal_output_ (terminal_output)
+        , newtonIterations_( 0 )
+        , linearIterations_( 0 )
     {
 #if HAVE_MPI
         if( terminal_output_ )
@@ -335,6 +337,9 @@ namespace detail {
             OPM_THROW(std::runtime_error, "Failed to compute converged solution in " << it << " iterations.");
             return -1;
         }
+
+        linearIterations_ += linearIterations;
+        newtonIterations_ += it;
 
         return linearIterations;
     }

--- a/opm/autodiff/SimulatorFullyImplicitBlackoil_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoil_impl.hpp
@@ -249,6 +249,9 @@ namespace Opm
             output_writer_.restore( timer, state, prev_well_state, restorefilename, desiredRestoreStep );
         }
 
+        unsigned int totalNewtonIterations = 0;
+        unsigned int totalLinearIterations = 0;
+
         // Main simulation loop.
         while (!timer.done()) {
             // Report timestep.
@@ -307,6 +310,10 @@ namespace Opm
             // take time that was used to solve system for this reportStep
             solver_timer.stop();
 
+            // accumulate the number of Newton and Linear Iterations
+            totalNewtonIterations += solver.newtonIterations();
+            totalLinearIterations += solver.linearIterations();
+
             // Report timing.
             const double st = solver_timer.secsSinceStart();
 
@@ -339,6 +346,8 @@ namespace Opm
         report.pressure_time = stime;
         report.transport_time = 0.0;
         report.total_time = total_timer.secsSinceStart();
+        report.total_newton_iterations = totalNewtonIterations;
+        report.total_linear_iterations = totalLinearIterations;
         return report;
     }
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoil_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoil_impl.hpp
@@ -185,7 +185,7 @@ namespace Opm
           solver_(linsolver),
           has_disgas_(has_disgas),
           has_vapoil_(has_vapoil),
-          terminal_output_(true),
+          terminal_output_(param.getDefault("output_terminal", true)),
           eclipse_state_(eclipse_state),
           output_writer_(output_writer),
           rateConverter_(props_, std::vector<int>(AutoDiffGrid::numCells(grid_), 0)),
@@ -198,12 +198,15 @@ namespace Opm
             allcells_[cell] = cell;
         }
 #if HAVE_MPI
-        if ( solver_.parallelInformation().type() == typeid(ParallelISTLInformation) )
+        if( terminal_output_ )
         {
-            const ParallelISTLInformation& info =
-                boost::any_cast<const ParallelISTLInformation&>(solver_.parallelInformation());
-            // Only rank 0 does print to std::cout
-            terminal_output_= (info.communicator().rank()==0);
+            if ( solver_.parallelInformation().type() == typeid(ParallelISTLInformation) )
+            {
+                const ParallelISTLInformation& info =
+                    boost::any_cast<const ParallelISTLInformation&>(solver_.parallelInformation());
+                // Only rank 0 does print to std::cout
+                terminal_output_= (info.communicator().rank()==0);
+            }
         }
 #endif
     }
@@ -283,7 +286,7 @@ namespace Opm
             // Run a multiple steps of the solver depending on the time step control.
             solver_timer.start();
 
-            FullyImplicitBlackoilSolver<T> solver(solverParam, grid_, props_, geo_, rock_comp_props_, wells, solver_, has_disgas_, has_vapoil_);
+            FullyImplicitBlackoilSolver<T> solver(solverParam, grid_, props_, geo_, rock_comp_props_, wells, solver_, has_disgas_, has_vapoil_, terminal_output_);
             if (!threshold_pressures_by_face_.empty()) {
                 solver.setThresholdPressures(threshold_pressures_by_face_);
             }

--- a/opm/autodiff/SimulatorFullyImplicitBlackoil_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoil_impl.hpp
@@ -198,8 +198,7 @@ namespace Opm
             allcells_[cell] = cell;
         }
 #if HAVE_MPI
-        if( terminal_output_ )
-        {
+        if ( terminal_output_ ) {
             if ( solver_.parallelInformation().type() == typeid(ParallelISTLInformation) )
             {
                 const ParallelISTLInformation& info =


### PR DESCRIPTION
This PR implements the output of Newton and Linear Solver iterations at the end of a simulation (flow).

Also:
1) A parameter tolerance_wells has been added to make the tolerance user adjustable. 
2) terminal output can now be disabled by setting output_terminal to false

As usual, default behaviour is the same as before.
    