### PR TITLE
Fix for test failures after #327.

### DIFF
--- a/opm/autodiff/RateConverter.hpp
+++ b/opm/autodiff/RateConverter.hpp
@@ -342,7 +342,7 @@ namespace Opm {
                 if (Details::PhaseUsed::water(pu)) {
                     // q[w]_r = q[w]_s / bw
 
-                    const V& bw = props_.bWat(ADB::constant(p), ADB::constant(T), c).value();
+                    const V bw = props_.bWat(ADB::constant(p), ADB::constant(T), c).value();
 
                     coeff[iw] = 1.0 / bw(0);
                 }
@@ -355,7 +355,7 @@ namespace Opm {
                 if (Details::PhaseUsed::oil(pu)) {
                     // q[o]_r = 1/(bo * (1 - rs*rv)) * (q[o]_s - rv*q[g]_s)
 
-                    const V&     bo  = props_.bOil(ADB::constant(p), ADB::constant(T), ADB::constant(m.rs), m.cond, c).value();
+                    const V      bo  = props_.bOil(ADB::constant(p), ADB::constant(T), ADB::constant(m.rs), m.cond, c).value();
                     const double den = bo(0) * detR;
 
                     coeff[io] += 1.0 / den;
@@ -368,7 +368,7 @@ namespace Opm {
                 if (Details::PhaseUsed::gas(pu)) {
                     // q[g]_r = 1/(bg * (1 - rs*rv)) * (q[g]_s - rs*q[o]_s)
 
-                    const V&     bg  = props_.bGas(ADB::constant(p), ADB::constant(T), ADB::constant(m.rv), m.cond, c).value();
+                    const V      bg  = props_.bGas(ADB::constant(p), ADB::constant(T), ADB::constant(m.rv), m.cond, c).value();
                     const double den = bg(0) * detR;
 
                     coeff[ig] += 1.0 / den;


### PR DESCRIPTION
Avoid storing return value in reference.

Normally this is OK for by-value returns, but here the right hand side was changed to call ADB::value(), which returns by reference.

This should fix the test failures that reported in #327.
