### PR TITLE
Further simplify properties

### DIFF
--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -635,47 +635,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
     /// \param[in]  cells  Array of n cell indices to be associated with the saturation values.
     /// \return            An std::vector with 3 elements, each an array of n relperm values,
     ///                    containing krw, kro, krg. Use PhaseIndex for indexing into the result.
-    std::vector<V> BlackoilPropsAdFromDeck::relperm(const V& sw,
-                                                    const V& so,
-                                                    const V& sg,
-                                                    const Cells& cells) const
-    {
-        const int n = cells.size();
-        const int np = numPhases();
-        Block s_all(n, np);
-        if (phase_usage_.phase_used[Water]) {
-            assert(sw.size() == n);
-            s_all.col(phase_usage_.phase_pos[Water]) = sw;
-        }
-        if (phase_usage_.phase_used[Oil]) {
-            assert(so.size() == n);
-            s_all.col(phase_usage_.phase_pos[Oil]) = so;
-        }
-        if (phase_usage_.phase_used[Gas]) {
-            assert(sg.size() == n);
-            s_all.col(phase_usage_.phase_pos[Gas]) = sg;
-        }
-        Block kr(n, np);
-        satprops_->relperm(n, s_all.data(), cells.data(), kr.data(), 0);
-        std::vector<V> relperms;
-        relperms.reserve(3);
-        for (int phase = 0; phase < 3; ++phase) {
-            if (phase_usage_.phase_used[phase]) {
-                relperms.emplace_back(kr.col(phase_usage_.phase_pos[phase]));
-            } else {
-                relperms.emplace_back();
-            }
-        }
-        return relperms;
-    }
-
-    /// Relative permeabilities for all phases.
-    /// \param[in]  sw     Array of n water saturation values.
-    /// \param[in]  so     Array of n oil saturation values.
-    /// \param[in]  sg     Array of n gas saturation values.
-    /// \param[in]  cells  Array of n cell indices to be associated with the saturation values.
-    /// \return            An std::vector with 3 elements, each an array of n relperm values,
-    ///                    containing krw, kro, krg. Use PhaseIndex for indexing into the result.
     std::vector<ADB> BlackoilPropsAdFromDeck::relperm(const ADB& sw,
                                                       const ADB& so,
                                                       const ADB& sg,

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -550,39 +550,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
     /// \param[in]  po     Array of n oil pressure values.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n bubble point values for Rs.
-    V BlackoilPropsAdFromDeck::rsSat(const V& po,
-                                     const Cells& cells) const
-    {
-        if (!phase_usage_.phase_used[Oil]) {
-            OPM_THROW(std::runtime_error, "Cannot call rsMax(): oil phase not present.");
-        }
-        const int n = cells.size();
-        mapPvtRegions(cells);
-        assert(po.size() == n);
-        V rbub(n);
-        V drbubdp(n);
-        props_[phase_usage_.phase_pos[Oil]]->rsSat(n, pvt_region_.data(), po.data(), rbub.data(), drbubdp.data());
-        return rbub;
-    }
-
-    /// Bubble point curve for Rs as function of oil pressure.
-    /// \param[in]  po     Array of n oil pressure values.
-    /// \param[in]  so     Array of n oil saturation values.
-    /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-    /// \return            Array of n bubble point values for Rs.
-    V BlackoilPropsAdFromDeck::rsSat(const V& po,
-                                     const V& so,
-                                     const Cells& cells) const
-    {
-        V rs = rsSat(po, cells);
-        applyVap(rs, so, cells, vap2_);
-        return rs;
-    }
-
-    /// Bubble point curve for Rs as function of oil pressure.
-    /// \param[in]  po     Array of n oil pressure values.
-    /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-    /// \return            Array of n bubble point values for Rs.
     ADB BlackoilPropsAdFromDeck::rsSat(const ADB& po,
                                        const Cells& cells) const
     {
@@ -618,45 +585,12 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         return rs;
     }
 
-    // ------ Condensation curve ------
+    // ------ Rv condensation curve ------
 
     /// Condensation curve for Rv as function of oil pressure.
     /// \param[in]  po     Array of n oil pressure values.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-    /// \return            Array of n bubble point values for Rs.
-    V BlackoilPropsAdFromDeck::rvSat(const V& po,
-                                     const Cells& cells) const
-    {
-        if (!phase_usage_.phase_used[Gas]) {
-            OPM_THROW(std::runtime_error, "Cannot call rvMax(): gas phase not present.");
-        }
-        const int n = cells.size();
-        mapPvtRegions(cells);
-        assert(po.size() == n);
-        V rv(n);
-        V drvdp(n);
-        props_[phase_usage_.phase_pos[Gas]]->rvSat(n, pvt_region_.data(), po.data(), rv.data(), drvdp.data());
-        return rv;
-    }
-
-    /// Condensation curve for Rv as function of oil pressure.
-    /// \param[in]  po     Array of n oil pressure values.
-    /// \param[in]  so     Array of n oil saturation values.
-    /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-    /// \return            Array of n bubble point values for Rs.
-    V BlackoilPropsAdFromDeck::rvSat(const V& po,
-                                     const V& so,
-                                     const Cells& cells) const
-    {
-        V rv = rvSat(po, cells);
-        applyVap(rv, so, cells, vap1_);
-        return rv;
-    }
-
-    /// Condensation curve for Rv as function of oil pressure.
-    /// \param[in]  po     Array of n oil pressure values.
-    /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-    /// \return            Array of n bubble point values for Rs.
+    /// \return            Array of n condensation point values for Rv.
     ADB BlackoilPropsAdFromDeck::rvSat(const ADB& po,
                                        const Cells& cells) const
     {
@@ -682,7 +616,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
     /// \param[in]  po     Array of n oil pressure values.
     /// \param[in]  so     Array of n oil saturation values.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-    /// \return            Array of n bubble point values for Rs.
+    /// \return            Array of n condensation point values for Rv.
     ADB BlackoilPropsAdFromDeck::rvSat(const ADB& po,
                                        const ADB& so,
                                        const Cells& cells) const

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -245,23 +245,7 @@ namespace Opm
         /// Condensation curve for Rv as function of oil pressure.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n bubble point values for Rs.
-        V rvSat(const V& po,
-                const Cells& cells) const;
-
-        /// Condensation curve for Rv as function of oil pressure.
-        /// \param[in]  po     Array of n oil pressure values.
-        /// \param[in]  so     Array of n oil saturation values.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n bubble point values for Rs.
-        V rvSat(const V& po,
-                const V& so,
-                const Cells& cells) const;
-
-        /// Condensation curve for Rv as function of oil pressure.
-        /// \param[in]  po     Array of n oil pressure values.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n bubble point values for Rs.
+        /// \return            Array of n condensation point values for Rv.
         ADB rvSat(const ADB& po,
                   const Cells& cells) const;
 
@@ -269,7 +253,7 @@ namespace Opm
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  so     Array of n oil saturation values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n bubble point values for Rs.
+        /// \return            Array of n condensation point values for Rv.
         ADB rvSat(const ADB& po,
                   const ADB& so,
                   const Cells& cells) const;

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -267,18 +267,6 @@ namespace Opm
         /// \param[in]  cells  Array of n cell indices to be associated with the saturation values.
         /// \return            An std::vector with 3 elements, each an array of n relperm values,
         ///                    containing krw, kro, krg. Use PhaseIndex for indexing into the result.
-        std::vector<V> relperm(const V& sw,
-                               const V& so,
-                               const V& sg,
-                               const Cells& cells) const;
-
-        /// Relative permeabilities for all phases.
-        /// \param[in]  sw     Array of n water saturation values.
-        /// \param[in]  so     Array of n oil saturation values.
-        /// \param[in]  sg     Array of n gas saturation values.
-        /// \param[in]  cells  Array of n cell indices to be associated with the saturation values.
-        /// \return            An std::vector with 3 elements, each an array of n relperm values,
-        ///                    containing krw, kro, krg. Use PhaseIndex for indexing into the result.
         std::vector<ADB> relperm(const ADB& sw,
                                  const ADB& so,
                                  const ADB& sg,

--- a/opm/autodiff/BlackoilPropsAdInterface.hpp
+++ b/opm/autodiff/BlackoilPropsAdInterface.hpp
@@ -179,24 +179,6 @@ namespace Opm
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n bubble point values for Rs.
         virtual
-        V rsSat(const V& po,
-                const Cells& cells) const = 0;
-
-        /// Bubble point curve for Rs as function of oil pressure.
-        /// \param[in]  po     Array of n oil pressure values.
-        /// \param[in]  so     Array of n oil saturation values.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n bubble point values for Rs.
-        virtual
-        V rsSat(const V& po,
-                const V& so,
-                const Cells& cells) const = 0;
-
-        /// Bubble point curve for Rs as function of oil pressure.
-        /// \param[in]  po     Array of n oil pressure values.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n bubble point values for Rs.
-        virtual
         ADB rsSat(const ADB& po,
                   const Cells& cells) const = 0;
 
@@ -210,39 +192,21 @@ namespace Opm
                   const ADB& so,
                   const Cells& cells) const = 0;
 
-        // ------ Rs bubble point curve ------
+        // ------ Rv condensation curve ------
 
-        /// Bubble point curve for Rs as function of oil pressure.
+        /// Condensation curve for Rv as function of oil pressure.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n bubble point values for Rs.
-        virtual
-        V rvSat(const V& po,
-                const Cells& cells) const = 0;
-
-        /// Bubble point curve for Rs as function of oil pressure.
-        /// \param[in]  po     Array of n oil pressure values.
-        /// \param[in]  so     Array of n oil saturation values.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n bubble point values for Rs.
-        virtual
-        V rvSat(const V& po,
-                const V& so,
-                const Cells& cells) const = 0;
-
-        /// Bubble point curve for Rs as function of oil pressure.
-        /// \param[in]  po     Array of n oil pressure values.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n bubble point values for Rs.
+        /// \return            Array of n condensation point values for Rv.
         virtual
         ADB rvSat(const ADB& po,
                   const Cells& cells) const = 0;
 
-        /// Bubble point curve for Rs as function of oil pressure.
+        /// Condensation curve for Rv as function of oil pressure.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  so     Array of n oil saturation values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return            Array of n bubble point values for Rs.
+        /// \return            Array of n condensation point values for Rv.
         virtual
         ADB rvSat(const ADB& po,
                   const ADB& so,

--- a/opm/autodiff/BlackoilPropsAdInterface.hpp
+++ b/opm/autodiff/BlackoilPropsAdInterface.hpp
@@ -222,19 +222,6 @@ namespace Opm
         /// \return            An std::vector with 3 elements, each an array of n relperm values,
         ///                    containing krw, kro, krg. Use PhaseIndex for indexing into the result.
         virtual
-        std::vector<V> relperm(const V& sw,
-                               const V& so,
-                               const V& sg,
-                               const Cells& cells) const = 0;
-
-        /// Relative permeabilities for all phases.
-        /// \param[in]  sw     Array of n water saturation values.
-        /// \param[in]  so     Array of n oil saturation values.
-        /// \param[in]  sg     Array of n gas saturation values.
-        /// \param[in]  cells  Array of n cell indices to be associated with the saturation values.
-        /// \return            An std::vector with 3 elements, each an array of n relperm values,
-        ///                    containing krw, kro, krg. Use PhaseIndex for indexing into the result.
-        virtual
         std::vector<ADB> relperm(const ADB& sw,
                                  const ADB& so,
                                  const ADB& sg,

--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -2154,10 +2154,10 @@ namespace detail {
     template<class T>
     V
     FullyImplicitBlackoilSolver<T>::fluidRsSat(const V&                p,
-                                            const V&                satOil,
-                                            const std::vector<int>& cells) const
+                                               const V&                satOil,
+                                               const std::vector<int>& cells) const
     {
-        return fluid_.rsSat(p, satOil, cells);
+        return fluid_.rsSat(ADB::constant(p), ADB::constant(satOil), cells).value();
     }
 
 
@@ -2167,19 +2167,20 @@ namespace detail {
     template<class T>
     ADB
     FullyImplicitBlackoilSolver<T>::fluidRsSat(const ADB&              p,
-                                            const ADB&              satOil,
-                                            const std::vector<int>& cells) const
+                                               const ADB&              satOil,
+                                               const std::vector<int>& cells) const
     {
         return fluid_.rsSat(p, satOil, cells);
     }
 
+
     template<class T>
     V
     FullyImplicitBlackoilSolver<T>::fluidRvSat(const V&                p,
-                                            const V&              satOil,
-                                            const std::vector<int>& cells) const
+                                               const V&              satOil,
+                                               const std::vector<int>& cells) const
     {
-        return fluid_.rvSat(p, satOil, cells);
+        return fluid_.rvSat(ADB::constant(p), ADB::constant(satOil), cells).value();
     }
 
 
@@ -2189,8 +2190,8 @@ namespace detail {
     template<class T>
     ADB
     FullyImplicitBlackoilSolver<T>::fluidRvSat(const ADB&              p,
-                                            const ADB&              satOil,
-                                            const std::vector<int>& cells) const
+                                               const ADB&              satOil,
+                                               const std::vector<int>& cells) const
     {
         return fluid_.rvSat(p, satOil, cells);
     }

--- a/opm/autodiff/ImpesTPFAAD.cpp
+++ b/opm/autodiff/ImpesTPFAAD.cpp
@@ -180,7 +180,7 @@ namespace {
         // Compute relperms once and for all (since saturations are explicit).
         DataBlock s = Eigen::Map<const DataBlock>(state.saturation().data(), nc, np);
         assert(np == 2);
-        kr_ = fluid_.relperm(s.col(0), s.col(1), V::Zero(nc,1), buildAllCells(nc));
+        kr_ = fluidRelperm(s.col(0), s.col(1), V::Zero(nc,1), buildAllCells(nc));
         // Compute relperms for wells. This must be revisited for crossflow.
         const int nw = wells_.number_of_wells;
         const int nperf = wells_.well_connpos[nw];
@@ -193,7 +193,7 @@ namespace {
         }
         const std::vector<int> well_cells(wells_.well_cells,
                                           wells_.well_cells + nperf);
-        well_kr_ = fluid_.relperm(well_s.col(0), well_s.col(1), V::Zero(nperf,1), well_cells);
+        well_kr_ = fluidRelperm(well_s.col(0), well_s.col(1), V::Zero(nperf,1), well_cells);
 
         const double atol  = 1.0e-10;
         const double rtol  = 5.0e-6;
@@ -255,7 +255,7 @@ namespace {
         // Compute relperms.
         DataBlock s = Eigen::Map<const DataBlock>(state.saturation().data(), nc, np);
         assert(np == 2);
-        kr_ = fluid_.relperm(s.col(0), s.col(1), V::Zero(nc,1), buildAllCells(nc));
+        kr_ = fluidRelperm(s.col(0), s.col(1), V::Zero(nc,1), buildAllCells(nc));
 
         // Compute relperms for wells. This must be revisited for crossflow.
         DataBlock well_s(nperf, np);
@@ -267,7 +267,7 @@ namespace {
         }
         const std::vector<int> well_cells(wells_.well_cells,
                                           wells_.well_cells + nperf);
-        well_kr_ = fluid_.relperm(well_s.col(0), well_s.col(1), V::Zero(nperf,1), well_cells);
+        well_kr_ = fluidRelperm(well_s.col(0), well_s.col(1), V::Zero(nperf,1), well_cells);
 
         // Compute well pressure differentials.
         // Construct pressure difference vector for wells.
@@ -635,6 +635,20 @@ namespace {
         ADB b = fluidFvf(phase, p, T, cells);
         ADB rho = V::Constant(p.size(), 1, rhos[phase]) * b;
         return rho;
+    }
+
+
+
+
+
+    std::vector<V> ImpesTPFAAD::fluidRelperm(const V& sw,
+                                             const V& so,
+                                             const V& sg,
+                                             const std::vector<int>& cells) const
+    {
+        std::vector<ADB> kr_ad = fluid_.relperm(ADB::constant(sw), ADB::constant(so), ADB::constant(sg), cells);
+        std::vector<V> kr = { kr_ad[0].value(), kr_ad[1].value(), kr_ad[2].value() };
+        return kr;
     }
 
 

--- a/opm/autodiff/ImpesTPFAAD.hpp
+++ b/opm/autodiff/ImpesTPFAAD.hpp
@@ -110,6 +110,7 @@ namespace Opm {
         ADB fluidFvf(const int phase, const ADB& p, const ADB& T, const std::vector<int>& cells) const;
         V fluidRho(const int phase, const V& p, const V& T, const std::vector<int>& cells) const;
         ADB fluidRho(const int phase, const ADB& p, const ADB& T, const std::vector<int>& cells) const;
+        std::vector<V> fluidRelperm(const V& sw, const V& so, const V& sg, const std::vector<int>& cells) const;
         V fluidKr(const int phase) const;
         V fluidKrWell(const int phase) const;
     };

--- a/opm/autodiff/RateConverter.hpp
+++ b/opm/autodiff/RateConverter.hpp
@@ -528,8 +528,9 @@ namespace Opm {
                     // pressure into account.  This facility uses the
                     // average *hydrocarbon* pressure rather than
                     // average phase pressure.
-                    Rmax_.col(io) = props_.rsSat(p_avg_, T_avg_, repcells_);
-                    Rmax_.col(ig) = props_.rvSat(p_avg_, T_avg_, repcells_);
+                    typedef BlackoilPropsAdInterface::ADB ADB;
+                    Rmax_.col(io) = props_.rsSat(ADB::constant(p_avg_), ADB::constant(T_avg_), repcells_).value();
+                    Rmax_.col(ig) = props_.rvSat(ADB::constant(p_avg_), ADB::constant(T_avg_), repcells_).value();
                 }
             }
 


### PR DESCRIPTION
With this, the `rsSat`, `rvSat` and `relperm()` overloaded methods are reduced to a single function.