### PR TITLE
SimFullyImplBO: write simulation state at all report step and in the end.

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoil_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoil_impl.hpp
@@ -274,9 +274,8 @@ namespace Opm
             WellStateFullyImplicitBlackoil well_state;
             well_state.init(wells, state, prev_well_state);
 
-            if( ! adaptiveTimeStepping ) {
-                output_writer_.writeTimeStep( timer, state, well_state );
-            }
+            // write simulation state at the report stage
+            output_writer_.writeTimeStep( timer, state, well_state );
 
             // Max oil saturation (for VPPARS), hysteresis update.
             props_.updateSatOilMax(state.saturation());
@@ -335,9 +334,7 @@ namespace Opm
         }
 
         // Write final simulation state.
-        if( ! adaptiveTimeStepping ) {
-            output_writer_.writeTimeStep( timer, state, prev_well_state );
-        }
+        output_writer_.writeTimeStep( timer, state, prev_well_state );
 
         // Stop timer and create timing report
         total_timer.stop();


### PR DESCRIPTION
This PR depends on OPM/opm-core#769 (opm-core). Here, the fix is to also write the first and last step when using adaptive substepping. The Writer internally keeps track of the `reportSteps` and only writes these once. I checked the result with 
