### PR TITLE
Reduce recalculation of phase pressures

### DIFF
--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -272,6 +272,12 @@ namespace Opm {
                          const ADB& so,
                          const ADB& sg) const;
 
+        V
+        computeGasPressure(const V& po,
+                           const V& sw,
+                           const V& so,
+                           const V& sg) const;
+
         std::vector<ADB>
         computeRelPerm(const SolutionState& state) const;
 

--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -221,11 +221,14 @@ namespace Opm {
 
         SolutionState
         constantState(const BlackoilState& x,
-                      const WellStateFullyImplicitBlackoil& xw);
+                      const WellStateFullyImplicitBlackoil& xw) const;
+
+        void
+        makeConstantState(SolutionState& state) const;
 
         SolutionState
         variableState(const BlackoilState& x,
-                      const WellStateFullyImplicitBlackoil& xw);
+                      const WellStateFullyImplicitBlackoil& xw) const;
 
         void
         computeAccum(const SolutionState& state,
@@ -251,6 +254,7 @@ namespace Opm {
         void
         assemble(const V&             dtpv,
                  const BlackoilState& x,
+                 const bool initial_assembly,
                  WellStateFullyImplicitBlackoil& xw);
 
         V solveJacobianSystem() const;

--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -160,6 +160,8 @@ namespace Opm {
             ADB              rv;
             ADB              qs;
             ADB              bhp;
+            // Below are quantities stored in the state for optimization purposes.
+            std::vector<ADB> canonical_phase_pressures; // Always has 3 elements, even if only 2 phases active.
         };
 
         struct WellOps {


### PR DESCRIPTION
This refactors some parts of the simulator to reduce the re-calculation of capillary and phase pressures. The changes are relatively minor. On my system, this yields a runtime reduction of approximately 5-10%.

There is still a little more to be gained, but it would require a somewhat larger change to the simulator structure than the current PR.

I also fixed a few whitespace issues nearby the changes I made. Add ?w=1 in the URL to review without whitespace changes.