### PR TITLE
Added SimulatorFullyImplicitBlackoilOutput.hpp to public headers, now us...

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -117,4 +117,6 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/autodiff/TransportSolverTwophaseAd.hpp
 	opm/autodiff/WellDensitySegmented.hpp
 	opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+	opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
 	)
+


### PR DESCRIPTION
...ed by opm-polymer

After merging of https://github.com/OPM/opm-polymer/pull/96 this header file must be included in the public headers.