### PR TITLE
also pass the deck to the output writer

### DIFF
--- a/examples/flow.cpp
+++ b/examples/flow.cpp
@@ -155,6 +155,7 @@ try
     const PhaseUsage pu = Opm::phaseUsageFromDeck(deck);
     Opm::BlackoilOutputWriter outputWriter(cGrid,
                                            param,
+                                           deck,
                                            eclipseState,
                                            pu );
 

--- a/examples/flow_cp.cpp
+++ b/examples/flow_cp.cpp
@@ -180,7 +180,7 @@ try
     grid->processEclipseFormat(deck, false, false, false, porv);
 
     const PhaseUsage pu = Opm::phaseUsageFromDeck(deck);
-    Opm::BlackoilOutputWriter outputWriter(*grid, param, eclipseState, pu );
+    Opm::BlackoilOutputWriter outputWriter(*grid, param, deck, eclipseState, pu );
 
     // Rock and fluid init
     props.reset(new BlackoilPropertiesFromDeck(deck, eclipseState,

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -187,6 +187,7 @@ namespace Opm
         template <class Grid>
         BlackoilOutputWriter(const Grid& grid,
                              const parameter::ParameterGroup& param,
+                             Opm::DeckConstPtr deck,
                              Opm::EclipseStateConstPtr eclipseState,
                              const Opm::PhaseUsage &phaseUsage);
 
@@ -235,6 +236,7 @@ namespace Opm
     BlackoilOutputWriter::
     BlackoilOutputWriter(const Grid& grid,
                          const parameter::ParameterGroup& param,
+                         Opm::DeckConstPtr deck,
                          Opm::EclipseStateConstPtr eclipseState,
                          const Opm::PhaseUsage &phaseUsage )
       : output_( param.getDefault("output", true) ),
@@ -246,7 +248,7 @@ namespace Opm
         matlabWriter_( output_ && param.getDefault("output_matlab", false) ?
                      new BlackoilMatlabWriter< Grid >( grid, outputDir_ ) : 0 ),
         eclWriter_( output_ && param.getDefault("output_ecl", true) ?
-                    new EclipseWriter(param, eclipseState, phaseUsage,
+                    new EclipseWriter(param, deck, eclipseState, phaseUsage,
                                       Opm::UgGridHelpers::numCells( grid ),
                                       Opm::UgGridHelpers::globalCell( grid ) )
                    : 0 )


### PR DESCRIPTION
this PR adapts to the EclipseWriter API change of OPM/opm-core#772 and must thus be merged synchronously.