### PR TITLE
More parameter for solvers.

### DIFF
--- a/opm/autodiff/CPRPreconditioner.hpp
+++ b/opm/autodiff/CPRPreconditioner.hpp
@@ -275,6 +275,7 @@ createEllipticPreconditionerPointer(const M& Ae, double relax,
         int cpr_max_ell_iter_;
         bool cpr_use_amg_;
         bool cpr_use_bicgstab_;
+        bool cpr_solver_verbose_;
 
         CPRParameter() { reset(); }
 
@@ -283,22 +284,24 @@ createEllipticPreconditionerPointer(const M& Ae, double relax,
             // reset values to default
             reset();
 
-            cpr_relax_        = param.getDefault("cpr_relax", cpr_relax_);
-            cpr_solver_tol_   = param.getDefault("cpr_solver_tol", cpr_solver_tol_);
-            cpr_ilu_n_        = param.getDefault("cpr_ilu_n", cpr_ilu_n_);
-            cpr_max_ell_iter_ = param.getDefault("cpr_max_elliptic_iter",cpr_max_ell_iter_);
-            cpr_use_amg_      = param.getDefault("cpr_use_amg", cpr_use_amg_);
-            cpr_use_bicgstab_ = param.getDefault("cpr_use_bicgstab", cpr_use_bicgstab_);
+            cpr_relax_          = param.getDefault("cpr_relax", cpr_relax_);
+            cpr_solver_tol_     = param.getDefault("cpr_solver_tol", cpr_solver_tol_);
+            cpr_ilu_n_          = param.getDefault("cpr_ilu_n", cpr_ilu_n_);
+            cpr_max_ell_iter_   = param.getDefault("cpr_max_elliptic_iter",cpr_max_ell_iter_);
+            cpr_use_amg_        = param.getDefault("cpr_use_amg", cpr_use_amg_);
+            cpr_use_bicgstab_   = param.getDefault("cpr_use_bicgstab", cpr_use_bicgstab_);
+            cpr_solver_verbose_ = param.getDefault("cpr_solver_verbose", cpr_solver_verbose_);
         }
 
         void reset()
         {
-            cpr_relax_        = 1.0;
-            cpr_solver_tol_   = 1e-4;
-            cpr_ilu_n_        = 0;
-            cpr_max_ell_iter_ = 5000;
-            cpr_use_amg_      = false;
-            cpr_use_bicgstab_ = true;
+            cpr_relax_          = 1.0;
+            cpr_solver_tol_     = 1e-4;
+            cpr_ilu_n_          = 0;
+            cpr_max_ell_iter_   = 5000;
+            cpr_use_amg_        = false;
+            cpr_use_bicgstab_   = true;
+            cpr_solver_verbose_ = false;
         }
     };
 
@@ -457,7 +460,7 @@ createEllipticPreconditionerPointer(const M& Ae, double relax,
             // Linear solver parameters
             const double tolerance = param_.cpr_solver_tol_;
             const int maxit        = param_.cpr_max_ell_iter_;
-            const int verbosity = 0;
+            const int verbosity    = param_.cpr_solver_verbose_ ? 1 : 0;
 
             // operator result containing iterations etc.
             Dune::InverseOperatorResult result;

--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -73,7 +73,8 @@ namespace Opm {
             double                          tolerance_mb_;
             double                          tolerance_cnv_;
             double                          tolerance_wells_;
-            int                             max_iter_;
+            int                             max_iter_; // max newton iterations
+            int                             min_iter_; // min newton iterations
 
             SolverParameter( const parameter::ParameterGroup& param );
             SolverParameter();
@@ -418,6 +419,7 @@ namespace Opm {
         double relaxIncrement() const { return param_.relax_increment_; };
         double relaxRelTol() const { return param_.relax_rel_tol_; };
         double maxIter() const     { return param_.max_iter_; }
+        double minIter() const     { return param_.min_iter_; }
         double maxResidualAllowed() const { return param_.max_residual_allowed_; }
 
     };

--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -2,6 +2,7 @@
   Copyright 2013 SINTEF ICT, Applied Mathematics.
   Copyright 2015 Dr. Blatt - HPC-Simulation-Software & Services
   Copyright 2015 NTNU
+  Copyright 2015 IRIS AS
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -143,7 +144,8 @@ namespace detail {
         relax_max_       = 0.5;
         relax_increment_ = 0.1;
         relax_rel_tol_   = 0.2;
-        max_iter_        = 15;
+        max_iter_        = 15; // not more then 15 its by default
+        min_iter_        = 0;  // keep the default as it was
         max_residual_allowed_  = std::numeric_limits< double >::max();
         tolerance_mb_    = 1.0e-7;
         tolerance_cnv_   = 1.0e-3;
@@ -171,6 +173,7 @@ namespace detail {
         dr_max_rel_  = param.getDefault("dr_max_rel", dr_max_rel_);
         relax_max_   = param.getDefault("relax_max", relax_max_);
         max_iter_    = param.getDefault("max_iter", max_iter_);
+        min_iter_    = param.getDefault("min_iter", min_iter_);
         max_residual_allowed_ = param.getDefault("max_residual_allowed", max_residual_allowed_);
 
         tolerance_mb_    = param.getDefault("tolerance_mb", tolerance_mb_);
@@ -294,7 +297,7 @@ namespace detail {
         const enum RelaxType relaxtype = relaxType();
         int linearIterations = 0;
 
-        while ((!converged) && (it < maxIter())) {
+        while ( (!converged && (it < maxIter())) || (minIter() > it)) {
             V dx = solveJacobianSystem();
 
             // store number of linear iterations used
@@ -326,9 +329,8 @@ namespace detail {
         }
 
         if (!converged) {
-            // the runtime_error is caught by the AdaptiveTimeStepping
-            OPM_THROW(std::runtime_error, "Failed to compute converged solution in " << it << " iterations.");
-            return -1;
+            std::cerr << "WARNING: Failed to compute converged solution in " << it << " iterations." << std::endl;
+            return -1; // -1 indicates that the solver has to be restarted
         }
 
         linearIterations_ += linearIterations;

--- a/opm/autodiff/NewtonIterationBlackoilCPR.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilCPR.cpp
@@ -99,13 +99,10 @@ namespace Opm
     /// Construct a system solver.
     NewtonIterationBlackoilCPR::NewtonIterationBlackoilCPR(const parameter::ParameterGroup& param,
                                                            const boost::any& parallelInformation)
-        : iterations_( 0 ), parallelInformation_(parallelInformation)
+        : cpr_param_( param ),
+          iterations_( 0 ),
+          parallelInformation_(parallelInformation)
     {
-        cpr_relax_        = param.getDefault("cpr_relax", 1.0);
-        cpr_ilu_n_        = param.getDefault("cpr_ilu_n", 0);
-        cpr_use_amg_      = param.getDefault("cpr_use_amg", false);
-        cpr_use_bicgstab_ = param.getDefault("cpr_use_bicgstab", true);
-
         linear_solver_reduction_ = param.getDefault("linear_solver_reduction", 1e-3 );
         linear_solver_maxiter_   = param.getDefault("linear_solver_maxiter", 150 );
         linear_solver_restart_   = param.getDefault("linear_solver_restart", 40 );

--- a/opm/autodiff/NewtonIterationBlackoilCPR.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilCPR.hpp
@@ -46,6 +46,7 @@ namespace Opm
         typedef Dune::FieldMatrix<double, 1, 1> MatrixBlockType;
         typedef Dune::BCRSMatrix <MatrixBlockType>        Mat;
         typedef Dune::BlockVector<VectorBlockType>        Vector;
+
     public:
 
         /// Construct a system solver.
@@ -91,9 +92,9 @@ namespace Opm
                 sp(ScalarProductChooser::construct(parallelInformation));
             // Construct preconditioner.
             // typedef Dune::SeqILU0<Mat,Vector,Vector> Preconditioner;
-            typedef Opm::CPRPreconditioner<Mat,Vector,Vector,P> Preconditioner;
+           typedef Opm::CPRPreconditioner<Mat,Vector,Vector,P> Preconditioner;
             parallelInformation.copyOwnerToAll(istlb, istlb);
-            Preconditioner precond(opA.getmat(), istlAe, cpr_relax_, cpr_ilu_n_, cpr_use_amg_, cpr_use_bicgstab_, parallelInformation);
+            Preconditioner precond(cpr_param_, opA.getmat(), istlAe, parallelInformation);
 
             // TODO: Revise when linear solvers interface opm-core is done
             // Construct linear solver.
@@ -112,11 +113,9 @@ namespace Opm
             }
         }
 
+        CPRParameter cpr_param_;
+
         mutable int iterations_;
-        double cpr_relax_;
-        unsigned int cpr_ilu_n_;
-        bool cpr_use_amg_;
-        bool cpr_use_bicgstab_;
         bool newton_use_gmres_;
         boost::any parallelInformation_;
 


### PR DESCRIPTION
This PR adds more parameters to steer the Newton and linear solvers. 

* `FullyImplicitBlackOil`: added min newton iteration, needed for Norne
* `NewtonIterationBlackoilCPR`: allow to use BiCG and adapt to parameter changes in CPR
* CPR: added tolerances as parameters and changed parameters for AMG.

Tested with SPE9 and Norne (see opm-data). 