### PR TITLE
Bugfix: distribute only if comm size is strictly > 1.

### DIFF
--- a/examples/flow_cp.cpp
+++ b/examples/flow_cp.cpp
@@ -246,7 +246,7 @@ try
     // At this point all properties and state variables are correctly initialized
     // If there are more than one processors involved, we now repartition the grid
     // and initilialize new properties and states for it.
-    bool must_distribute = ( grid->comm().size()>=1 );
+    bool must_distribute = ( grid->comm().size() > 1 );
     if( must_distribute )
     {
         if( param.getDefault("output_matlab", false) || param.getDefault("output_ecl", true) )


### PR DESCRIPTION
After this, flow_cp can run standard tests such as SPE9 on a serial configuration.