### PR TITLE
fixed: use size_t and not unsigned long

### DIFF
--- a/opm/autodiff/BackupRestore.hpp
+++ b/opm/autodiff/BackupRestore.hpp
@@ -79,7 +79,7 @@ namespace Opm {
             container.resize( size );
         }
 
-        template <class T, unsigned long n>
+        template <class T, size_t n>
         void resizeContainer( std::array<T, n>& /* a */, size_t size )
         {
             static_cast<void>(size);


### PR DESCRIPTION
fixes builds on i386