### PR TITLE
CPRPreconditioner: use UnSymmetricCriterion for AMG.

### DIFF
--- a/opm/autodiff/CPRPreconditioner.hpp
+++ b/opm/autodiff/CPRPreconditioner.hpp
@@ -543,7 +543,9 @@ createEllipticPreconditionerPointer(const M& Ae, double relax,
               typedef Dune::Amg::FirstDiagonal CouplingMetric;
 
               // The coupling criterion used in the AMG
-              typedef Dune::Amg::SymmetricCriterion<M, CouplingMetric> CritBase;
+              // use UnSymmetricCriterion because the resulting matrices happen to be
+              // unsymmetric sometimes due to the drop of values close to zero
+              typedef Dune::Amg::UnSymmetricCriterion<M, CouplingMetric> CritBase;
 
               // The coarsening criterion used in the AMG
               typedef Dune::Amg::CoarsenCriterion<CritBase> Criterion;


### PR DESCRIPTION
This PR fixes the issue with the AMG throwing an ISTLError every now and then due to unsymmetric matrices. 
