### PR TITLE
std::runtime_error --> LinearSolverProblem. 

### DIFF
--- a/opm/autodiff/CPRPreconditioner.hpp
+++ b/opm/autodiff/CPRPreconditioner.hpp
@@ -44,6 +44,7 @@
 #include <opm/core/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/core/utility/Exceptions.hpp>
 
 namespace Opm
 {
@@ -498,7 +499,7 @@ createEllipticPreconditionerPointer(const M& Ae, double relax,
             }
 
             if (!result.converged) {
-                OPM_THROW(std::runtime_error, "CPRPreconditioner failed to solve elliptic subsystem.");
+                OPM_THROW(LinearSolverProblem, "CPRPreconditioner failed to solve elliptic subsystem.");
             }
         }
 

--- a/opm/autodiff/ImpesTPFAAD.cpp
+++ b/opm/autodiff/ImpesTPFAAD.cpp
@@ -25,6 +25,7 @@
 #include <opm/core/simulator/BlackoilState.hpp>
 #include <opm/core/simulator/WellState.hpp>
 #include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/core/utility/Exceptions.hpp>
 #include <opm/core/linalg/LinearSolverInterface.hpp>
 #include <opm/core/wells.h>
 
@@ -62,12 +63,12 @@ namespace {
         std::vector<int> f2hf(2 * numFaces(grid), -1);
         Eigen::Array<int, Eigen::Dynamic, 2, Eigen::RowMajor>
             face_cells = faceCellsToEigen(grid);
-        
+
         typedef typename Opm::UgGridHelpers::Cell2FacesTraits<UnstructuredGrid>::Type
             Cell2Faces;
         Cell2Faces c2f=cell2Faces(grid);
         for (int c = 0; c < nc; ++c) {
-            typename Cell2Faces::row_type 
+            typename Cell2Faces::row_type
                 cell_faces = c2f[c];
             typedef typename Cell2Faces::row_type::iterator Iter;
             for (Iter f=cell_faces.begin(), end=cell_faces.end();
@@ -445,7 +446,7 @@ namespace {
                                matr.outerIndexPtr(), matr.innerIndexPtr(), matr.valuePtr(),
                                total_residual_.value().data(), dx.data());
         if (!rep.converged) {
-            OPM_THROW(std::runtime_error, "ImpesTPFAAD::solve(): Linear solver convergence failure.");
+            OPM_THROW(LinearSolverProblem, "ImpesTPFAAD::solve(): Linear solver convergence failure.");
         }
         const V p0 = Eigen::Map<const V>(&state.pressure()[0], nc, 1);
         const V dp = subset(dx, Span(nc));

--- a/opm/autodiff/NewtonIterationBlackoilCPR.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilCPR.cpp
@@ -26,6 +26,7 @@
 #include <opm/autodiff/NewtonIterationBlackoilCPR.hpp>
 #include <opm/autodiff/AutoDiffHelpers.hpp>
 #include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/core/utility/Exceptions.hpp>
 #include <opm/core/utility/Units.hpp>
 #include <opm/core/linalg/LinearSolverFactory.hpp>
 #include <opm/core/linalg/ParallelIstlInformation.hpp>
@@ -208,7 +209,7 @@ namespace Opm
 
         // Check for failure of linear solver.
         if (!result.converged) {
-            OPM_THROW(std::runtime_error, "Convergence failure for linear solver.");
+            OPM_THROW(LinearSolverProblem, "Convergence failure for linear solver.");
         }
 
         // Copy solver output to dx.

--- a/opm/autodiff/NewtonIterationBlackoilSimple.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilSimple.cpp
@@ -22,6 +22,7 @@
 #include <opm/autodiff/NewtonIterationBlackoilSimple.hpp>
 #include <opm/autodiff/AutoDiffHelpers.hpp>
 #include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/core/utility/Exceptions.hpp>
 #include <opm/core/linalg/LinearSolverFactory.hpp>
 
 namespace Opm
@@ -67,7 +68,7 @@ namespace Opm
         iterations_ = rep.iterations;
 
         if (!rep.converged) {
-            OPM_THROW(std::runtime_error,
+            OPM_THROW(LinearSolverProblem,
                       "FullyImplicitBlackoilSolver::solveJacobianSystem(): "
                       "Linear solver convergence failure.");
         }

--- a/opm/autodiff/TransportSolverTwophaseAd.cpp
+++ b/opm/autodiff/TransportSolverTwophaseAd.cpp
@@ -25,6 +25,7 @@
 #include <opm/core/pressure/tpfa/trans_tpfa.h>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/core/utility/Exceptions.hpp>
 #include <iostream>
 
 
@@ -236,7 +237,7 @@ namespace Opm
                                    smatr.outerIndexPtr(), smatr.innerIndexPtr(), smatr.valuePtr(),
                                    transport_residual.value().data(), ds.data());
             if (!rep.converged) {
-                OPM_THROW(std::runtime_error, "Linear solver convergence error in TransportSolverTwophaseAd::solve()");
+                OPM_THROW(LinearSolverProblem, "Linear solver convergence error in TransportSolverTwophaseAd::solve()");
             }
 
             // Update (possible clamp) sw1.


### PR DESCRIPTION
Consequently throw LinearSolverException when the linear solver was not converged. 
Since LinearSolverProblem is derived from std::runtime_error everything should work as
before.