### PR TITLE
Use more appropriate end-of-sim timing output.

### DIFF
--- a/examples/flow.cpp
+++ b/examples/flow.cpp
@@ -263,7 +263,7 @@ try
     SimulatorReport fullReport = simulator.run(simtimer, state);
 
     std::cout << "\n\n================    End of simulation     ===============\n\n";
-    fullReport.report(std::cout);
+    fullReport.reportFullyImplicit(std::cout);
 
     if (output) {
         std::string filename = output_dir + "/walltime.txt";

--- a/examples/flow_cp.cpp
+++ b/examples/flow_cp.cpp
@@ -341,7 +341,7 @@ try
     if( grid->comm().rank()==0 )
     {
         std::cout << "\n\n================    End of simulation     ===============\n\n";
-        fullReport.report(std::cout);
+        fullReport.reportFullyImplicit(std::cout);
     }
 
     if (output) {


### PR DESCRIPTION
This requires OPM/opm-core#789.

I intend to put this in the release branch as well.