### PR TITLE
FullyImplicitBlockOil: increase max_allowed_residual to 1e7.

### DIFF
--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -146,7 +146,7 @@ namespace detail {
         relax_rel_tol_   = 0.2;
         max_iter_        = 15; // not more then 15 its by default
         min_iter_        = 1;  // Default to always do at least one nonlinear iteration.
-        max_residual_allowed_ = 1e5;
+        max_residual_allowed_ = 1e7;
         tolerance_mb_    = 1.0e-5;
         tolerance_cnv_   = 1.0e-2;
         tolerance_wells_ = 1.0e-2;


### PR DESCRIPTION
This small change is necessary to make SPE3 run without adaptive time stepping for comparisons with ECL. The results of the other test cases are not changed and run times stay the same.

This should also be merged into the release branch.
