### PR TITLE
BlackoilOutputWriter: fix restore when last step is selected.

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -331,11 +331,17 @@ namespace Opm
                     break;
                 }
 
+                // try to read next report step
+                restorefile.read( (char *) &reportStep, sizeof(int) );
+
+                // if read failed, exit loop
+                if( ! restorefile ) {
+                    break;
+                }
+
                 // next step
                 timer.advance();
 
-                // read next report step
-                restorefile.read( (char *) &reportStep, sizeof(int) );
                 if( timer.reportStepNum() != reportStep ) {
                     break;
                 }


### PR DESCRIPTION
This PR fixes the restore of data when last report step that was written is selected. 
If still possible, this could go into the release.