### PR TITLE
[bugfix] Use full set of processes to determine whether to redistribute ...

### DIFF
--- a/examples/flow_cp.cpp
+++ b/examples/flow_cp.cpp
@@ -266,7 +266,7 @@ try
     // At this point all properties and state variables are correctly initialized
     // If there are more than one processors involved, we now repartition the grid
     // and initilialize new properties and states for it.
-    bool must_distribute = ( grid->comm().size() > 1 );
+    bool must_distribute = ( mpi_helper.size() > 1 );
     if( must_distribute )
     {
         if( param.getDefault("output_matlab", false) || param.getDefault("output_ecl", true) )


### PR DESCRIPTION
...or not.

Previously we used the size of the communicator within the CpGrid to check
whether we are running in parallel and need to redistribute the grid.
Unfortunately, this is MPI_COMM_SELF until we actually loadbalance and redistribute.
Therefore we now use the size of the MPI_Helper (i.e. MPI_COMM_WORLD) which
gives us the number of all available processes.

Note that the wrong behaviour was provoked with 656e5de3310. Before that we
redistributed in any case which luckily included runs with more than 1 process.