### PR TITLE
[bugfix] Pass parallel information to AMG preconditioner within CPR.

### DIFF
--- a/opm/autodiff/CPRPreconditioner.hpp
+++ b/opm/autodiff/CPRPreconditioner.hpp
@@ -564,7 +564,7 @@ createEllipticPreconditionerPointer(const M& Ae, double relax,
               smootherArgs.iterations = 1;
               smootherArgs.relaxationFactor = param_.cpr_relax_;
 
-              amg_ = std::unique_ptr< AMG > (new AMG(*opAe_, criterion, smootherArgs ));
+              amg_ = std::unique_ptr< AMG > (new AMG(*opAe_, criterion, smootherArgs, comm ));
             }
             else
             {


### PR DESCRIPTION
Previously only passed the parallel information to the ILU preconditioner,
but of course needs this information to set up the communication, too.
With this commit we pass the parallel information object to AMG's constructor.