### PR TITLE
Changed throw in main() to return EXIT_FAILURE

### DIFF
--- a/examples/flow.cpp
+++ b/examples/flow.cpp
@@ -63,6 +63,7 @@
 #include <iostream>
 #include <vector>
 #include <numeric>
+#include <cstdlib>
 
 
 namespace

--- a/examples/flow.cpp
+++ b/examples/flow.cpp
@@ -101,7 +101,8 @@ try
     parameter::ParameterGroup param(argc, argv, false);
     if (!param.unhandledArguments().empty()) {
         if (param.unhandledArguments().size() != 1) {
-            OPM_THROW(std::runtime_error, "You can only specify a single input deck on the command line.");
+            std::cerr << "You can only specify a single input deck on the command line.\n";
+            return EXIT_FAILURE;
         } else {
             param.insertParameter("deck_filename", param.unhandledArguments()[0]);
         }
@@ -113,8 +114,8 @@ try
             "Specify the deck filename either\n"
             "    a) as a command line argument by itself\n"
             "    b) as a command line parameter with the syntax deck_filename=<path to your deck>, or\n"
-            "    c) as a parameter in a parameter file (.param or .xml) passed to the program.";
-        OPM_THROW(std::runtime_error, "Input deck required.");
+            "    c) as a parameter in a parameter file (.param or .xml) passed to the program.\n";
+        return EXIT_FAILURE;
     }
     std::shared_ptr<GridManager> grid;
     std::shared_ptr<BlackoilPropertiesInterface> props;
@@ -138,7 +139,8 @@ try
             create_directories(fpath);
         }
         catch (...) {
-            OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
+            std::cerr << "Creating directories failed: " << fpath << std::endl;
+            return EXIT_FAILURE;
         }
         // Write simulation parameters.
         param.writeParam(output_dir + "/simulation.param");
@@ -280,6 +282,6 @@ try
 }
 catch (const std::exception &e) {
     std::cerr << "Program threw an exception: " << e.what() << "\n";
-    throw;
+    return EXIT_FAILURE;
 }
 

--- a/examples/flow_cp.cpp
+++ b/examples/flow_cp.cpp
@@ -128,7 +128,8 @@ try
     parameter::ParameterGroup param(argc, argv, false);
     if (!param.unhandledArguments().empty()) {
         if (param.unhandledArguments().size() != 1) {
-            OPM_THROW(std::runtime_error, "You can only specify a single input deck on the command line.");
+            std::cerr << "You can only specify a single input deck on the command line.\n";
+            return EXIT_FAILURE;
         } else {
             param.insertParameter("deck_filename", param.unhandledArguments()[0]);
         }
@@ -140,8 +141,8 @@ try
             "Specify the deck filename either\n"
             "    a) as a command line argument by itself\n"
             "    b) as a command line parameter with the syntax deck_filename=<path to your deck>, or\n"
-            "    c) as a parameter in a parameter file (.param or .xml) passed to the program.";
-        OPM_THROW(std::runtime_error, "Input deck required.");
+            "    c) as a parameter in a parameter file (.param or .xml) passed to the program.\n";
+        return EXIT_FAILURE;
     }
     std::shared_ptr<Dune::CpGrid> grid;
     std::shared_ptr<BlackoilPropertiesInterface> props;
@@ -165,7 +166,8 @@ try
             create_directories(fpath);
         }
         catch (...) {
-            OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
+            std::cerr << "Creating directories failed: " << fpath << std::endl;
+            return EXIT_FAILURE;
         }
         // Write simulation parameters.
         param.writeParam(output_dir + "/simulation.param");
@@ -271,9 +273,10 @@ try
     {
         if( param.getDefault("output_matlab", false) || param.getDefault("output_ecl", true) )
         {
-            OPM_THROW(std::logic_error, "We only support vtk output during parallel runs. "
-                      <<"Please use \"output_matlab=false output_ecl=false\" to deactivate the "
-                      <<"other outputs!");
+        	std::cerr << "We only support vtk output during parallel runs. \n"
+                      << "Please use \"output_matlab=false output_ecl=false\" to deactivate the \n"
+                      << "other outputs!" << std::endl;
+        	return EXIT_FAILURE;
         }
         grid->loadBalance();
         Dune::CpGrid global_grid      = *grid;
@@ -359,6 +362,6 @@ try
 }
 catch (const std::exception &e) {
     std::cerr << "Program threw an exception: " << e.what() << "\n";
-    throw;
+    return EXIT_FAILURE;
 }
 

--- a/examples/flow_cp.cpp
+++ b/examples/flow_cp.cpp
@@ -89,6 +89,7 @@
 #include <iostream>
 #include <vector>
 #include <numeric>
+#include <cstdlib>
 
 namespace
 {


### PR DESCRIPTION
This addresses issue #372, in which an exception thrown from main() ends up in a core dump. Simply changes throws in main() to return EXIT_FAILURE.