### PR TITLE
Check scaled well residuals for convergence

### DIFF
--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -1973,11 +1973,13 @@ namespace detail {
             converged_MB                = converged_MB && (mass_balance_residual[idx] < tol_mb);
             converged_CNV               = converged_CNV && (CNV[idx] < tol_cnv);
 
+            double maxNormWell = 0.0;
             for ( int w=0; w<nw; ++w )
             {
-                well_flux_residual[idx] += std::abs(residual_.well_flux_eq.value()[nw*idx + w]);
+                maxNormWell  = std::max(maxNormWell, std::abs(residual_.well_flux_eq.value()[nw*idx + w]));
             }
-            well_flux_residual[idx]     *= (B_avg[idx] * dt/nw);
+            well_flux_residual[idx] = B_avg[idx] * dt * maxNormWell;
+
             converged_Well = converged_Well && (well_flux_residual[idx] < tol_wells);
         }
 

--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -149,7 +149,7 @@ namespace detail {
         max_residual_allowed_ = 1e7;
         tolerance_mb_    = 1.0e-5;
         tolerance_cnv_   = 1.0e-2;
-        tolerance_wells_ = 1.0e-2;
+        tolerance_wells_ = 5.0e-1;
     }
 
     template<class T>


### PR DESCRIPTION
The well residuals are scaled with the volume factor before convergence is checked to avoid too large weight on the gas phase. The default tolerance is changed such that the overall run time is less than 10% more than before, while still improving the results for some critical wells.   