### PR TITLE
Prevent printing stats on more than 1 process for CPR.

### DIFF
--- a/examples/flow_cp.cpp
+++ b/examples/flow_cp.cpp
@@ -373,7 +373,9 @@ try
     } else {
         outputWriter.writeInit( simtimer );
         if ( output_cout )
+        {
             std::cout << "\n\n================ Simulation turned off ===============\n" << std::flush;
+        }
     }
 }
 catch (const std::exception &e) {

--- a/opm/autodiff/CPRPreconditioner.hpp
+++ b/opm/autodiff/CPRPreconditioner.hpp
@@ -459,7 +459,8 @@ createEllipticPreconditionerPointer(const M& Ae, double relax,
             // Linear solver parameters
             const double tolerance = param_.cpr_solver_tol_;
             const int maxit        = param_.cpr_max_ell_iter_;
-            const int verbosity    = param_.cpr_solver_verbose_ ? 1 : 0;
+            const int verbosity    = ( param_.cpr_solver_verbose_ &&
+                                       comm_.communicator().rank()==0 ) ? 1 : 0;
 
             // operator result containing iterations etc.
             Dune::InverseOperatorResult result;


### PR DESCRIPTION
Previously, each process did print its own statistics to std::cout. This result in the same ouput printed multiple (the number of processes) times.

Together with and based upon PR OPM/opm-core#800 this PR drastically decreases the noise. Now only the process with rank equal to zero will print to standard out.

Note: PR OPM/opm-core#800 needs to be merged before this one.