### PR TITLE
Removes unused residualNorm method.

### DIFF
--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -289,9 +289,6 @@ namespace Opm {
 
         void applyThresholdPressures(ADB& dp);
 
-        double
-        residualNorm() const;
-
         /// \brief Compute the residual norms of the mass balance for each phase,
         /// the well flux, and the well equation.
         /// \return a vector that contains for each phase the norm of the mass balance

--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -1722,34 +1722,6 @@ namespace detail {
         dp = keep_high_potential * (dp - threshold_modification);
     }
 
-
-
-
-
-    template<class T>
-    double
-    FullyImplicitBlackoilSolver<T>::residualNorm() const
-    {
-        double globalNorm = 0;
-        std::vector<ADB>::const_iterator quantityIt = residual_.material_balance_eq.begin();
-        const std::vector<ADB>::const_iterator endQuantityIt = residual_.material_balance_eq.end();
-        for (; quantityIt != endQuantityIt; ++quantityIt) {
-            const double quantityResid = (*quantityIt).value().matrix().norm();
-            if (!std::isfinite(quantityResid)) {
-                const int trouble_phase = quantityIt - residual_.material_balance_eq.begin();
-                OPM_THROW(Opm::NumericalProblem,
-                          "Encountered a non-finite residual in material balance equation "
-                          << trouble_phase);
-            }
-            globalNorm = std::max(globalNorm, quantityResid);
-        }
-        globalNorm = std::max(globalNorm, residual_.well_flux_eq.value().matrix().norm());
-        globalNorm = std::max(globalNorm, residual_.well_eq.value().matrix().norm());
-
-        return globalNorm;
-    }
-
-
     template<class T>
     std::vector<double>
     FullyImplicitBlackoilSolver<T>::computeResidualNorms() const


### PR DESCRIPTION
This method seems to be some leftover from refactoring.
In flow we now use computeResidualNorms() instead and
residualNorm() is not used anywhere. Therefore this commit
removes it to prevent confusion.