### PR TITLE
Fix parallel communication  for whole system

### DIFF
--- a/opm/autodiff/CPRPreconditioner.hpp
+++ b/opm/autodiff/CPRPreconditioner.hpp
@@ -386,7 +386,7 @@ createEllipticPreconditionerPointer(const M& Ae, double relax,
               comm_(comm)
         {
             // create appropriate preconditioner for elliptic system
-            createPreconditioner( param_.cpr_use_amg_, comm );
+            createEllipticPreconditioner( param_.cpr_use_amg_, comm );
 
             if( param_.cpr_ilu_n_ == 0 ) {
                 pre_ = createILU0Ptr<M,X>( A_, param_.cpr_relax_, comm );
@@ -537,7 +537,7 @@ createEllipticPreconditionerPointer(const M& Ae, double relax,
         //! \brief The information about the parallelization
         const P& comm_;
      protected:
-        void createPreconditioner( const bool amg, const P& comm )
+        void createEllipticPreconditioner( const bool amg, const P& comm )
         {
             if( amg )
             {

--- a/opm/autodiff/CPRPreconditioner.hpp
+++ b/opm/autodiff/CPRPreconditioner.hpp
@@ -371,28 +371,31 @@ createEllipticPreconditionerPointer(const M& Ae, double relax,
                                     parallel run
         */
         CPRPreconditioner (const CPRParameter& param, const M& A, const M& Ae,
-                           const ParallelInformation& comm=ParallelInformation())
+                           const ParallelInformation& comm=ParallelInformation(),
+                           const ParallelInformation& commAe=ParallelInformation())
             : param_( param ),
               A_(A),
               Ae_(Ae),
               de_( Ae_.N() ),
               ve_( Ae_.M() ),
               dmodified_( A_.N() ),
-              opAe_(CPRSelector<M,X,Y,P>::makeOperator(Ae_, comm)),
+              opAe_(CPRSelector<M,X,Y,P>::makeOperator(Ae_, commAe)),
               precond_(), // ilu0 preconditioner for elliptic system
               amg_(),     // amg  preconditioner for elliptic system
               pre_(), // copy A will be made be the preconditioner
               vilu_( A_.N() ),
-              comm_(comm)
+              comm_(comm),
+              commAe_(commAe)
         {
             // create appropriate preconditioner for elliptic system
-            createEllipticPreconditioner( param_.cpr_use_amg_, comm );
+            createEllipticPreconditioner( param_.cpr_use_amg_, commAe_ );
 
+            // create the preconditioner for the whole system.
             if( param_.cpr_ilu_n_ == 0 ) {
-                pre_ = createILU0Ptr<M,X>( A_, param_.cpr_relax_, comm );
+                pre_ = createILU0Ptr<M,X>( A_, param_.cpr_relax_, comm_ );
             }
             else {
-                pre_ = createILUnPtr<M,X>( A_, param_.cpr_ilu_n_, param_.cpr_relax_, comm );
+                pre_ = createILUnPtr<M,X>( A_, param_.cpr_ilu_n_, param_.cpr_relax_, comm_ );
             }
         }
 
@@ -430,6 +433,8 @@ createEllipticPreconditionerPointer(const M& Ae, double relax,
             // dmodified = d - A * vfull
             dmodified_ = d;
             A_.mmv(v, dmodified_);
+            // A is not parallel, do communication manually.
+            comm_.copyOwnerToAll(dmodified_, dmodified_);
 
             // Apply Preconditioner for whole system (relax will be applied already)
             pre_->apply( vilu_, dmodified_);
@@ -470,7 +475,7 @@ createEllipticPreconditionerPointer(const M& Ae, double relax,
                 ScalarProductChooser;
             // the scalar product.
             std::unique_ptr<typename ScalarProductChooser::ScalarProduct>
-                sp(ScalarProductChooser::construct(comm_));
+                sp(ScalarProductChooser::construct(commAe_));
 
             if( amg_ )
             {
@@ -534,8 +539,11 @@ createEllipticPreconditionerPointer(const M& Ae, double relax,
         //! \brief temporary variables for ILU solve
         Y vilu_;
 
-        //! \brief The information about the parallelization
+        //! \brief The information about the parallelization of the whole system.
         const P& comm_;
+        //! \brief The information about the parallelization of the elliptic part
+        //! of the system
+        const P& commAe_;
      protected:
         void createEllipticPreconditioner( const bool amg, const P& comm )
         {

--- a/opm/autodiff/CPRPreconditioner.hpp
+++ b/opm/autodiff/CPRPreconditioner.hpp
@@ -3,6 +3,7 @@
   Copyright 2014 IRIS AS.
   Copyright 2015 Dr. Blatt - HPC-Simulation-Software & Services
   Copyright 2015 NTNU
+  Copyright 2015 Statoil AS
 
   This file is part of the Open Porous Media project (OPM).
 

--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -389,7 +389,9 @@ namespace Opm {
         ///                   maximum of tempV for the phase i.
         /// \param[out] B_avg An array of size MaxNumPhases where entry i contains the average
         ///                   of B for the phase i.
+        /// \param[out] maxNormWell The maximum of the well equations for each phase.
         /// \param[in]  nc    The number of cells of the local grid.
+        /// \param[in]  nw    The number of wells on the local grid.
         /// \return The total pore volume over all cells.
         double
         convergenceReduction(const Eigen::Array<double, Eigen::Dynamic, MaxNumPhases>& B,
@@ -398,7 +400,9 @@ namespace Opm {
                              std::array<double,MaxNumPhases>& R_sum,
                              std::array<double,MaxNumPhases>& maxCoeff,
                              std::array<double,MaxNumPhases>& B_avg,
-                             int nc) const;
+                             std::vector<double>& maxNormWell,
+                             int nc,
+                             int nw) const;
 
         void detectNewtonOscillations(const std::vector<std::vector<double>>& residual_history,
                                       const int it, const double relaxRelTol,

--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -1,5 +1,8 @@
 /*
   Copyright 2013 SINTEF ICT, Applied Mathematics.
+  Copyright 2014, 2015 Dr. Markus Blatt - HPC-Simulation-Software & Services
+  Copyright 2014, 2015 Statoil AS
+  Copyright 2015 NTNU
 
   This file is part of the Open Porous Media project (OPM).
 

--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -1,6 +1,7 @@
 /*
   Copyright 2013 SINTEF ICT, Applied Mathematics.
-  Copyright 2015 Dr. Blatt - HPC-Simulation-Software & Services
+  Copyright 2014, 2015 Dr. Blatt - HPC-Simulation-Software & Services
+  Copyright 2014, 2015 Statoil AS
   Copyright 2015 NTNU
   Copyright 2015 IRIS AS
 

--- a/opm/autodiff/NewtonIterationBlackoilCPR.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilCPR.cpp
@@ -2,6 +2,7 @@
   Copyright 2014 SINTEF ICT, Applied Mathematics.
   Copyright 2015 Dr. Blatt - HPC-Simulation-Software & Services
   Copyright 2015 NTNU
+  Copyright 2015 Statoil AS
 
   This file is part of the Open Porous Media project (OPM).
 

--- a/opm/autodiff/NewtonIterationBlackoilCPR.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilCPR.cpp
@@ -188,11 +188,14 @@ namespace Opm
             const ParallelISTLInformation& info =
                 boost::any_cast<const ParallelISTLInformation&>( parallelInformation_);
             Comm istlComm(info.communicator());
-            info.copyValuesTo(istlComm.indexSet(), istlComm.remoteIndices());
+            Comm istlAeComm(info.communicator());
+            info.copyValuesTo(istlAeComm.indexSet(), istlAeComm.remoteIndices());
+            info.copyValuesTo(istlComm.indexSet(), istlComm.remoteIndices(),
+                              istlAe.N(), istlA.N()/istlAe.N());
             // Construct operator, scalar product and vectors needed.
             typedef Dune::OverlappingSchwarzOperator<Mat,Vector,Vector,Comm> Operator;
             Operator opA(istlA, istlComm);
-            constructPreconditionerAndSolve<Dune::SolverCategory::overlapping>(opA, istlAe, x, istlb, istlComm, result);
+            constructPreconditionerAndSolve<Dune::SolverCategory::overlapping>(opA, istlAe, x, istlb, istlComm, istlAeComm, result);
         }
         else
 #endif
@@ -201,7 +204,7 @@ namespace Opm
             typedef Dune::MatrixAdapter<Mat,Vector,Vector> Operator;
             Operator opA(istlA);
             Dune::Amg::SequentialInformation info;
-            constructPreconditionerAndSolve(opA, istlAe, x, istlb, info, result);
+            constructPreconditionerAndSolve(opA, istlAe, x, istlb, info, info, result);
         }
 
         // store number of iterations

--- a/opm/autodiff/NewtonIterationBlackoilCPR.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilCPR.hpp
@@ -85,6 +85,7 @@ namespace Opm
         void constructPreconditionerAndSolve(O& opA, DuneMatrix& istlAe,
                                              Vector& x, Vector& istlb,
                                              const P& parallelInformation,
+                                             const P& parallelInformationAe,
                                              Dune::InverseOperatorResult& result) const
         {
             typedef Dune::ScalarProductChooser<Vector,P,category> ScalarProductChooser;
@@ -94,7 +95,8 @@ namespace Opm
             // typedef Dune::SeqILU0<Mat,Vector,Vector> Preconditioner;
            typedef Opm::CPRPreconditioner<Mat,Vector,Vector,P> Preconditioner;
             parallelInformation.copyOwnerToAll(istlb, istlb);
-            Preconditioner precond(cpr_param_, opA.getmat(), istlAe, parallelInformation);
+            Preconditioner precond(cpr_param_, opA.getmat(), istlAe, parallelInformation,
+                                   parallelInformationAe);
 
             // TODO: Revise when linear solvers interface opm-core is done
             // Construct linear solver.

--- a/opm/autodiff/NewtonIterationBlackoilCPR.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilCPR.hpp
@@ -1,6 +1,9 @@
 /*
   Copyright 2014 SINTEF ICT, Applied Mathematics.
   Copyright 2015 IRIS AS
+  Copyright 2015 Dr. Blatt - HPC-Simulation-Software & Services
+  Copyright 2015 NTNU
+  Copyright 2015 Statoil AS
 
   This file is part of the Open Porous Media project (OPM).
 

--- a/opm/autodiff/RedistributeDataHandles.hpp
+++ b/opm/autodiff/RedistributeDataHandles.hpp
@@ -1,6 +1,7 @@
 /*
   Copyright 2015 Dr. Blatt - HPC-Simulation-Software & Services.
   Coypright 2015 NTNU
+  Copyright 2015 Statoil AS
 
   This file is part of the Open Porous Media project (OPM).
 

--- a/opm/autodiff/RedistributeDataHandles.hpp
+++ b/opm/autodiff/RedistributeDataHandles.hpp
@@ -71,7 +71,7 @@ public:
         }
     }
     template<class B, class T>
-    void scatter(B& buffer, const T& e, std::size_t size)
+    void scatter(B& buffer, const T& e, std::size_t /* size */)
     {
         assert( T::codimension == 0);
         double val;

--- a/opm/autodiff/SimulatorFullyImplicitBlackoil_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoil_impl.hpp
@@ -207,7 +207,7 @@ namespace Opm
                     boost::any_cast<const ParallelISTLInformation&>(solver_.parallelInformation());
                 // Only rank 0 does print to std::cout
                 terminal_output_= (info.communicator().rank()==0);
-                is_parallel_run_ = info.communicator().size();
+                is_parallel_run_ = ( info.communicator().size() > 1 );
             }
         }
 #endif

--- a/opm/autodiff/SimulatorFullyImplicitBlackoil_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoil_impl.hpp
@@ -206,7 +206,7 @@ namespace Opm
                 const ParallelISTLInformation& info =
                     boost::any_cast<const ParallelISTLInformation&>(solver_.parallelInformation());
                 // Only rank 0 does print to std::cout
-                terminal_output_= (info.communicator().rank()==0);
+                terminal_output_ = ( info.communicator().rank() == 0 );
                 is_parallel_run_ = ( info.communicator().size() > 1 );
             }
         }

--- a/opm/autodiff/SimulatorFullyImplicitBlackoil_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoil_impl.hpp
@@ -120,6 +120,8 @@ namespace Opm
         RateConverterType rateConverter_;
         // Threshold pressures.
         std::vector<double> threshold_pressures_by_face_;
+        // Whether this a parallel simulation or not
+        bool is_parallel_run_;
 
         void
         computeRESV(const std::size_t               step,
@@ -205,6 +207,7 @@ namespace Opm
                     boost::any_cast<const ParallelISTLInformation&>(solver_.parallelInformation());
                 // Only rank 0 does print to std::cout
                 terminal_output_= (info.communicator().rank()==0);
+                is_parallel_run_ = info.communicator().size();
             }
         }
 #endif
@@ -269,7 +272,8 @@ namespace Opm
                                        Opm::UgGridHelpers::dimensions(grid_),
                                        Opm::UgGridHelpers::cell2Faces(grid_),
                                        Opm::UgGridHelpers::beginFaceCentroids(grid_),
-                                       props_.permeability());
+                                       props_.permeability(),
+                                       is_parallel_run_);
             const Wells* wells = wells_manager.c_wells();
             WellStateFullyImplicitBlackoil well_state;
             well_state.init(wells, state, prev_well_state);


### PR DESCRIPTION
This PR fixes a bunch of problems during parallel runs. Among them
- Correctly compute the infinity norm in parallel.
- Setup the parallel communication information for the whole system and use where necessary, i.e.
   the ILU preconditioner and for matrix vector products of the whole system.
- Port @totto82 changes in PR #375  to the parallel use case.

Note: Currently this is only tested with SPE1 and the equilibrium case (i.e. SPE1 without wells) and constant time stepping. For these cases it seems to produce reasonable results. The more advanced time stepping schemes are still broken as we need to modify OPM/opm-core for it. I will do this in the following days.

This PR require OPM/opm-core#803 to be merged first.