### PR TITLE
Activates the parallelism in the adaptive time stepping schemes.

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoil_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoil_impl.hpp
@@ -244,7 +244,7 @@ namespace Opm
         std::unique_ptr< AdaptiveTimeStepping > adaptiveTimeStepping;
         if( param_.getDefault("timestep.adaptive", true ) )
         {
-            adaptiveTimeStepping.reset( new AdaptiveTimeStepping( param_ ) );
+            adaptiveTimeStepping.reset( new AdaptiveTimeStepping( param_, solver_.parallelInformation() ) );
         }
 
         // init output writer


### PR DESCRIPTION
It does this simply by passing the information about the parallelization to the adaptive time stepper.

This PR is based upon OPM/opm-core#805 which needs to be merged before this one.