### PR TITLE
Create solver and model parameters only once.

### DIFF
--- a/opm/autodiff/SimulatorBase.hpp
+++ b/opm/autodiff/SimulatorBase.hpp
@@ -163,8 +163,13 @@ namespace Opm
         typedef RateConverter::
         SurfaceToReservoirVoidage< BlackoilPropsAdInterface,
                                    std::vector<int> > RateConverterType;
+        typedef typename Traits::Model Model;
+        typedef typename Model::ModelParameters ModelParameters;
+        typedef typename Solver::SolverParameters SolverParameters;
 
         const parameter::ParameterGroup param_;
+        ModelParameters model_param_;
+        SolverParameters solver_param_;
 
         // Observed objects.
         const Grid& grid_;

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -38,6 +38,8 @@ namespace Opm
                                                  OutputWriter& output_writer,
                                                  const std::vector<double>& threshold_pressures_by_face)
         : param_(param),
+          model_param_(param),
+          solver_param_(param),
           grid_(grid),
           props_(props),
           rock_comp_props_(rock_comp_props),
@@ -332,12 +334,7 @@ namespace Opm
     auto SimulatorBase<Implementation>::createSolver(const Wells* wells)
         -> std::unique_ptr<Solver>
     {
-        typedef typename Traits::Model Model;
-        typedef typename Model::ModelParameters ModelParams;
-        ModelParams modelParams( param_ );
-        typedef NewtonSolver<Model> Solver;
-
-        auto model = std::unique_ptr<Model>(new Model(modelParams,
+        auto model = std::unique_ptr<Model>(new Model(model_param_,
                                                       grid_,
                                                       props_,
                                                       geo_,
@@ -352,9 +349,7 @@ namespace Opm
             model->setThresholdPressures(threshold_pressures_by_face_);
         }
 
-        typedef typename Solver::SolverParameters SolverParams;
-        SolverParams solverParams( param_ );
-        return std::unique_ptr<Solver>(new Solver(solverParams, std::move(model)));
+        return std::unique_ptr<Solver>(new Solver(solver_param_, std::move(model)));
     }
 
     template <class Implementation>


### PR DESCRIPTION
After the recent refactoring, solver and model parameter objects are created every timestep, creating lots of unneeded output. With this, they will only be created once.