### PR TITLE
OPM-212: Added parameter override of IOConfig Restart write setting

### DIFF
--- a/examples/flow.cpp
+++ b/examples/flow.cpp
@@ -176,6 +176,14 @@ try
     grid.reset(new GridManager(eclipseState->getEclipseGrid(), porv));
     auto &cGrid = *grid->c_grid();
     const PhaseUsage pu = Opm::phaseUsageFromDeck(deck);
+
+    // Possibly override IOConfig setting (from deck) for how often RESTART files should get written to disk (every N report step)
+    if (param.has("output_interval")) {
+        int output_interval = param.get<int>("output_interval");
+        IOConfigPtr ioConfig = eclipseState->getIOConfig();
+        ioConfig->overrideRestartWriteInterval((size_t)output_interval);
+    }
+
     Opm::BlackoilOutputWriter outputWriter(cGrid,
                                            param,
                                            eclipseState,

--- a/examples/flow_cp.cpp
+++ b/examples/flow_cp.cpp
@@ -216,6 +216,13 @@ try
     std::vector<double> porv = eclipseState->getDoubleGridProperty("PORV")->getData();
     grid->processEclipseFormat(deck, false, false, false, porv);
 
+    // Possibly override IOConfig setting (from deck) for how often RESTART files should get written to disk (every N report step)
+    if (param.has("output_interval")) {
+        int output_interval = param.get<int>("output_interval");
+        IOConfigPtr ioConfig = eclipseState->getIOConfig();
+        ioConfig->overrideRestartWriteInterval((size_t)output_interval);
+    }
+
     const PhaseUsage pu = Opm::phaseUsageFromDeck(deck);
     Opm::BlackoilOutputWriter outputWriter(*grid, param, eclipseState, pu );
 


### PR DESCRIPTION
With the new opm-parser `IOConfig` object (retrievable from `EclipseState`), output interval of restart files are now governed from the deck by the keywords RPTSCHED and RPTRST. 

Before this was implemented the output interval (`N`) could be set from command line param. 

This PR reintroduces this functionality, implemented by calling a new "override" method in `IOConfig`. 
Setting `N=0` means no write of restart files at all.

This PR depends on PR OPM/opm-parser#495 being merged first.