### PR TITLE
Solve well equation initially 

### DIFF
--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -294,14 +294,31 @@ namespace Opm {
         std::vector<V>
         variableStateInitials(const ReservoirState& x,
                               const WellState& xw) const;
+        void
+        variableReservoirStateInitials(const ReservoirState& x,
+                                       std::vector<V>& vars0) const;
+        void
+        variableWellStateInitials(const WellState& xw,
+                                  std::vector<V>& vars0) const;
 
         std::vector<int>
         variableStateIndices() const;
+
+        std::vector<int>
+        variableWellsStateIndices() const;
+
+        void
+        addWellContribution2MassBalanceEq(const std::vector<ADB>& cq_s);
 
         SolutionState
         variableStateExtractVars(const ReservoirState& x,
                                  const std::vector<int>& indices,
                                  std::vector<ADB>& vars) const;
+
+        void
+        variableStateExtractWellsVars(const std::vector<int>& indices,
+                                      std::vector<ADB>& vars,
+                                      SolutionState& state) const;
 
         void
         computeAccum(const SolutionState& state,
@@ -321,7 +338,8 @@ namespace Opm {
         void
         addWellEq(const SolutionState& state,
                   WellState& xw,
-                  V& aliveWells);
+                  V& aliveWells,
+                  std::vector<ADB>& cq_s);
 
         void
         extraAddWellEq(const SolutionState& state,
@@ -332,6 +350,9 @@ namespace Opm {
                        const std::vector<int>& well_cells);
 
         void updateWellControls(WellState& xw) const;
+
+        void updateWellState(const V& dx,
+                         WellState& well_state);
 
         std::vector<ADB>
         computePressures(const ADB& po,

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -336,8 +336,16 @@ namespace Opm {
                          const V& aliveWells);
 
         void
+        solveWellEq(const std::vector<ADB>& mob_perfcells,
+                    const std::vector<ADB>& b_perfcells,
+                    SolutionState& state,
+                    WellState& well_state);
+
+        void
         addWellEq(const SolutionState& state,
                   WellState& xw,
+                  const std::vector<ADB>& mob_perfcells,
+                  const std::vector<ADB>& b_perfcells,
                   V& aliveWells,
                   std::vector<ADB>& cq_s);
 
@@ -353,6 +361,8 @@ namespace Opm {
 
         void updateWellState(const V& dx,
                          WellState& well_state);
+
+        bool getWellConvergence(const int iteration);
 
         std::vector<ADB>
         computePressures(const ADB& po,

--- a/opm/autodiff/BlackoilModelParameters.cpp
+++ b/opm/autodiff/BlackoilModelParameters.cpp
@@ -46,6 +46,7 @@ namespace Opm
         tolerance_mb_    = param.getDefault("tolerance_mb", tolerance_mb_);
         tolerance_cnv_   = param.getDefault("tolerance_cnv", tolerance_cnv_);
         tolerance_wells_ = param.getDefault("tolerance_wells", tolerance_wells_ );
+        solve_wellEq_initially_ = param.getDefault("solve_wellEq_initially",solve_wellEq_initially_);
     }
 
 
@@ -60,7 +61,8 @@ namespace Opm
         max_residual_allowed_ = 1e7;
         tolerance_mb_    = 1.0e-5;
         tolerance_cnv_   = 1.0e-2;
-        tolerance_wells_ = 5.0e-1;
+        tolerance_wells_ = 1.0e-3;
+        solve_wellEq_initially_ = false;
     }
 
 

--- a/opm/autodiff/BlackoilModelParameters.hpp
+++ b/opm/autodiff/BlackoilModelParameters.hpp
@@ -43,6 +43,9 @@ namespace Opm
         /// Well convergence tolerance.
         double tolerance_wells_;
 
+        /// Solve well equation initially
+        bool solve_wellEq_initially_;
+
         /// Construct from user parameters or defaults.
         explicit BlackoilModelParameters( const parameter::ParameterGroup& param );
 


### PR DESCRIPTION
This PR provides a option for solving the well equations seperatly before the whole system (well and reservoir) is solved coupled. It is currently default to not beeing used. For norne, solving the well equations seperatly as a pre-processing step gives approximatly 5% reduction in run time.
For SPE9 the reduction is insignificant. 

Note that this PR changes the well tolerance in the newton solver and makes it independed on time-step size. The 5% reduction is only on the well equation part. The change of well tolerance gives additional reduction to the run time without changing the solution significantly.  