### PR TITLE
Add more parameters to addWellContributionToMassBalanceEq.

### DIFF
--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -307,9 +307,6 @@ namespace Opm {
         std::vector<int>
         variableWellStateIndices() const;
 
-        void
-        addWellContributionToMassBalanceEq(const std::vector<ADB>& cq_s);
-
         SolutionState
         variableStateExtractVars(const ReservoirState& x,
                                  const std::vector<int>& indices,
@@ -350,12 +347,9 @@ namespace Opm {
                   std::vector<ADB>& cq_s);
 
         void
-        extraAddWellEq(const SolutionState& state,
-                       const WellState& xw,
-                       const std::vector<ADB>& cq_ps,
-                       const std::vector<ADB>& cmix_s,
-                       const ADB& cqt_is,
-                       const std::vector<int>& well_cells);
+        addWellContributionToMassBalanceEq(const SolutionState& state,
+                                           const WellState& xw,
+                                           const std::vector<ADB>& cq_s);
 
         void updateWellControls(WellState& xw) const;
 

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -811,7 +811,7 @@ namespace detail {
         }
 
         asImpl().addWellEq(state, well_state, mob_perfcells, b_perfcells, aliveWells, cq_s);
-        addWellContributionToMassBalanceEq(cq_s);
+        asImpl().addWellContributionToMassBalanceEq(state, well_state, cq_s);
         addWellControlEq(state, well_state, aliveWells);        
     }
 
@@ -875,7 +875,9 @@ namespace detail {
 
     template <class Grid, class Implementation>
     void
-    BlackoilModelBase<Grid, Implementation>::addWellContributionToMassBalanceEq(const std::vector<ADB>& cq_s)
+    BlackoilModelBase<Grid, Implementation>::addWellContributionToMassBalanceEq(const SolutionState&,
+                                                                                const WellState&,
+                                                                                const std::vector<ADB>& cq_s)
     {
         // Add well contributions to mass balance equations
         const int nc = Opm::AutoDiffGrid::numCells(grid_);
@@ -1038,23 +1040,6 @@ namespace detail {
         xw.perfPhaseRates() = cq_d;
 
         residual_.well_flux_eq = qs;
-
-        asImpl().extraAddWellEq(state, xw, cq_ps, cmix_s, cqt_is, well_cells);
-    }
-
-
-
-
-
-    template <class Grid, class Implementation>
-    void BlackoilModelBase<Grid, Implementation>::extraAddWellEq(const SolutionState& /* state */,
-                                                                 const WellState& /* xw */,
-                                                                 const std::vector<ADB>& /* cq_ps */,
-                                                                 const std::vector<ADB>& /* cmix_s */,
-                                                                 const ADB& /* cqt_is */,
-                                                                 const std::vector<int>& /* well_cells */)
-    {
-        // Does nothing in this model.
     }
 
 


### PR DESCRIPTION
Also:
 - call using asImpl(),
 - remove extraAddWellEq().

This change is done to facilitate using the new solve-well-equations feature recently merged with downstream variants such as flow_polymer.