### PR TITLE
Refactor addWellEq().

### DIFF
--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -328,28 +328,36 @@ namespace Opm {
         assembleMassBalanceEq(const SolutionState& state);
 
         void
-        addWellControlEq(const SolutionState& state,
-                         const WellState& xw,
-                         const V& aliveWells);
-
-        void
         solveWellEq(const std::vector<ADB>& mob_perfcells,
                     const std::vector<ADB>& b_perfcells,
                     SolutionState& state,
                     WellState& well_state);
 
         void
-        addWellEq(const SolutionState& state,
-                  WellState& xw,
-                  const std::vector<ADB>& mob_perfcells,
-                  const std::vector<ADB>& b_perfcells,
-                  V& aliveWells,
-                  std::vector<ADB>& cq_s);
+        computeWellFlux(const SolutionState& state,
+                        const std::vector<ADB>& mob_perfcells,
+                        const std::vector<ADB>& b_perfcells,
+                        V& aliveWells,
+                        std::vector<ADB>& cq_s);
 
         void
-        addWellContributionToMassBalanceEq(const SolutionState& state,
-                                           const WellState& xw,
-                                           const std::vector<ADB>& cq_s);
+        updatePerfPhaseRatesAndPressures(const std::vector<ADB>& cq_s,
+                                         const SolutionState& state,
+                                         WellState& xw);
+
+        void
+        addWellFluxEq(const std::vector<ADB>& cq_s,
+                      const SolutionState& state);
+
+        void
+        addWellContributionToMassBalanceEq(const std::vector<ADB>& cq_s,
+                                           const SolutionState& state,
+                                           const WellState& xw);
+
+        void
+        addWellControlEq(const SolutionState& state,
+                         const WellState& xw,
+                         const V& aliveWells);
 
         void updateWellControls(WellState& xw) const;
 


### PR DESCRIPTION
Note: do not merge until a companion PR in opm-polymer is ready.

The method has been split in three parts:
```
        computeWellFlux(const SolutionState& state,
                        const std::vector<ADB>& mob_perfcells,
                        const std::vector<ADB>& b_perfcells,
                        V& aliveWells,
                        std::vector<ADB>& cq_s);

        void
        updatePerfPhaseRatesAndPressures(const std::vector<ADB>& cq_s,
                                         const SolutionState& state,
                                         WellState& xw);

        void
        addWellFluxEq(const std::vector<ADB>& cq_s,
                      const SolutionState& state);

```
This reduces the function length, although most of the content of addWellEq() now is in computeWellFlux(), so that function is still quite long. It also allows us to use smaller sets of function arguments, which makes methods easier to understand.

Finally, it makes it easier to create derived models with custom behaviour.