### PR TITLE
Performance enhancements and simplifications for BlackoilModelBase

### DIFF
--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -396,8 +396,7 @@ namespace Opm {
                        const ADB&              temp ,
                        const ADB&              rs   ,
                        const ADB&              rv   ,
-                       const std::vector<PhasePresence>& cond,
-                       const std::vector<int>& cells) const;
+                       const std::vector<PhasePresence>& cond) const;
 
         ADB
         fluidReciprocFVF(const int               phase,
@@ -405,17 +404,13 @@ namespace Opm {
                          const ADB&              temp ,
                          const ADB&              rs   ,
                          const ADB&              rv   ,
-                         const std::vector<PhasePresence>& cond,
-                         const std::vector<int>& cells) const;
+                         const std::vector<PhasePresence>& cond) const;
 
         ADB
-        fluidDensity(const int               phase,
-                     const ADB&              p    ,
-                     const ADB&              temp ,
-                     const ADB&              rs   ,
-                     const ADB&              rv   ,
-                     const std::vector<PhasePresence>& cond,
-                     const std::vector<int>& cells) const;
+        fluidDensity(const int  phase,
+                     const ADB& b,
+                     const ADB& rs,
+                     const ADB& rv) const;
 
         V
         fluidRsSat(const V&                p,

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1821,8 +1821,7 @@ namespace detail {
         // Compute head differentials. Gravity potential is done using the face average as in eclipse and MRST.
         const ADB rho = fluidDensity(canonicalPhaseIdx, rq_[actph].b, state.rs, state.rv);
         const ADB rhoavg = ops_.caver * rho;
-        const V gdz = geo_.gravity()[2] * (ops_.ngrad * geo_.z().matrix());
-        rq_[ actph ].dh = ops_.ngrad * phasePressure - rhoavg * gdz;
+        rq_[ actph ].dh = ops_.ngrad * phasePressure - geo_.gravity()[2] * (rhoavg * (ops_.ngrad * geo_.z().matrix()));
         if (use_threshold_pressure_) {
             applyThresholdPressures(rq_[ actph ].dh);
         }
@@ -1832,7 +1831,7 @@ namespace detail {
         const ADB& mob = rq_[ actph ].mob;
         const ADB& dh  = rq_[ actph ].dh;
         UpwindSelector<double> upwind(grid_, ops_, dh.value());
-        rq_[ actph ].mflux = (transi * upwind.select(b * mob)) * dh;
+        rq_[ actph ].mflux = upwind.select(b * mob) * (transi * dh);
     }
 
 

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1821,7 +1821,8 @@ namespace detail {
         // Compute head differentials. Gravity potential is done using the face average as in eclipse and MRST.
         const ADB rho = fluidDensity(canonicalPhaseIdx, phasePressure, state.temperature, state.rs, state.rv, cond, cells_);
         const ADB rhoavg = ops_.caver * rho;
-        rq_[ actph ].dh = ops_.ngrad * phasePressure - geo_.gravity()[2] * (rhoavg * (ops_.ngrad * geo_.z().matrix()));
+        const V gdz = geo_.gravity()[2] * (ops_.ngrad * geo_.z().matrix());
+        rq_[ actph ].dh = ops_.ngrad * phasePressure - rhoavg * gdz;
         if (use_threshold_pressure_) {
             applyThresholdPressures(rq_[ actph ].dh);
         }
@@ -1831,7 +1832,7 @@ namespace detail {
         const ADB& mob = rq_[ actph ].mob;
         const ADB& dh  = rq_[ actph ].dh;
         UpwindSelector<double> upwind(grid_, ops_, dh.value());
-        rq_[ actph ].mflux = upwind.select(b * mob) * (transi * dh);
+        rq_[ actph ].mflux = (transi * upwind.select(b * mob)) * dh;
     }
 
 


### PR DESCRIPTION
Eliminating a redundant recalculation and changing the order of some operations yields a small performance benefit (on the order of perhaps 3% on SPE9).

Some of the private fluid methods of the class have got simplified interfaces, especially fluidDensity() which now receives the b factor as an argument instead of recalculating it.

Tested on SPE9 and a few steps of Norne (not a full run).