### PR TITLE
Dense AD experiments

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -50,6 +50,7 @@ list (APPEND MAIN_SOURCE_FILES
 # originally generated with the command:
 # find tests -name '*.cpp' -a ! -wholename '*/not-unit/*' -printf '\t%p\n' | sort
 list (APPEND TEST_SOURCE_FILES
+	tests/test_autodiffdense.cpp
 	tests/test_autodiffhelpers.cpp
 	tests/test_block.cpp
 	tests/test_boprops_ad.cpp
@@ -102,6 +103,7 @@ list (APPEND PROGRAM_SOURCE_FILES
 # find opm -name '*.h*' -a ! -name '*-pch.hpp' -printf '\t%p\n' | sort
 list (APPEND PUBLIC_HEADER_FILES
 	opm/autodiff/AutoDiffBlock.hpp
+	opm/autodiff/AutoDiffDense.hpp
 	opm/autodiff/AutoDiffHelpers.hpp
 	opm/autodiff/AutoDiff.hpp
 	opm/autodiff/BackupRestore.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -51,6 +51,7 @@ list (APPEND MAIN_SOURCE_FILES
 # find tests -name '*.cpp' -a ! -wholename '*/not-unit/*' -printf '\t%p\n' | sort
 list (APPEND TEST_SOURCE_FILES
 	tests/test_autodiffdense.cpp
+	tests/test_autodiffdenseblock.cpp
 	tests/test_autodiffhelpers.cpp
 	tests/test_block.cpp
 	tests/test_boprops_ad.cpp
@@ -104,6 +105,7 @@ list (APPEND PROGRAM_SOURCE_FILES
 list (APPEND PUBLIC_HEADER_FILES
 	opm/autodiff/AutoDiffBlock.hpp
 	opm/autodiff/AutoDiffDense.hpp
+	opm/autodiff/AutoDiffDenseBlock.hpp
 	opm/autodiff/AutoDiffHelpers.hpp
 	opm/autodiff/AutoDiff.hpp
 	opm/autodiff/BackupRestore.hpp

--- a/opm/autodiff/AutoDiff.hpp
+++ b/opm/autodiff/AutoDiff.hpp
@@ -256,7 +256,7 @@ namespace Opm
                const AutoDiff<Scalar>& rhs)
     {
         Scalar a =  Scalar(lhs) / rhs.val();
-        Scalar b = -Scalar(lhs) / (rhs.val() * rhs.val());
+        Scalar b = (-Scalar(lhs) / (rhs.val() * rhs.val())) * rhs.der();
 
         return AutoDiff<Scalar>::function(a, b);
     }

--- a/opm/autodiff/AutoDiffDense.hpp
+++ b/opm/autodiff/AutoDiffDense.hpp
@@ -1,0 +1,293 @@
+/*
+  Copyright 2015 SINTEF ICT, Applied Mathematics.
+  Copyright 2015 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_AUTODIFFDENSE_HEADER_INCLUDED
+#define OPM_AUTODIFFDENSE_HEADER_INCLUDED
+
+
+#include <opm/core/utility/platform_dependent/disable_warnings.h>
+
+#include <Eigen/Eigen>
+
+#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+
+
+namespace Opm
+{
+
+    /// A simple class for forward-mode automatic differentiation.
+    ///
+    /// The class represents a single value and a small, dense vector
+    /// of derivatives.  Only basic arithmetic operators are
+    /// implemented for it.
+    template <typename Scalar, int NumDerivs>
+    class AutoDiffDense
+    {
+    public:
+        typedef Scalar Value;
+        typedef Eigen::Array<Scalar, NumDerivs, 1> Derivative;
+
+        /// Create an AutoDiffDense object representing a constant, that
+        /// is, its derivative is zero.
+        static AutoDiffDense
+        constant(const Scalar x)
+        {
+            return function(x, Derivative::Zero());
+        }
+
+        /// Create an AutoDiffDense object representing a primary variable,
+        /// that is, its derivative is one.
+        static AutoDiffDense
+        variable(const int index, const Scalar x)
+        {
+            Derivative dx = Derivative::Zero();
+            dx(index) = 1.0;
+            return function(x, dx);
+        }
+
+        /// Create an AutoDiffDense object representing a function value
+        /// and its derivative.
+        static AutoDiffDense
+        function(const Scalar x, const Derivative& dx)
+        {
+            return AutoDiffDense(x, dx);
+        }
+
+        void
+        operator +=(const Scalar& rhs)
+        {
+            val_ += rhs;
+        }
+
+        void
+        operator +=(const AutoDiffDense& rhs)
+        {
+            val_ += rhs.val_;
+            der_ += rhs.der_;
+        }
+
+        void
+        operator -=(const Scalar& rhs)
+        {
+            val_ -= rhs;
+        }
+
+        void
+        operator -=(const AutoDiffDense& rhs)
+        {
+            val_ -= rhs.val_;
+            der_ -= rhs.der_;
+        }
+
+        void
+        operator *=(const Scalar& rhs)
+        {
+            val_ *= rhs;
+            der_ *= rhs;
+        }
+
+        void
+        operator *=(const AutoDiffDense& rhs)
+        {
+            der_   = der_*rhs.val_ + val_*rhs.der_;
+            val_  *= rhs.val_;
+        }
+
+        void
+        operator /=(const Scalar& rhs)
+        {
+            val_ /= rhs;
+            der_ /= rhs;
+        }
+
+        void
+        operator /=(const AutoDiffDense& rhs)
+        {
+            der_   = (der_*rhs.val_ - val_*rhs.der_) / (rhs.val_ * rhs.val_);
+            val_  /= rhs.val_;
+        }
+
+        template <class Ostream>
+        Ostream&
+        print(Ostream& os) const
+        {
+            os << "(x,dx) = (" << val_ << ',' << der_ << ")";
+
+            return os;
+        }
+
+        const Scalar val() const { return val_; }
+        const Derivative& der() const { return der_; }
+
+    private:
+        AutoDiffDense(const Scalar x, const Derivative& dx)
+            : val_(x), der_(dx)
+        {}
+
+        Scalar val_;
+        Derivative der_;
+    };
+
+
+
+
+
+
+    template <class Ostream, typename Scalar, int NumDerivs>
+    Ostream&
+    operator<<(Ostream& os, const AutoDiffDense<Scalar, NumDerivs>& fw)
+    {
+        return fw.print(os);
+    }
+
+    template <typename Scalar, int NumDerivs>
+    AutoDiffDense<Scalar, NumDerivs>
+    operator +(const AutoDiffDense<Scalar, NumDerivs>& lhs,
+               const AutoDiffDense<Scalar, NumDerivs>& rhs)
+    {
+        AutoDiffDense<Scalar, NumDerivs> ret = lhs;
+        ret += rhs;
+
+        return ret;
+    }
+
+    template <typename Scalar, int NumDerivs, typename T>
+    AutoDiffDense<Scalar, NumDerivs>
+    operator +(const T                lhs,
+               const AutoDiffDense<Scalar, NumDerivs>& rhs)
+    {
+        AutoDiffDense<Scalar, NumDerivs> ret = rhs;
+        ret += Scalar(lhs);
+
+        return ret;
+    }
+
+    template <typename Scalar, int NumDerivs, typename T>
+    AutoDiffDense<Scalar, NumDerivs>
+    operator +(const AutoDiffDense<Scalar, NumDerivs>& lhs,
+               const T                rhs)
+    {
+        AutoDiffDense<Scalar, NumDerivs> ret = lhs;
+        ret += Scalar(rhs);
+
+        return ret;
+    }
+
+    template <typename Scalar, int NumDerivs>
+    AutoDiffDense<Scalar, NumDerivs>
+    operator -(const AutoDiffDense<Scalar, NumDerivs>& lhs,
+               const AutoDiffDense<Scalar, NumDerivs>& rhs)
+    {
+        AutoDiffDense<Scalar, NumDerivs> ret = lhs;
+        ret -= rhs;
+
+        return ret;
+    }
+
+    template <typename Scalar, int NumDerivs, typename T>
+    AutoDiffDense<Scalar, NumDerivs>
+    operator -(const T                lhs,
+               const AutoDiffDense<Scalar, NumDerivs>& rhs)
+    {
+        return AutoDiffDense<Scalar, NumDerivs>::function(Scalar(lhs) - rhs.val(), -rhs.der());
+    }
+
+    template <typename Scalar, int NumDerivs, typename T>
+    AutoDiffDense<Scalar, NumDerivs>
+    operator -(const AutoDiffDense<Scalar, NumDerivs>& lhs,
+               const T                rhs)
+    {
+        AutoDiffDense<Scalar, NumDerivs> ret = lhs;
+        ret -= Scalar(rhs);
+
+        return ret;
+    }
+
+    template <typename Scalar, int NumDerivs>
+    AutoDiffDense<Scalar, NumDerivs>
+    operator *(const AutoDiffDense<Scalar, NumDerivs>& lhs,
+               const AutoDiffDense<Scalar, NumDerivs>& rhs)
+    {
+        AutoDiffDense<Scalar, NumDerivs> ret = lhs;
+        ret *= rhs;
+
+        return ret;
+    }
+
+    template <typename Scalar, int NumDerivs, typename T>
+    AutoDiffDense<Scalar, NumDerivs>
+    operator *(const T                lhs,
+               const AutoDiffDense<Scalar, NumDerivs>& rhs)
+    {
+        AutoDiffDense<Scalar, NumDerivs> ret = rhs;
+        ret *= Scalar(lhs);
+
+        return ret;
+    }
+
+    template <typename Scalar, int NumDerivs, typename T>
+    AutoDiffDense<Scalar, NumDerivs>
+    operator *(const AutoDiffDense<Scalar, NumDerivs>& lhs,
+               const T                rhs)
+    {
+        AutoDiffDense<Scalar, NumDerivs> ret = lhs;
+        ret *= Scalar(rhs);
+
+        return ret;
+    }
+
+    template <typename Scalar, int NumDerivs>
+    AutoDiffDense<Scalar, NumDerivs>
+    operator /(const AutoDiffDense<Scalar, NumDerivs>& lhs,
+               const AutoDiffDense<Scalar, NumDerivs>& rhs)
+    {
+        AutoDiffDense<Scalar, NumDerivs> ret = lhs;
+        ret /= rhs;
+
+        return ret;
+    }
+
+    template <typename Scalar, int NumDerivs, typename T>
+    AutoDiffDense<Scalar, NumDerivs>
+    operator /(const T                lhs,
+               const AutoDiffDense<Scalar, NumDerivs>& rhs)
+    {
+        Scalar a =  Scalar(lhs) / rhs.val();
+        typedef typename AutoDiffDense<Scalar, NumDerivs>::Derivative Derivative;
+        Derivative b = (-Scalar(lhs) / (rhs.val() * rhs.val())) * rhs.der();
+
+        return AutoDiffDense<Scalar, NumDerivs>::function(a, b);
+    }
+
+    template <typename Scalar, int NumDerivs, typename T>
+    AutoDiffDense<Scalar, NumDerivs>
+    operator /(const AutoDiffDense<Scalar, NumDerivs>& lhs,
+               const T                rhs)
+    {
+        Scalar a = lhs.val() / Scalar(rhs);
+        auto b = lhs.der() / Scalar(rhs);
+
+        return AutoDiffDense<Scalar, NumDerivs>::function(a, b);
+    }
+
+} // namespace Opm
+
+
+#endif // OPM_AUTODIFFDENSE_HEADER_INCLUDED

--- a/opm/autodiff/AutoDiffDenseBlock.hpp
+++ b/opm/autodiff/AutoDiffDenseBlock.hpp
@@ -18,8 +18,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef OPM_AUTODIFFBLOCK_HEADER_INCLUDED
-#define OPM_AUTODIFFBLOCK_HEADER_INCLUDED
+#ifndef OPM_AUTODIFFDENSEBLOCK_HEADER_INCLUDED
+#define OPM_AUTODIFFDENSEBLOCK_HEADER_INCLUDED
 
 #include <opm/core/utility/platform_dependent/disable_warnings.h>
 
@@ -377,4 +377,4 @@ namespace Opm
 
 
 
-#endif // OPM_AUTODIFFBLOCK_HEADER_INCLUDED
+#endif // OPM_AUTODIFFDENSEBLOCK_HEADER_INCLUDED

--- a/opm/autodiff/AutoDiffDenseBlock.hpp
+++ b/opm/autodiff/AutoDiffDenseBlock.hpp
@@ -1,0 +1,380 @@
+/*
+  Copyright 2015 SINTEF ICT, Applied Mathematics.
+  Copyright 2015 Statoil AS.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_AUTODIFFBLOCK_HEADER_INCLUDED
+#define OPM_AUTODIFFBLOCK_HEADER_INCLUDED
+
+#include <opm/core/utility/platform_dependent/disable_warnings.h>
+
+#include <Eigen/Eigen>
+
+#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+
+#include <utility>
+#include <vector>
+#include <cassert>
+#include <iostream>
+
+namespace Opm
+{
+
+    /// A class for forward-mode automatic differentiation with array
+    /// values and a small, dense set of derivatives.
+    ///
+    /// The class contains a (column) array of values and a rectangular
+    /// dense array representing its partial derivatives. Each
+    /// such array has a number of rows equal to the number of rows
+    /// in the value array, and a number of columns equal to the
+    /// number of discrete variables we want to compute the
+    /// derivatives with respect to. Only basic arithmetic operators.
+    ///
+    /// The class is built on the Eigen library, using Eigen array
+    /// types. The overloaded operators are intended to behave in
+    /// a similar way to Eigen arrays, meaning for example that the *
+    /// operator is elementwise multiplication.
+    ///
+    /// There are no public constructors, instead we use the Named
+    /// Constructor pattern. In general, one needs to know which
+    /// variables one wants to compute the derivatives with respect to
+    /// before constructing an AutoDiffDenseBlock.
+    ///
+    /// For example: you want the derivatives with respect to three
+    /// different variables p, r and s, each of which has 20 elements.
+    /// When creating the variables p, r and s in your program you
+    /// have two options:
+    ///     - Use the variable() constructor three times, passing the
+    ///       index (0 for p, 1 for r and 2 for s) and initial values
+    ///       for each variable.
+    ///     - Use the variables() constructor passing only the initial
+    ///       values of each variable. This is usually the simplest
+    ///       option if you have multiple variables. Note that this
+    ///       constructor returns a vector of all three variables, so
+    ///       you need to use index access (operator[]) to get the
+    ///       individual variables (that is p, r and s).
+    ///
+    /// After this, the r variable for example will have a size() of
+    /// 20, its value() will have 20 values equal to the initial
+    /// values passed in during construction, and it derivative() will
+    /// be a 20x3 array with zeros in columns 0 and 2, and ones in
+    /// column 1.
+    template <typename Scalar, int NumDerivs>
+    class AutoDiffDenseBlock
+    {
+    public:
+        /// Underlying type for values.
+        typedef Eigen::Array<Scalar, Eigen::Dynamic, 1> Value;
+        /// Underlying type for derivatives.
+        typedef Eigen::Array<Scalar, Eigen::Dynamic, NumDerivs> Derivative;
+
+        /// Construct an empty AutoDiffDenseBlock.
+        static AutoDiffDenseBlock null()
+        {
+            return AutoDiffDenseBlock(Value(), Derivative());
+        }
+
+        /// Create an AutoDiffDenseBlock representing a constant.
+        /// \param[in] val         values
+        static AutoDiffDenseBlock constant(Value&& val)
+        {
+            return AutoDiffDenseBlock(std::move(val));
+        }
+
+        /// Create an AutoDiffDenseBlock representing a constant.
+        /// \param[in] val         values
+        static AutoDiffDenseBlock constant(const Value& val)
+        {
+            return AutoDiffDenseBlock(val);
+        }
+
+        /// Create an AutoDiffDenseBlock representing a single variable block.
+        /// \param[in] index       index of the variable you are constructing
+        /// \param[in] val         values
+        /// The resulting object will have size() val.size().
+        /// Its derivative() will all be zero, except for column index, which
+        /// will be all ones.
+        static AutoDiffDenseBlock variable(const int index, Value&& val)
+        {
+            Derivative jac = Derivative::Zero(val.rows(), 3);
+            jac.col(index) = Value::Ones(val.rows());
+            return AutoDiffDenseBlock(std::move(val), std::move(jac));
+        }
+
+        /// Create an AutoDiffDenseBlock representing a single variable block.
+        /// \param[in] index       index of the variable you are constructing
+        /// \param[in] val         values
+        /// The resulting object will have size() val.size().
+        /// Its derivative() will all be zero, except for column index, which
+        /// will be all ones.
+        static AutoDiffDenseBlock variable(const int index, const Value& val)
+        {
+            Value val_copy = val;
+            return variable(index, std::move(val_copy));
+        }
+
+        /// Create an AutoDiffDenseBlock by directly specifying values and jacobians.
+        /// This version of function() moves its arguments and is therefore
+        /// quite efficient, but leaves the argument variables empty (but valid).
+        /// \param[in] val         values
+        /// \param[in] jac         derivatives
+        static AutoDiffDenseBlock function(Value&& val, Derivative&& jac)
+        {
+            return AutoDiffDenseBlock(std::move(val), std::move(jac));
+        }
+
+        /// Create an AutoDiffDenseBlock by directly specifying values and jacobians.
+        /// This version of function() copies its arguments and is therefore
+        /// less efficient than the other (moving) overload.
+        /// \param[in] val         values
+        /// \param[in] jac         derivatives
+        static AutoDiffDenseBlock function(const Value& val, const Derivative& jac)
+        {
+            Value val_copy(val);
+            Derivative jac_copy(jac);
+            return AutoDiffDenseBlock(std::move(val_copy), std::move(jac_copy));
+        }
+
+        /// Construct a set of primary variables, each initialized to
+        /// a given vector.
+        static std::vector<AutoDiffDenseBlock> variables(const std::vector<Value>& initial_values)
+        {
+            const int num_vars = initial_values.size();
+            std::vector<AutoDiffDenseBlock> vars;
+            for (int v = 0; v < num_vars; ++v) {
+                vars.emplace_back(variable(v, initial_values[v]));
+            }
+            return vars;
+        }
+
+        /// Elementwise operator +=
+        AutoDiffDenseBlock& operator+=(const AutoDiffDenseBlock& rhs)
+        {
+            val_ += rhs.val_;
+            jac_ += rhs.jac_;
+            return *this;
+        }
+
+        /// Elementwise operator -=
+        AutoDiffDenseBlock& operator-=(const AutoDiffDenseBlock& rhs)
+        {
+            val_ -= rhs.val_;
+            jac_ -= rhs.jac_;
+            return *this;
+        }
+
+        /// Elementwise operator +
+        AutoDiffDenseBlock operator+(const AutoDiffDenseBlock& rhs) const
+        {
+            return function(val_ + rhs.val_, jac_ + rhs.jac_);
+        }
+
+        /// Elementwise operator -
+        AutoDiffDenseBlock operator-(const AutoDiffDenseBlock& rhs) const
+        {
+            return function(val_ - rhs.val_, jac_ - rhs.jac_);
+        }
+
+        /// Elementwise operator *
+        AutoDiffDenseBlock operator*(const AutoDiffDenseBlock& rhs) const
+        {
+            Derivative jac = jac_.colwise() * rhs.val_  +  rhs.jac_.colwise() * val_;
+            return function(val_ * rhs.val_, std::move(jac));
+        }
+
+        /// Elementwise operator /
+        AutoDiffDenseBlock operator/(const AutoDiffDenseBlock& rhs) const
+        {
+            Derivative jac = (jac_.colwise() * rhs.val_ - rhs.jac_.colwise() * val_).colwise() / (rhs.val_*rhs.val_);
+            return function(val_ / rhs.val_, std::move(jac));
+        }
+
+        /// I/O.
+        template <class Ostream>
+        Ostream&
+        print(Ostream& os) const
+        {
+            os << "Value =\n" << val_ << "\n\nJacobian =\n" << jac_ << '\n';
+            return os;
+        }
+
+        /// Efficient swap function.
+        void swap(AutoDiffDenseBlock& other)
+        {
+            val_.swap(other.val_);
+            jac_.swap(other.jac_);
+        }
+
+        /// Number of elements
+        int size() const
+        {
+            return val_.size();
+        }
+
+        /// Function value.
+        const Value& value() const
+        {
+            return val_;
+        }
+
+        /// Function derivatives.
+        const Derivative& derivative() const
+        {
+            return jac_;
+        }
+
+    private:
+        AutoDiffDenseBlock(const Value& val)
+        : val_(val), jac_(Derivative::Zero(val.rows(), NumDerivs))
+        {
+        }
+
+        AutoDiffDenseBlock(Value&& val)
+        : val_(std::move(val)), jac_(Derivative::Zero(val.rows(), NumDerivs))
+        {
+        }
+
+        AutoDiffDenseBlock(Value&& val, Derivative&& jac)
+            : val_(std::move(val)), jac_(std::move(jac))
+        {
+            assert(val_.rows() == jac_.rows());
+        }
+
+        Value val_;
+        Derivative jac_;
+    };
+
+
+    // ---------  Free functions and operators for AutoDiffDenseBlock  ---------
+
+    /// Stream output.
+    template <class Ostream, typename Scalar, int NumDerivs>
+    Ostream&
+    operator<<(Ostream& os, const AutoDiffDenseBlock<Scalar, NumDerivs>& fw)
+    {
+        return fw.print(os);
+    }
+
+
+    /// Elementwise multiplication with constant on the left.
+    template <typename Scalar, int NumDerivs>
+    AutoDiffDenseBlock<Scalar, NumDerivs> operator*(const typename AutoDiffDenseBlock<Scalar, NumDerivs>::Value& lhs,
+                                                    const AutoDiffDenseBlock<Scalar, NumDerivs>& rhs)
+    {
+        return AutoDiffDenseBlock<Scalar, NumDerivs>::constant(lhs) * rhs;
+    }
+
+
+    /// Elementwise multiplication with constant on the right.
+    template <typename Scalar, int NumDerivs>
+    AutoDiffDenseBlock<Scalar, NumDerivs> operator*(const AutoDiffDenseBlock<Scalar, NumDerivs>& lhs,
+                                                    const typename AutoDiffDenseBlock<Scalar, NumDerivs>::Value& rhs)
+    {
+        return rhs * lhs; // Commutative operation.
+    }
+
+
+    /// Elementwise addition with constant on the left.
+    template <typename Scalar, int NumDerivs>
+    AutoDiffDenseBlock<Scalar, NumDerivs> operator+(const typename AutoDiffDenseBlock<Scalar, NumDerivs>::Value& lhs,
+                                                    const AutoDiffDenseBlock<Scalar, NumDerivs>& rhs)
+    {
+        return AutoDiffDenseBlock<Scalar, NumDerivs>::constant(lhs) + rhs;
+    }
+
+
+    /// Elementwise addition with constant on the right.
+    template <typename Scalar, int NumDerivs>
+    AutoDiffDenseBlock<Scalar, NumDerivs> operator+(const AutoDiffDenseBlock<Scalar, NumDerivs>& lhs,
+                                                    const typename AutoDiffDenseBlock<Scalar, NumDerivs>::Value& rhs)
+    {
+        return rhs + lhs; // Commutative operation.
+    }
+
+
+    /// Elementwise subtraction with constant on the left.
+    template <typename Scalar, int NumDerivs>
+    AutoDiffDenseBlock<Scalar, NumDerivs> operator-(const typename AutoDiffDenseBlock<Scalar, NumDerivs>::Value& lhs,
+                                                    const AutoDiffDenseBlock<Scalar, NumDerivs>& rhs)
+    {
+        return AutoDiffDenseBlock<Scalar, NumDerivs>::constant(lhs, rhs.blockPattern()) - rhs;
+    }
+
+
+    /// Elementwise subtraction with constant on the right.
+    template <typename Scalar, int NumDerivs>
+    AutoDiffDenseBlock<Scalar, NumDerivs> operator-(const AutoDiffDenseBlock<Scalar, NumDerivs>& lhs,
+                                                    const typename AutoDiffDenseBlock<Scalar, NumDerivs>::Value& rhs)
+    {
+        return lhs - AutoDiffDenseBlock<Scalar, NumDerivs>::constant(rhs);
+    }
+
+
+    /// Elementwise division with constant on the left.
+    template <typename Scalar, int NumDerivs>
+    AutoDiffDenseBlock<Scalar, NumDerivs> operator/(const typename AutoDiffDenseBlock<Scalar, NumDerivs>::Value& lhs,
+                                                    const AutoDiffDenseBlock<Scalar, NumDerivs>& rhs)
+    {
+        return AutoDiffDenseBlock<Scalar, NumDerivs>::constant(lhs) / rhs;
+    }
+
+
+    /// Elementwise division with constant on the right.
+    template <typename Scalar, int NumDerivs>
+    AutoDiffDenseBlock<Scalar, NumDerivs> operator/(const AutoDiffDenseBlock<Scalar, NumDerivs>& lhs,
+                                                    const typename AutoDiffDenseBlock<Scalar, NumDerivs>::Value& rhs)
+    {
+        return lhs / AutoDiffDenseBlock<Scalar, NumDerivs>::constant(rhs);
+    }
+
+
+    /**
+     * @brief Operator for multiplication with a scalar on the right-hand side
+     *
+     * @param lhs The left-hand side AD forward block
+     * @param rhs The scalar to multiply with
+     * @return The product
+     */
+    template <typename Scalar, int NumDerivs>
+    AutoDiffDenseBlock<Scalar, NumDerivs> operator*(const AutoDiffDenseBlock<Scalar, NumDerivs>& lhs,
+                                                    const Scalar& rhs)
+    {
+        return AutoDiffDenseBlock<Scalar, NumDerivs>::function( lhs.value() * rhs, lhs.derivative() * rhs );
+    }
+
+
+    /**
+     * @brief Operator for multiplication with a scalar on the left-hand side
+     *
+     * @param lhs The scalar to multiply with
+     * @param rhs The right-hand side AD forward block
+     * @return The product
+     */
+    template <typename Scalar, int NumDerivs>
+    AutoDiffDenseBlock<Scalar, NumDerivs> operator*(const Scalar& lhs,
+                                                    const AutoDiffDenseBlock<Scalar, NumDerivs>& rhs)
+    {
+        return rhs * lhs; // Commutative operation.
+    }
+
+
+} // namespace Opm
+
+
+
+#endif // OPM_AUTODIFFBLOCK_HEADER_INCLUDED

--- a/opm/autodiff/AutoDiffDenseBlock.hpp
+++ b/opm/autodiff/AutoDiffDenseBlock.hpp
@@ -352,7 +352,7 @@ namespace Opm
     AutoDiffDenseBlock<Scalar, NumDerivs> operator-(const typename AutoDiffDenseBlock<Scalar, NumDerivs>::Value& lhs,
                                                     const AutoDiffDenseBlock<Scalar, NumDerivs>& rhs)
     {
-        return AutoDiffDenseBlock<Scalar, NumDerivs>::constant(lhs, rhs.blockPattern()) - rhs;
+        return AutoDiffDenseBlock<Scalar, NumDerivs>::constant(lhs) - rhs;
     }
 
 

--- a/opm/autodiff/AutoDiffDenseBlock.hpp
+++ b/opm/autodiff/AutoDiffDenseBlock.hpp
@@ -21,6 +21,8 @@
 #ifndef OPM_AUTODIFFDENSEBLOCK_HEADER_INCLUDED
 #define OPM_AUTODIFFDENSEBLOCK_HEADER_INCLUDED
 
+#include <opm/core/utility/ErrorMacros.hpp>
+
 #include <opm/core/utility/platform_dependent/disable_warnings.h>
 
 #include <Eigen/Eigen>
@@ -31,6 +33,7 @@
 #include <vector>
 #include <cassert>
 #include <iostream>
+#include <stdexcept>
 
 namespace Opm
 {
@@ -111,6 +114,10 @@ namespace Opm
         /// will be all ones.
         static AutoDiffDenseBlock variable(const int index, Value&& val)
         {
+            if (index >= NumDerivs) {
+                OPM_THROW(std::runtime_error, "Cannot create variable with index "
+                          << index << " since NumDerivs = " << NumDerivs);
+            }
             Derivative jac = Derivative::Zero(val.rows(), 3);
             jac.col(index) = Value::Ones(val.rows());
             return AutoDiffDenseBlock(std::move(val), std::move(jac));

--- a/opm/autodiff/AutoDiffHelpers.hpp
+++ b/opm/autodiff/AutoDiffHelpers.hpp
@@ -315,9 +315,9 @@ AutoDiffDenseBlock<Scalar, NumDerivs>
 subset(const AutoDiffDenseBlock<Scalar, NumDerivs>& x,
        const IntVec& indices)
 {
-    typedef AutoDiffDenseBlock<Scalar, NumDerivs> ADD;
-    typedef typename ADD::Value V;
-    typedef typename ADD::Derivative D;
+    typedef AutoDiffDenseBlock<Scalar, NumDerivs> ADDB;
+    typedef typename ADDB::Value V;
+    typedef typename ADDB::Derivative D;
     typedef typename V::Index Index;
     const Index size = indices.size();
     V val(size);
@@ -327,7 +327,7 @@ subset(const AutoDiffDenseBlock<Scalar, NumDerivs>& x,
         val[i] = x.value()[indices[i]];
         jac.row(i) = x.derivative().row(indices[i]);
     }
-    return ADD::function(std::move(val), std::move(jac));
+    return ADDB::function(std::move(val), std::move(jac));
 }
 
 

--- a/opm/autodiff/AutoDiffHelpers.hpp
+++ b/opm/autodiff/AutoDiffHelpers.hpp
@@ -22,6 +22,7 @@
 #define OPM_AUTODIFFHELPERS_HEADER_INCLUDED
 
 #include <opm/autodiff/AutoDiffBlock.hpp>
+#include <opm/autodiff/AutoDiffDenseBlock.hpp>
 #include <opm/autodiff/GridHelpers.hpp>
 #include <opm/core/grid.h>
 #include <opm/core/utility/ErrorMacros.hpp>
@@ -305,6 +306,28 @@ subset(const AutoDiffBlock<Scalar>& x,
     const typename AutoDiffBlock<Scalar>::M sub
         = constructSupersetSparseMatrix<Scalar>(x.value().size(), indices).transpose();
     return sub * x;
+}
+
+
+/// Returns x(indices).
+template <typename Scalar, int NumDerivs, class IntVec>
+AutoDiffDenseBlock<Scalar, NumDerivs>
+subset(const AutoDiffDenseBlock<Scalar, NumDerivs>& x,
+       const IntVec& indices)
+{
+    typedef AutoDiffDenseBlock<Scalar, NumDerivs> ADD;
+    typedef typename ADD::Value V;
+    typedef typename ADD::Derivative D;
+    typedef typename V::Index Index;
+    const Index size = indices.size();
+    V val(size);
+    D jac(size, NumDerivs);
+    Eigen::Array<Scalar, Eigen::Dynamic, 1> ret( size );
+    for (Index i = 0; i < size; ++i) {
+        val[i] = x.value()[indices[i]];
+        jac.row(i) = x.derivative().row(indices[i]);
+    }
+    return ADD::function(std::move(val), std::move(jac));
 }
 
 

--- a/opm/autodiff/AutoDiffHelpers.hpp
+++ b/opm/autodiff/AutoDiffHelpers.hpp
@@ -472,7 +472,6 @@ spdiag(const AutoDiffBlock<double>::V& d)
 	    const Index size = x1.size();
 	    V val(size);
 	    D jac(size, NumDerivs);
-	    const Index nl = left_elems_.size();
 	    for (Index i : left_elems_) {
 		val[i] = x1.value()[i];
 		jac.row(i) = x1.derivative().row(i);

--- a/opm/autodiff/AutoDiffHelpers.hpp
+++ b/opm/autodiff/AutoDiffHelpers.hpp
@@ -794,6 +794,7 @@ AutoDiffBlock<Scalar> convertToAutoDiffBlock(const AutoDiffDenseBlock<Scalar, Nu
         // Build sparse diagonal Jacobians.
         typedef typename AutoDiffBlock<Scalar>::M M;
         std::vector<M> jacs;
+        jacs.reserve(bpn);
         for (int ii = 0; ii < NumDerivs; ++ii) {
             if (x.hasZeroDerivative(ii)) {
                 jacs.emplace_back(n, n);

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -274,7 +274,7 @@ namespace Opm {
         std::vector<int>         primalVariable_;
         V pvdt_;
 
-        std::vector<int> block_pattern_;
+        bool use_well_only_blockpattern_;
 
         // ---------  Protected methods  ---------
 
@@ -343,15 +343,15 @@ namespace Opm {
         assembleMassBalanceEq(const SolutionState& state);
 
         void
-        solveWellEq(const std::vector<ADD>& mob_perfcells,
-                    const std::vector<ADD>& b_perfcells,
+        solveWellEq(const std::vector<ADB>& mob_perfcells,
+                    const std::vector<ADB>& b_perfcells,
                     SolutionState& state,
                     WellState& well_state);
 
         void
         computeWellFlux(const SolutionState& state,
-                        const std::vector<ADD>& mob_perfcells,
-                        const std::vector<ADD>& b_perfcells,
+                        const std::vector<ADB>& mob_perfcells,
+                        const std::vector<ADB>& b_perfcells,
                         V& aliveWells,
                         std::vector<ADB>& cq_s);
 

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -52,27 +52,27 @@ namespace Opm {
     struct DefaultBlackoilSolutionState
     {
         typedef AutoDiffBlock<double> ADB;
-        typedef AutoDiffDenseBlock<double, 3> ADD;
+        typedef AutoDiffDenseBlock<double, 3> ADDB;
         explicit DefaultBlackoilSolutionState(const int np)
-            : pressure  (    ADD::null())
-            , temperature(   ADD::null())
-            , saturation(np, ADD::null())
-            , rs        (    ADD::null())
-            , rv        (    ADD::null())
+            : pressure  (    ADDB::null())
+            , temperature(   ADDB::null())
+            , saturation(np, ADDB::null())
+            , rs        (    ADDB::null())
+            , rv        (    ADDB::null())
             , qs        (    ADB::null())
             , bhp       (    ADB::null())
-            , canonical_phase_pressures(3, ADD::null())
+            , canonical_phase_pressures(3, ADDB::null())
         {
         }
-        ADD              pressure;
-        ADD              temperature;
-        std::vector<ADD> saturation;
-        ADD              rs;
-        ADD              rv;
-        ADB              qs;
-        ADB              bhp;
+        ADDB              pressure;
+        ADDB              temperature;
+        std::vector<ADDB> saturation;
+        ADDB              rs;
+        ADDB              rv;
+        ADB               qs;
+        ADB               bhp;
         // Below are quantities stored in the state for optimization purposes.
-        std::vector<ADD> canonical_phase_pressures; // Always has 3 elements, even if only 2 phases active.
+        std::vector<ADDB> canonical_phase_pressures; // Always has 3 elements, even if only 2 phases active.
     };
 
 
@@ -104,7 +104,7 @@ namespace Opm {
         typedef AutoDiffBlock<double> ADB;
         typedef ADB::V V;
         typedef ADB::M M;
-        typedef AutoDiffDenseBlock<double, 3> ADD;
+        typedef AutoDiffDenseBlock<double, 3> ADDB;
 
         typedef typename ModelTraits<Implementation>::ReservoirState ReservoirState;
         typedef typename ModelTraits<Implementation>::WellState WellState;
@@ -222,11 +222,11 @@ namespace Opm {
 
         struct ReservoirResidualQuant {
             ReservoirResidualQuant();
-            std::vector<ADD> accum; // Accumulations
-            ADB              mflux; // Mass flux (surface conditions)
-            ADD              b;     // Reciprocal FVF
-            ADB              dh;    // Pressure drop across int. interfaces
-            ADD              mob;   // Phase mobility (per cell)
+            std::vector<ADDB> accum; // Accumulations
+            ADB               mflux; // Mass flux (surface conditions)
+            ADDB              b;     // Reciprocal FVF
+            ADB               dh;    // Pressure drop across int. interfaces
+            ADDB              mob;   // Phase mobility (per cell)
         };
 
         struct WellOps {
@@ -323,7 +323,7 @@ namespace Opm {
         SolutionState
         variableStateExtractVars(const ReservoirState& x,
                                  const std::vector<int>& indices,
-                                 std::vector<ADD>& vars) const;
+                                 std::vector<ADDB>& vars) const;
 
         void
         variableStateExtractWellsVars(const std::vector<int>& indices,
@@ -383,11 +383,11 @@ namespace Opm {
 
         bool isVFPActive() const;
 
-        std::vector<ADD>
-        computePressures(const ADD& po,
-                         const ADD& sw,
-                         const ADD& so,
-                         const ADD& sg) const;
+        std::vector<ADDB>
+        computePressures(const ADDB& po,
+                         const ADDB& sw,
+                         const ADDB& so,
+                         const ADDB& sg) const;
 
         V
         computeGasPressure(const V& po,
@@ -395,49 +395,49 @@ namespace Opm {
                            const V& so,
                            const V& sg) const;
 
-        std::vector<ADD>
+        std::vector<ADDB>
         computeRelPerm(const SolutionState& state) const;
 
         void
         computeMassFlux(const int               actph ,
                         const V&                transi,
-                        const ADD&              kr    ,
-                        const ADD&              p     ,
+                        const ADDB&              kr    ,
+                        const ADDB&              p     ,
                         const SolutionState&    state );
 
         void applyThresholdPressures(ADB& dp);
 
-        ADD
-        fluidViscosity(const int               phase,
-                       const ADD&              p    ,
-                       const ADD&              temp ,
-                       const ADD&              rs   ,
-                       const ADD&              rv   ,
+        ADDB
+        fluidViscosity(const int                phase,
+                       const ADDB&              p    ,
+                       const ADDB&              temp ,
+                       const ADDB&              rs   ,
+                       const ADDB&              rv   ,
                        const std::vector<PhasePresence>& cond) const;
 
-        ADD
+        ADDB
         fluidReciprocFVF(const int phase,
-                         const ADD& p,
-                         const ADD& temp,
-                         const ADD& rs,
-                         const ADD& rv,
+                         const ADDB& p,
+                         const ADDB& temp,
+                         const ADDB& rs,
+                         const ADDB& rv,
                          const std::vector<PhasePresence>& cond) const;
 
 
-        ADD
+        ADDB
         fluidDensity(const int  phase,
-                     const ADD& b,
-                     const ADD& rs,
-                     const ADD& rv) const;
+                     const ADDB& b,
+                     const ADDB& rs,
+                     const ADDB& rv) const;
 
         V
         fluidRsSat(const V&                p,
                    const V&                so,
                    const std::vector<int>& cells) const;
 
-        ADD
-        fluidRsSat(const ADD&              p,
-                   const ADD&              so,
+        ADDB
+        fluidRsSat(const ADDB&              p,
+                   const ADDB&              so,
                    const std::vector<int>& cells) const;
 
         V
@@ -445,16 +445,16 @@ namespace Opm {
                    const V&                so,
                    const std::vector<int>& cells) const;
 
-        ADD
-        fluidRvSat(const ADD&              p,
-                   const ADD&              so,
+        ADDB
+        fluidRvSat(const ADDB&              p,
+                   const ADDB&              so,
                    const std::vector<int>& cells) const;
 
-        ADD
-        poroMult(const ADD& p) const;
+        ADDB
+        poroMult(const ADDB& p) const;
 
-        ADD
-        transMult(const ADD& p) const;
+        ADDB
+        transMult(const ADDB& p) const;
 
         const std::vector<PhasePresence>
         phaseCondition() const {return phaseCondition_;}

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -922,19 +922,19 @@ namespace detail {
             const int po = fluid_.phaseUsage().phase_pos[ Oil ];
             const int pg = fluid_.phaseUsage().phase_pos[ Gas ];
 
-            const UpwindSelector<double> upwindOil(grid_, ops_,
-                                                rq_[po].dh.value());
-            const ADB rs_face = upwindOil.select(convertToAutoDiffBlock(state.rs, blockPattern()));
+            if (has_disgas_) {
+                const UpwindSelector<double> upwindOil(grid_, ops_,
+                                                       rq_[po].dh.value());
+                const ADB rs_face = upwindOil.select(convertToAutoDiffBlock(state.rs, blockPattern()));
+                residual_.material_balance_eq[ pg ] += ops_.div * (rs_face * rq_[po].mflux);
+            }
 
-            const UpwindSelector<double> upwindGas(grid_, ops_,
-                                                rq_[pg].dh.value());
-            const ADB rv_face = upwindGas.select(convertToAutoDiffBlock(state.rv, blockPattern()));
-
-            residual_.material_balance_eq[ pg ] += ops_.div * (rs_face * rq_[po].mflux);
-            residual_.material_balance_eq[ po ] += ops_.div * (rv_face * rq_[pg].mflux);
-
-            // OPM_AD_DUMP(residual_.material_balance_eq[ Gas ]);
-
+            if (has_vapoil_) {
+                const UpwindSelector<double> upwindGas(grid_, ops_,
+                                                       rq_[pg].dh.value());
+                const ADB rv_face = upwindGas.select(convertToAutoDiffBlock(state.rv, blockPattern()));
+                residual_.material_balance_eq[ po ] += ops_.div * (rv_face * rq_[pg].mflux);
+            }
         }
     }
 

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -46,7 +46,7 @@ namespace Opm
     typedef BlackoilPropsAdFromDeck::ADB ADB;
     typedef BlackoilPropsAdFromDeck::V V;
     typedef Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> Block;
-    typedef BlackoilPropsAdInterface::ADD ADD;
+    typedef BlackoilPropsAdInterface::ADDB ADDB;
 
 
     /// Constructor wrapping an opm-core black oil interface.
@@ -433,9 +433,9 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
     /// \param[in]  T      Array of n temperature values.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n viscosity values.
-    ADD BlackoilPropsAdFromDeck::muWat(const ADD& pw,
-                                       const ADD& T,
-                                       const Cells& cells) const
+    ADDB BlackoilPropsAdFromDeck::muWat(const ADDB& pw,
+					const ADDB& T,
+					const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Water]) {
             OPM_THROW(std::runtime_error, "Cannot call muWat(): water phase not present.");
@@ -451,8 +451,8 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         props_[phase_usage_.phase_pos[Water]]->mu(n, pvt_region_.data(), pw.value().data(), T.value().data(), rs,
                                                   mu.data(), dmudp.data(), dmudr.data());
 
-        ADD::Derivative jac = pw.derivative().colwise() * dmudp;
-        return ADD::function(std::move(mu), std::move(jac));
+        ADDB::Derivative jac = pw.derivative().colwise() * dmudp;
+        return ADDB::function(std::move(mu), std::move(jac));
     }
 
     /// Oil viscosity.
@@ -462,11 +462,11 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
     /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n viscosity values.
-    ADD BlackoilPropsAdFromDeck::muOil(const ADD& po,
-                                       const ADD& T,
-                                       const ADD& rs,
-                                       const std::vector<PhasePresence>& cond,
-                                       const Cells& cells) const
+    ADDB BlackoilPropsAdFromDeck::muOil(const ADDB& po,
+					const ADDB& T,
+					const ADDB& rs,
+					const std::vector<PhasePresence>& cond,
+					const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Oil]) {
             OPM_THROW(std::runtime_error, "Cannot call muOil(): oil phase not present.");
@@ -481,8 +481,8 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         props_[phase_usage_.phase_pos[Oil]]->mu(n, pvt_region_.data(), po.value().data(), T.value().data(), rs.value().data(),
                                                 &cond[0], mu.data(), dmudp.data(), dmudr.data());
 
-        ADD::Derivative jac = po.derivative().colwise() * dmudp + rs.derivative().colwise() * dmudr;
-        return ADD::function(std::move(mu), std::move(jac));
+        ADDB::Derivative jac = po.derivative().colwise() * dmudp + rs.derivative().colwise() * dmudr;
+        return ADDB::function(std::move(mu), std::move(jac));
     }
 
     /// Gas viscosity.
@@ -492,11 +492,11 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
     /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n viscosity values.
-    ADD BlackoilPropsAdFromDeck::muGas(const ADD& pg,
-                                       const ADD& T,
-                                       const ADD& rv,
-                                       const std::vector<PhasePresence>& cond,
-                                       const Cells& cells) const
+    ADDB BlackoilPropsAdFromDeck::muGas(const ADDB& pg,
+					const ADDB& T,
+					const ADDB& rv,
+					const std::vector<PhasePresence>& cond,
+					const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Gas]) {
             OPM_THROW(std::runtime_error, "Cannot call muGas(): gas phase not present.");
@@ -511,8 +511,8 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         props_[phase_usage_.phase_pos[Gas]]->mu(n, pvt_region_.data(), pg.value().data(), T.value().data(), rv.value().data(),&cond[0],
                                                   mu.data(), dmudp.data(), dmudr.data());
 
-        ADD::Derivative jac = pg.derivative().colwise() * dmudp + rv.derivative().colwise() * dmudr;
-        return ADD::function(std::move(mu), std::move(jac));
+        ADDB::Derivative jac = pg.derivative().colwise() * dmudp + rv.derivative().colwise() * dmudr;
+        return ADDB::function(std::move(mu), std::move(jac));
     }
 
 
@@ -640,9 +640,9 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
     /// \param[in]  T      Array of n temperature values.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n formation volume factor values.
-    ADD BlackoilPropsAdFromDeck::bWat(const ADD& pw,
-                                      const ADD& T,
-                                      const Cells& cells) const
+    ADDB BlackoilPropsAdFromDeck::bWat(const ADDB& pw,
+				       const ADDB& T,
+				       const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Water]) {
             OPM_THROW(std::runtime_error, "Cannot call muWat(): water phase not present.");
@@ -659,8 +659,8 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         props_[phase_usage_.phase_pos[Water]]->b(n, pvt_region_.data(), pw.value().data(), T.value().data(), rs,
                                                  b.data(), dbdp.data(), dbdr.data());
 
-        ADD::Derivative jac = pw.derivative().colwise() * dbdp;
-        return ADD::function(std::move(b), std::move(jac));
+        ADDB::Derivative jac = pw.derivative().colwise() * dbdp;
+        return ADDB::function(std::move(b), std::move(jac));
     }
 
     /// Oil formation volume factor.
@@ -670,11 +670,11 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
     /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n formation volume factor values.
-    ADD BlackoilPropsAdFromDeck::bOil(const ADD& po,
-                                      const ADD& T,
-                                      const ADD& rs,
-                                      const std::vector<PhasePresence>& cond,
-                                      const Cells& cells) const
+    ADDB BlackoilPropsAdFromDeck::bOil(const ADDB& po,
+				       const ADDB& T,
+				       const ADDB& rs,
+				       const std::vector<PhasePresence>& cond,
+				       const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Oil]) {
             OPM_THROW(std::runtime_error, "Cannot call muOil(): oil phase not present.");
@@ -690,8 +690,8 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         props_[phase_usage_.phase_pos[Oil]]->b(n, pvt_region_.data(), po.value().data(), T.value().data(), rs.value().data(),
                                                &cond[0], b.data(), dbdp.data(), dbdr.data());
 
-        ADD::Derivative jac = po.derivative().colwise() * dbdp + rs.derivative().colwise() * dbdr;
-        return ADD::function(std::move(b), std::move(jac));
+        ADDB::Derivative jac = po.derivative().colwise() * dbdp + rs.derivative().colwise() * dbdr;
+        return ADDB::function(std::move(b), std::move(jac));
     }
 
     /// Gas formation volume factor.
@@ -701,11 +701,11 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
     /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n formation volume factor values.
-    ADD BlackoilPropsAdFromDeck::bGas(const ADD& pg,
-                                      const ADD& T,
-                                      const ADD& rv,
-                                      const std::vector<PhasePresence>& cond,
-                                      const Cells& cells) const
+    ADDB BlackoilPropsAdFromDeck::bGas(const ADDB& pg,
+				       const ADDB& T,
+				       const ADDB& rv,
+				       const std::vector<PhasePresence>& cond,
+				       const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Gas]) {
             OPM_THROW(std::runtime_error, "Cannot call muGas(): gas phase not present.");
@@ -721,8 +721,8 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         props_[phase_usage_.phase_pos[Gas]]->b(n, pvt_region_.data(), pg.value().data(), T.value().data(), rv.value().data(), &cond[0],
                                                b.data(), dbdp.data(), dbdr.data());
 
-        ADD::Derivative jac = pg.derivative().colwise() * dbdp + rv.derivative().colwise() * dbdr;
-        return ADD::function(std::move(b), std::move(jac));
+        ADDB::Derivative jac = pg.derivative().colwise() * dbdp + rv.derivative().colwise() * dbdr;
+        return ADDB::function(std::move(b), std::move(jac));
     }
 
 
@@ -775,8 +775,8 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
     /// \param[in]  po     Array of n oil pressure values.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n bubble point values for Rs.
-    ADD BlackoilPropsAdFromDeck::rsSat(const ADD& po,
-                                       const Cells& cells) const
+    ADDB BlackoilPropsAdFromDeck::rsSat(const ADDB& po,
+					const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Oil]) {
             OPM_THROW(std::runtime_error, "Cannot call rsMax(): oil phase not present.");
@@ -787,8 +787,8 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         V rbub(n);
         V drbubdp(n);
         props_[phase_usage_.phase_pos[Oil]]->rsSat(n, pvt_region_.data(), po.value().data(), rbub.data(), drbubdp.data());
-        ADD::Derivative jac = po.derivative().colwise() * drbubdp;
-        return ADD::function(std::move(rbub), std::move(jac));
+        ADDB::Derivative jac = po.derivative().colwise() * drbubdp;
+        return ADDB::function(std::move(rbub), std::move(jac));
     }
 
     /// Bubble point curve for Rs as function of oil pressure.
@@ -796,11 +796,11 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
     /// \param[in]  so     Array of n oil saturation values.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n bubble point values for Rs.
-    ADD BlackoilPropsAdFromDeck::rsSat(const ADD& po,
-                                       const ADD& so,
-                                       const Cells& cells) const
+    ADDB BlackoilPropsAdFromDeck::rsSat(const ADDB& po,
+					const ADDB& so,
+					const Cells& cells) const
     {
-        ADD rs = rsSat(po, cells);
+        ADDB rs = rsSat(po, cells);
         applyVap(rs, so, cells, vap2_);
         return rs;
     }
@@ -852,8 +852,8 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
     /// \param[in]  po     Array of n oil pressure values.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n condensation point values for Rv.
-    ADD BlackoilPropsAdFromDeck::rvSat(const ADD& po,
-                                       const Cells& cells) const
+    ADDB BlackoilPropsAdFromDeck::rvSat(const ADDB& po,
+					const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Gas]) {
             OPM_THROW(std::runtime_error, "Cannot call rvMax(): gas phase not present.");
@@ -864,8 +864,8 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         V rv(n);
         V drvdp(n);
         props_[phase_usage_.phase_pos[Gas]]->rvSat(n, pvt_region_.data(), po.value().data(), rv.data(), drvdp.data());
-        ADD::Derivative jac = po.derivative().colwise() * drvdp;
-        return ADD::function(std::move(rv), std::move(jac));
+        ADDB::Derivative jac = po.derivative().colwise() * drvdp;
+        return ADDB::function(std::move(rv), std::move(jac));
     }
 
     /// Condensation curve for Rv as function of oil pressure.
@@ -873,11 +873,11 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
     /// \param[in]  so     Array of n oil saturation values.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n condensation point values for Rv.
-    ADD BlackoilPropsAdFromDeck::rvSat(const ADD& po,
-                                       const ADD& so,
-                                       const Cells& cells) const
+    ADDB BlackoilPropsAdFromDeck::rvSat(const ADDB& po,
+					const ADDB& so,
+					const Cells& cells) const
     {
-        ADD rv = rvSat(po, cells);
+        ADDB rv = rvSat(po, cells);
         applyVap(rv, so, cells, vap1_);
         return rv;
     }
@@ -1023,10 +1023,10 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
     /// \param[in]  cells  Array of n cell indices to be associated with the saturation values.
     /// \return            An std::vector with 3 elements, each an array of n relperm values,
     ///                    containing krw, kro, krg. Use PhaseIndex for indexing into the result.
-    std::vector<ADD> BlackoilPropsAdFromDeck::relperm(const ADD& sw,
-                                                      const ADD& so,
-                                                      const ADD& sg,
-                                                      const Cells& cells) const
+    std::vector<ADDB> BlackoilPropsAdFromDeck::relperm(const ADDB& sw,
+						       const ADDB& so,
+						       const ADDB& sg,
+						       const Cells& cells) const
     {
         const int n = cells.size();
         const int np = numPhases();
@@ -1048,18 +1048,14 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         Block kr(n, np);
         Block dkr(n, np*np);
         satprops_->relperm(n, s_all.data(), cells.data(), kr.data(), dkr.data());
-        std::vector<ADD> relperms;
+        std::vector<ADDB> relperms;
         relperms.reserve(3);
-        typedef const ADD* ADDPtr;
-        ADDPtr s[3] = { &sw, &so, &sg };
+        typedef const ADDB* ADDBPtr;
+        ADDBPtr s[3] = { &sw, &so, &sg };
         for (int phase1 = 0; phase1 < 3; ++phase1) {
             if (phase_usage_.phase_used[phase1]) {
                 const int phase1_pos = phase_usage_.phase_pos[phase1];
-                // std::vector<ADD::M> jacs(num_blocks);
-                // for (int block = 0; block < num_blocks; ++block) {
-                //     jacs[block] = ADD::M(n, s[phase1]->derivative()[block].cols());
-                // }
-                ADD::Derivative jac = ADD::Derivative::Zero(n, 3);
+                ADDB::Derivative jac = ADDB::Derivative::Zero(n, 3);
                 for (int phase2 = 0; phase2 < 3; ++phase2) {
                     if (!phase_usage_.phase_used[phase2]) {
                         continue;
@@ -1067,18 +1063,12 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
                     const int phase2_pos = phase_usage_.phase_pos[phase2];
                     // Assemble dkr1/ds2.
                     const int column = phase1_pos + np*phase2_pos; // Recall: Fortran ordering from props_.relperm()
-                    // ADD::M dkr1_ds2_diag = spdiag(dkr.col(column));
-                    // for (int block = 0; block < num_blocks; ++block) {
-                    //     ADD::M temp;
-                    //     fastSparseProduct(dkr1_ds2_diag, s[phase2]->derivative()[block], temp);
-                    //     jacs[block] += temp;
-                    // }
                     jac += s[phase2]->derivative().colwise() * dkr.col(column);
                 }
                 V val = kr.col(phase1_pos);
-                relperms.emplace_back(ADD::function(std::move(val), std::move(jac)));
+                relperms.emplace_back(ADDB::function(std::move(val), std::move(jac)));
             } else {
-                relperms.emplace_back(ADD::null());
+                relperms.emplace_back(ADDB::null());
             }
         }
         return relperms;
@@ -1086,10 +1076,10 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
 
 
 
-    std::vector<ADD> BlackoilPropsAdFromDeck::capPress(const ADD& sw,
-                                                       const ADD& so,
-                                                       const ADD& sg,
-                                                       const Cells& cells) const
+    std::vector<ADDB> BlackoilPropsAdFromDeck::capPress(const ADDB& sw,
+							const ADDB& so,
+							const ADDB& sg,
+							const Cells& cells) const
     {
         const int numCells = cells.size();
         const int numActivePhases = numPhases();
@@ -1114,35 +1104,25 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         Block dpc(numCells, numActivePhases*numActivePhases);
         satprops_->capPress(numCells, activeSat.data(), cells.data(), pc.data(), dpc.data());
 
-        std::vector<ADD> adbCapPressures;
+        std::vector<ADDB> adbCapPressures;
         adbCapPressures.reserve(3);
-        const ADD* s[3] = { &sw, &so, &sg };
+        const ADDB* s[3] = { &sw, &so, &sg };
         for (int phase1 = 0; phase1 < 3; ++phase1) {
             if (phase_usage_.phase_used[phase1]) {
                 const int phase1_pos = phase_usage_.phase_pos[phase1];
-                // std::vector<ADD::M> jacs(numBlocks);
-                // for (int block = 0; block < numBlocks; ++block) {
-                //     jacs[block] = ADD::M(numCells, s[phase1]->derivative()[block].cols());
-                // }
-                ADD::Derivative jac = ADD::Derivative::Zero(numCells, 3);
+                ADDB::Derivative jac = ADDB::Derivative::Zero(numCells, 3);
                 for (int phase2 = 0; phase2 < 3; ++phase2) {
                     if (!phase_usage_.phase_used[phase2])
                         continue;
                     const int phase2_pos = phase_usage_.phase_pos[phase2];
                     // Assemble dpc1/ds2.
                     const int column = phase1_pos + numActivePhases*phase2_pos; // Recall: Fortran ordering from props_.relperm()
-                    // ADD::M dpc1_ds2_diag = spdiag(dpc.col(column));
-                    // for (int block = 0; block < numBlocks; ++block) {
-                    //     ADD::M temp;
-                    //     fastSparseProduct(dpc1_ds2_diag, s[phase2]->derivative()[block], temp);
-                    //     jacs[block] += temp;
-                    // }
                     jac += s[phase2]->derivative().colwise() * dpc.col(column);
                 }
                 V val = pc.col(phase1_pos);
-                adbCapPressures.emplace_back(ADD::function(std::move(val), std::move(jac)));
+                adbCapPressures.emplace_back(ADDB::function(std::move(val), std::move(jac)));
             } else {
-                adbCapPressures.emplace_back(ADD::null());
+                adbCapPressures.emplace_back(ADDB::null());
             }
         }
         return adbCapPressures;
@@ -1258,8 +1238,8 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
     /// \param[in]     so    Array of n oil saturation values.
     /// \param[in]     cells Array of n cell indices to be associated with the r and so values.
     /// \param[in]     vap   Correction parameter.
-    void BlackoilPropsAdFromDeck::applyVap(ADD& r,
-                                           const ADD& so,
+    void BlackoilPropsAdFromDeck::applyVap(ADDB& r,
+                                           const ADDB& so,
                                            const std::vector<int>& cells,
                                            const double vap) const
     {
@@ -1276,8 +1256,8 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
                     dfactor_dso[i] = vap*std::pow(so_i/satOilMax_[cells[i]], vap-1.0)/satOilMax_[cells[i]];
                 }
             }
-            ADD::Derivative jac = so.derivative().colwise() * dfactor_dso;
-            r = ADD::function(std::move(factor), std::move(jac)) * r;
+            ADDB::Derivative jac = so.derivative().colwise() * dfactor_dso;
+            r = ADDB::function(std::move(factor), std::move(jac)) * r;
         }
     }
 

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -177,9 +177,9 @@ namespace Opm
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         virtual
-        ADD muWat(const ADD& pw,
-                  const ADD& T,
-                  const Cells& cells) const;
+        ADDB muWat(const ADDB& pw,
+		   const ADDB& T,
+		   const Cells& cells) const;
 
         /// Oil viscosity.
         /// \param[in]  po     Array of n oil pressure values.
@@ -189,11 +189,11 @@ namespace Opm
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         virtual
-        ADD muOil(const ADD& po,
-                  const ADD& T,
-                  const ADD& rs,
-                  const std::vector<PhasePresence>& cond,
-                  const Cells& cells) const;
+        ADDB muOil(const ADDB& po,
+		   const ADDB& T,
+		   const ADDB& rs,
+		   const std::vector<PhasePresence>& cond,
+		   const Cells& cells) const;
 
         /// Gas viscosity.
         /// \param[in]  pg     Array of n gas pressure values.
@@ -203,11 +203,11 @@ namespace Opm
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         virtual
-        ADD muGas(const ADD& pg,
-                  const ADD& T,
-                  const ADD& rv,
-                  const std::vector<PhasePresence>& cond,
-                  const Cells& cells) const;
+        ADDB muGas(const ADDB& pg,
+		   const ADDB& T,
+		   const ADDB& rv,
+		   const std::vector<PhasePresence>& cond,
+		   const Cells& cells) const;
 
         // ------ Formation volume factor (b) ------
 
@@ -254,9 +254,9 @@ namespace Opm
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         virtual
-        ADD bWat(const ADD& pw,
-                 const ADD& T,
-                 const Cells& cells) const;
+        ADDB bWat(const ADDB& pw,
+		  const ADDB& T,
+		  const Cells& cells) const;
 
         /// Oil formation volume factor.
         /// \param[in]  po     Array of n oil pressure values.
@@ -266,11 +266,11 @@ namespace Opm
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         virtual
-        ADD bOil(const ADD& po,
-                 const ADD& T,
-                 const ADD& rs,
-                 const std::vector<PhasePresence>& cond,
-                 const Cells& cells) const;
+        ADDB bOil(const ADDB& po,
+		  const ADDB& T,
+		  const ADDB& rs,
+		  const std::vector<PhasePresence>& cond,
+		  const Cells& cells) const;
 
         /// Gas formation volume factor.
         /// \param[in]  pg     Array of n gas pressure values.
@@ -280,11 +280,11 @@ namespace Opm
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         virtual
-        ADD bGas(const ADD& pg,
-                 const ADD& T,
-                 const ADD& rv,
-                 const std::vector<PhasePresence>& cond,
-                 const Cells& cells) const;
+        ADDB bGas(const ADDB& pg,
+		  const ADDB& T,
+		  const ADDB& rv,
+		  const std::vector<PhasePresence>& cond,
+		  const Cells& cells) const;
 
         // ------ Rs bubble point curve ------
 
@@ -327,8 +327,8 @@ namespace Opm
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n bubble point values for Rs.
         virtual
-        ADD rsSat(const ADD& po,
-                  const Cells& cells) const;
+        ADDB rsSat(const ADDB& po,
+		   const Cells& cells) const;
 
         /// Bubble point curve for Rs as function of oil pressure.
         /// \param[in]  po     Array of n oil pressure values.
@@ -336,9 +336,9 @@ namespace Opm
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n bubble point values for Rs.
         virtual
-        ADD rsSat(const ADD& po,
-                  const ADD& so,
-                  const Cells& cells) const;
+        ADDB rsSat(const ADDB& po,
+		   const ADDB& so,
+		   const Cells& cells) const;
 
         // ------ Rv condensation curve ------
 
@@ -365,8 +365,8 @@ namespace Opm
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n condensation point values for Rv.
         virtual
-        ADD rvSat(const ADD& po,
-                  const Cells& cells) const;
+        ADDB rvSat(const ADDB& po,
+		   const Cells& cells) const;
 
         /// Condensation curve for Rv as function of oil pressure.
         /// \param[in]  po     Array of n oil pressure values.
@@ -374,9 +374,9 @@ namespace Opm
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n condensation point values for Rv.
         virtual
-        ADD rvSat(const ADD& po,
-                  const ADD& so,
-                  const Cells& cells) const;
+        ADDB rvSat(const ADDB& po,
+		   const ADDB& so,
+		   const Cells& cells) const;
 
         // ------ Saturation functions ------
 
@@ -415,10 +415,10 @@ namespace Opm
         /// \return            An std::vector with 3 elements, each an array of n relperm values,
         ///                    containing krw, kro, krg. Use PhaseIndex for indexing into the result.
         virtual
-        std::vector<ADD> relperm(const ADD& sw,
-                                 const ADD& so,
-                                 const ADD& sg,
-                                 const Cells& cells) const;
+        std::vector<ADDB> relperm(const ADDB& sw,
+				  const ADDB& so,
+				  const ADDB& sg,
+				  const Cells& cells) const;
 
         /// Capillary pressure for all phases.
         /// \param[in]  sw     Array of n water saturation values.
@@ -429,10 +429,10 @@ namespace Opm
         ///                    containing the offsets for each p_g, p_o, p_w. The capillary pressure between
         ///                    two arbitrary phases alpha and beta is then given as p_alpha - p_beta.
         virtual
-        std::vector<ADD> capPress(const ADD& sw,
-                                  const ADD& so,
-                                  const ADD& sg,
-                                  const Cells& cells) const;
+        std::vector<ADDB> capPress(const ADDB& sw,
+				   const ADDB& so,
+				   const ADDB& sg,
+				   const Cells& cells) const;
 
         /// Saturation update for hysteresis behavior.
         /// \param[in]  cells       Array of n cell indices to be associated with the saturation values.
@@ -446,7 +446,7 @@ namespace Opm
         /// \param[in]  saturation Array of n*numPhases saturation values.
         /// \param[in]  pc         Array of n*numPhases capillary pressure values.
         void setSwatInitScaling(const std::vector<double>& saturation,
-                      const std::vector<double>& pc);
+				const std::vector<double>& pc);
 
 
     private:
@@ -472,8 +472,8 @@ namespace Opm
                       const std::vector<int>& cells,
                       const double vap) const;
 
-        void applyVap(ADD& r,
-                      const ADD& so,
+        void applyVap(ADDB& r,
+                      const ADDB& so,
                       const std::vector<int>& cells,
                       const double vap) const;
 

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -169,6 +169,46 @@ namespace Opm
                   const std::vector<PhasePresence>& cond,
                   const Cells& cells) const;
 
+        // ------ Viscosity, dense interface ------
+
+        /// Water viscosity.
+        /// \param[in]  pw     Array of n water pressure values.
+        /// \param[in]  T      Array of n temperature values.
+        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+        /// \return            Array of n viscosity values.
+        virtual
+        ADD muWat(const ADD& pw,
+                  const ADD& T,
+                  const Cells& cells) const;
+
+        /// Oil viscosity.
+        /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  T      Array of n temperature values.
+        /// \param[in]  rs     Array of n gas solution factor values.
+        /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
+        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+        /// \return            Array of n viscosity values.
+        virtual
+        ADD muOil(const ADD& po,
+                  const ADD& T,
+                  const ADD& rs,
+                  const std::vector<PhasePresence>& cond,
+                  const Cells& cells) const;
+
+        /// Gas viscosity.
+        /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
+        /// \param[in]  rv     Array of n vapor oil/gas ratios.
+        /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
+        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+        /// \return            Array of n viscosity values.
+        virtual
+        ADD muGas(const ADD& pg,
+                  const ADD& T,
+                  const ADD& rv,
+                  const std::vector<PhasePresence>& cond,
+                  const Cells& cells) const;
+
         // ------ Formation volume factor (b) ------
 
         /// Water formation volume factor.
@@ -206,23 +246,63 @@ namespace Opm
                  const std::vector<PhasePresence>& cond,
                  const Cells& cells) const;
 
+        // ------ Formation volume factor (b) dense interface ------
+
+        /// Water formation volume factor.
+        /// \param[in]  pw     Array of n water pressure values.
+        /// \param[in]  T      Array of n temperature values.
+        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+        /// \return            Array of n formation volume factor values.
+        virtual
+        ADD bWat(const ADD& pw,
+                 const ADD& T,
+                 const Cells& cells) const;
+
+        /// Oil formation volume factor.
+        /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  T      Array of n temperature values.
+        /// \param[in]  rs     Array of n gas solution factor values.
+        /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
+        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+        /// \return            Array of n formation volume factor values.
+        virtual
+        ADD bOil(const ADD& po,
+                 const ADD& T,
+                 const ADD& rs,
+                 const std::vector<PhasePresence>& cond,
+                 const Cells& cells) const;
+
+        /// Gas formation volume factor.
+        /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
+        /// \param[in]  rv     Array of n vapor oil/gas ratios.
+        /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
+        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+        /// \return            Array of n formation volume factor values.
+        virtual
+        ADD bGas(const ADD& pg,
+                 const ADD& T,
+                 const ADD& rv,
+                 const std::vector<PhasePresence>& cond,
+                 const Cells& cells) const;
+
         // ------ Rs bubble point curve ------
 
         /// Bubble point curve for Rs as function of oil pressure.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n bubble point values for Rs.
-        V rsSat(const V& po,
-                const Cells& cells) const;
+        // V rsSat(const V& po,
+        //         const Cells& cells) const;
 
         /// Bubble point curve for Rs as function of oil pressure.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  so     Array of n oil saturation values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n bubble point values for Rs.
-        V rsSat(const V& po,
-                const V& so,
-                const Cells& cells) const;
+        // V rsSat(const V& po,
+        //         const V& so,
+        //         const Cells& cells) const;
 
         /// Bubble point curve for Rs as function of oil pressure.
         /// \param[in]  po     Array of n oil pressure values.
@@ -238,6 +318,26 @@ namespace Opm
         /// \return            Array of n bubble point values for Rs.
         ADB rsSat(const ADB& po,
                   const ADB& so,
+                  const Cells& cells) const;
+
+        // ------ Rs bubble point curve, dense interface ------
+
+        /// Bubble point curve for Rs as function of oil pressure.
+        /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+        /// \return            Array of n bubble point values for Rs.
+        virtual
+        ADD rsSat(const ADD& po,
+                  const Cells& cells) const;
+
+        /// Bubble point curve for Rs as function of oil pressure.
+        /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  so     Array of n oil saturation values.
+        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+        /// \return            Array of n bubble point values for Rs.
+        virtual
+        ADD rsSat(const ADD& po,
+                  const ADD& so,
                   const Cells& cells) const;
 
         // ------ Rv condensation curve ------
@@ -258,7 +358,27 @@ namespace Opm
                   const ADB& so,
                   const Cells& cells) const;
 
-        // ------ Relative permeability ------
+        // ------ Rv condensation curve, dense interface ------
+
+        /// Condensation curve for Rv as function of oil pressure.
+        /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+        /// \return            Array of n condensation point values for Rv.
+        virtual
+        ADD rvSat(const ADD& po,
+                  const Cells& cells) const;
+
+        /// Condensation curve for Rv as function of oil pressure.
+        /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  so     Array of n oil saturation values.
+        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+        /// \return            Array of n condensation point values for Rv.
+        virtual
+        ADD rvSat(const ADD& po,
+                  const ADD& so,
+                  const Cells& cells) const;
+
+        // ------ Saturation functions ------
 
         /// Relative permeabilities for all phases.
         /// \param[in]  sw     Array of n water saturation values.
@@ -285,6 +405,35 @@ namespace Opm
                                   const ADB& sg,
                                   const Cells& cells) const;
                                   
+        // ------ Saturation functions, dense interface ------
+
+        /// Relative permeabilities for all phases.
+        /// \param[in]  sw     Array of n water saturation values.
+        /// \param[in]  so     Array of n oil saturation values.
+        /// \param[in]  sg     Array of n gas saturation values.
+        /// \param[in]  cells  Array of n cell indices to be associated with the saturation values.
+        /// \return            An std::vector with 3 elements, each an array of n relperm values,
+        ///                    containing krw, kro, krg. Use PhaseIndex for indexing into the result.
+        virtual
+        std::vector<ADD> relperm(const ADD& sw,
+                                 const ADD& so,
+                                 const ADD& sg,
+                                 const Cells& cells) const;
+
+        /// Capillary pressure for all phases.
+        /// \param[in]  sw     Array of n water saturation values.
+        /// \param[in]  so     Array of n oil saturation values.
+        /// \param[in]  sg     Array of n gas saturation values.
+        /// \param[in]  cells  Array of n cell indices to be associated with the saturation values.
+        /// \return            An std::vector with 3 elements, each an array of n capillary pressure values,
+        ///                    containing the offsets for each p_g, p_o, p_w. The capillary pressure between
+        ///                    two arbitrary phases alpha and beta is then given as p_alpha - p_beta.
+        virtual
+        std::vector<ADD> capPress(const ADD& sw,
+                                  const ADD& so,
+                                  const ADD& sg,
+                                  const Cells& cells) const;
+
         /// Saturation update for hysteresis behavior.
         /// \param[in]  cells       Array of n cell indices to be associated with the saturation values.
         void updateSatHyst(const std::vector<double>& saturation,
@@ -320,6 +469,11 @@ namespace Opm
 
         void applyVap(ADB& r,
                       const ADB& so,
+                      const std::vector<int>& cells,
+                      const double vap) const;
+
+        void applyVap(ADD& r,
+                      const ADD& so,
                       const std::vector<int>& cells,
                       const double vap) const;
 

--- a/opm/autodiff/BlackoilPropsAdInterface.hpp
+++ b/opm/autodiff/BlackoilPropsAdInterface.hpp
@@ -68,7 +68,7 @@ namespace Opm
         typedef AutoDiffBlock<double> ADB;
         typedef ADB::V V;
         typedef ADB::M M;
-        typedef AutoDiffDenseBlock<double, 3> ADD;
+        typedef AutoDiffDenseBlock<double, 3> ADDB;
         typedef std::vector<int> Cells;
 
         /// \return   Number of active phases (also the number of components).
@@ -142,9 +142,9 @@ namespace Opm
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         virtual
-        ADD muWat(const ADD& pw,
-                  const ADD& T,
-                  const Cells& cells) const = 0;
+	ADDB muWat(const ADDB& pw,
+		   const ADDB& T,
+		   const Cells& cells) const = 0;
 
         /// Oil viscosity.
         /// \param[in]  po     Array of n oil pressure values.
@@ -154,11 +154,11 @@ namespace Opm
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         virtual
-        ADD muOil(const ADD& po,
-                  const ADD& T,
-                  const ADD& rs,
-                  const std::vector<PhasePresence>& cond,
-                  const Cells& cells) const = 0;
+        ADDB muOil(const ADDB& po,
+		   const ADDB& T,
+		   const ADDB& rs,
+		   const std::vector<PhasePresence>& cond,
+		   const Cells& cells) const = 0;
 
         /// Gas viscosity.
         /// \param[in]  pg     Array of n gas pressure values.
@@ -168,11 +168,11 @@ namespace Opm
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         virtual
-        ADD muGas(const ADD& pg,
-                  const ADD& T,
-                  const ADD& rv,
-                  const std::vector<PhasePresence>& cond,
-                  const Cells& cells) const = 0;
+        ADDB muGas(const ADDB& pg,
+		   const ADDB& T,
+		   const ADDB& rv,
+		   const std::vector<PhasePresence>& cond,
+		   const Cells& cells) const = 0;
 
         // ------ Formation volume factor (b) ------
 
@@ -222,9 +222,9 @@ namespace Opm
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         virtual
-        ADD bWat(const ADD& pw,
-                 const ADD& T,
-                 const Cells& cells) const = 0;
+        ADDB bWat(const ADDB& pw,
+		  const ADDB& T,
+		  const Cells& cells) const = 0;
 
         /// Oil formation volume factor.
         /// \param[in]  po     Array of n oil pressure values.
@@ -234,11 +234,11 @@ namespace Opm
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         virtual
-        ADD bOil(const ADD& po,
-                 const ADD& T,
-                 const ADD& rs,
-                 const std::vector<PhasePresence>& cond,
-                 const Cells& cells) const = 0;
+        ADDB bOil(const ADDB& po,
+		  const ADDB& T,
+		  const ADDB& rs,
+		  const std::vector<PhasePresence>& cond,
+		  const Cells& cells) const = 0;
 
         /// Gas formation volume factor.
         /// \param[in]  pg     Array of n gas pressure values.
@@ -248,11 +248,11 @@ namespace Opm
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         virtual
-        ADD bGas(const ADD& pg,
-                 const ADD& T,
-                 const ADD& rv,
-                 const std::vector<PhasePresence>& cond,
-                 const Cells& cells) const = 0;
+        ADDB bGas(const ADDB& pg,
+		  const ADDB& T,
+		  const ADDB& rv,
+		  const std::vector<PhasePresence>& cond,
+		  const Cells& cells) const = 0;
 
         // ------ Rs bubble point curve ------
 
@@ -281,8 +281,8 @@ namespace Opm
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n bubble point values for Rs.
         virtual
-        ADD rsSat(const ADD& po,
-                  const Cells& cells) const = 0;
+        ADDB rsSat(const ADDB& po,
+		   const Cells& cells) const = 0;
 
         /// Bubble point curve for Rs as function of oil pressure.
         /// \param[in]  po     Array of n oil pressure values.
@@ -290,9 +290,9 @@ namespace Opm
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n bubble point values for Rs.
         virtual
-        ADD rsSat(const ADD& po,
-                  const ADD& so,
-                  const Cells& cells) const = 0;
+        ADDB rsSat(const ADDB& po,
+		   const ADDB& so,
+		   const Cells& cells) const = 0;
 
         // ------ Rv condensation curve ------
 
@@ -321,8 +321,8 @@ namespace Opm
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n condensation point values for Rv.
         virtual
-        ADD rvSat(const ADD& po,
-                  const Cells& cells) const = 0;
+        ADDB rvSat(const ADDB& po,
+		   const Cells& cells) const = 0;
 
         /// Condensation curve for Rv as function of oil pressure.
         /// \param[in]  po     Array of n oil pressure values.
@@ -330,9 +330,9 @@ namespace Opm
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n condensation point values for Rv.
         virtual
-        ADD rvSat(const ADD& po,
-                  const ADD& so,
-                  const Cells& cells) const = 0;
+        ADDB rvSat(const ADDB& po,
+		   const ADDB& so,
+		   const Cells& cells) const = 0;
 
         // ------ Saturation functions ------
 
@@ -373,10 +373,10 @@ namespace Opm
         /// \return            An std::vector with 3 elements, each an array of n relperm values,
         ///                    containing krw, kro, krg. Use PhaseIndex for indexing into the result.
         virtual
-        std::vector<ADD> relperm(const ADD& sw,
-                                 const ADD& so,
-                                 const ADD& sg,
-                                 const Cells& cells) const = 0;
+        std::vector<ADDB> relperm(const ADDB& sw,
+				  const ADDB& so,
+				  const ADDB& sg,
+				  const Cells& cells) const = 0;
 
         /// Capillary pressure for all phases.
         /// \param[in]  sw     Array of n water saturation values.
@@ -387,10 +387,10 @@ namespace Opm
         ///                    containing the offsets for each p_g, p_o, p_w. The capillary pressure between
         ///                    two arbitrary phases alpha and beta is then given as p_alpha - p_beta.
         virtual
-        std::vector<ADD> capPress(const ADD& sw,
-                                  const ADD& so,
-                                  const ADD& sg,
-                                  const Cells& cells) const = 0;
+        std::vector<ADDB> capPress(const ADDB& sw,
+				   const ADDB& so,
+				   const ADDB& sg,
+				   const Cells& cells) const = 0;
 
         /// Saturation update for hysteresis behavior.
         /// \param[in]  cells       Array of n cell indices to be associated with the saturation values.

--- a/opm/autodiff/BlackoilPropsAdInterface.hpp
+++ b/opm/autodiff/BlackoilPropsAdInterface.hpp
@@ -21,6 +21,7 @@
 #define OPM_BLACKOILPROPSADINTERFACE_HEADER_INCLUDED
 
 #include <opm/autodiff/AutoDiffBlock.hpp>
+#include <opm/autodiff/AutoDiffDenseBlock.hpp>
 #include <opm/core/props/BlackoilPhases.hpp>
 
 namespace Opm
@@ -67,6 +68,7 @@ namespace Opm
         typedef AutoDiffBlock<double> ADB;
         typedef ADB::V V;
         typedef ADB::M M;
+        typedef AutoDiffDenseBlock<double, 3> ADD;
         typedef std::vector<int> Cells;
 
         /// \return   Number of active phases (also the number of components).
@@ -132,6 +134,46 @@ namespace Opm
                   const std::vector<PhasePresence>& cond,
                   const Cells& cells) const = 0;
 
+        // ------ Viscosity, dense interface ------
+
+        /// Water viscosity.
+        /// \param[in]  pw     Array of n water pressure values.
+        /// \param[in]  T      Array of n temperature values.
+        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+        /// \return            Array of n viscosity values.
+        virtual
+        ADD muWat(const ADD& pw,
+                  const ADD& T,
+                  const Cells& cells) const = 0;
+
+        /// Oil viscosity.
+        /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  T      Array of n temperature values.
+        /// \param[in]  rs     Array of n gas solution factor values.
+        /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
+        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+        /// \return            Array of n viscosity values.
+        virtual
+        ADD muOil(const ADD& po,
+                  const ADD& T,
+                  const ADD& rs,
+                  const std::vector<PhasePresence>& cond,
+                  const Cells& cells) const = 0;
+
+        /// Gas viscosity.
+        /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
+        /// \param[in]  rv     Array of n vapor oil/gas ratios.
+        /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
+        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+        /// \return            Array of n viscosity values.
+        virtual
+        ADD muGas(const ADD& pg,
+                  const ADD& T,
+                  const ADD& rv,
+                  const std::vector<PhasePresence>& cond,
+                  const Cells& cells) const = 0;
+
         // ------ Formation volume factor (b) ------
 
         /// Water formation volume factor.
@@ -172,6 +214,46 @@ namespace Opm
                  const std::vector<PhasePresence>& cond,
                  const Cells& cells) const = 0;
 
+        // ------ Formation volume factor (b) dense interface ------
+
+        /// Water formation volume factor.
+        /// \param[in]  pw     Array of n water pressure values.
+        /// \param[in]  T      Array of n temperature values.
+        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+        /// \return            Array of n formation volume factor values.
+        virtual
+        ADD bWat(const ADD& pw,
+                 const ADD& T,
+                 const Cells& cells) const = 0;
+
+        /// Oil formation volume factor.
+        /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  T      Array of n temperature values.
+        /// \param[in]  rs     Array of n gas solution factor values.
+        /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
+        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+        /// \return            Array of n formation volume factor values.
+        virtual
+        ADD bOil(const ADD& po,
+                 const ADD& T,
+                 const ADD& rs,
+                 const std::vector<PhasePresence>& cond,
+                 const Cells& cells) const = 0;
+
+        /// Gas formation volume factor.
+        /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
+        /// \param[in]  rv     Array of n vapor oil/gas ratios.
+        /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
+        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+        /// \return            Array of n formation volume factor values.
+        virtual
+        ADD bGas(const ADD& pg,
+                 const ADD& T,
+                 const ADD& rv,
+                 const std::vector<PhasePresence>& cond,
+                 const Cells& cells) const = 0;
+
         // ------ Rs bubble point curve ------
 
         /// Bubble point curve for Rs as function of oil pressure.
@@ -190,6 +272,26 @@ namespace Opm
         virtual
         ADB rsSat(const ADB& po,
                   const ADB& so,
+                  const Cells& cells) const = 0;
+
+        // ------ Rs bubble point curve, dense interface ------
+
+        /// Bubble point curve for Rs as function of oil pressure.
+        /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+        /// \return            Array of n bubble point values for Rs.
+        virtual
+        ADD rsSat(const ADD& po,
+                  const Cells& cells) const = 0;
+
+        /// Bubble point curve for Rs as function of oil pressure.
+        /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  so     Array of n oil saturation values.
+        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+        /// \return            Array of n bubble point values for Rs.
+        virtual
+        ADD rsSat(const ADD& po,
+                  const ADD& so,
                   const Cells& cells) const = 0;
 
         // ------ Rv condensation curve ------
@@ -212,7 +314,27 @@ namespace Opm
                   const ADB& so,
                   const Cells& cells) const = 0;
 
-        // ------ Relative permeability ------
+        // ------ Rv condensation curve, dense interface ------
+
+        /// Condensation curve for Rv as function of oil pressure.
+        /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+        /// \return            Array of n condensation point values for Rv.
+        virtual
+        ADD rvSat(const ADD& po,
+                  const Cells& cells) const = 0;
+
+        /// Condensation curve for Rv as function of oil pressure.
+        /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  so     Array of n oil saturation values.
+        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+        /// \return            Array of n condensation point values for Rv.
+        virtual
+        ADD rvSat(const ADD& po,
+                  const ADD& so,
+                  const Cells& cells) const = 0;
+
+        // ------ Saturation functions ------
 
         /// Relative permeabilities for all phases.
         /// \param[in]  sw     Array of n water saturation values.
@@ -226,7 +348,6 @@ namespace Opm
                                  const ADB& so,
                                  const ADB& sg,
                                  const Cells& cells) const = 0;
-
 
         /// Capillary pressure for all phases.
         /// \param[in]  sw     Array of n water saturation values.
@@ -242,6 +363,35 @@ namespace Opm
                                   const ADB& sg,
                                   const Cells& cells) const = 0;
                                   
+        // ------ Saturation functions, dense interface ------
+
+        /// Relative permeabilities for all phases.
+        /// \param[in]  sw     Array of n water saturation values.
+        /// \param[in]  so     Array of n oil saturation values.
+        /// \param[in]  sg     Array of n gas saturation values.
+        /// \param[in]  cells  Array of n cell indices to be associated with the saturation values.
+        /// \return            An std::vector with 3 elements, each an array of n relperm values,
+        ///                    containing krw, kro, krg. Use PhaseIndex for indexing into the result.
+        virtual
+        std::vector<ADD> relperm(const ADD& sw,
+                                 const ADD& so,
+                                 const ADD& sg,
+                                 const Cells& cells) const = 0;
+
+        /// Capillary pressure for all phases.
+        /// \param[in]  sw     Array of n water saturation values.
+        /// \param[in]  so     Array of n oil saturation values.
+        /// \param[in]  sg     Array of n gas saturation values.
+        /// \param[in]  cells  Array of n cell indices to be associated with the saturation values.
+        /// \return            An std::vector with 3 elements, each an array of n capillary pressure values,
+        ///                    containing the offsets for each p_g, p_o, p_w. The capillary pressure between
+        ///                    two arbitrary phases alpha and beta is then given as p_alpha - p_beta.
+        virtual
+        std::vector<ADD> capPress(const ADD& sw,
+                                  const ADD& so,
+                                  const ADD& sg,
+                                  const Cells& cells) const = 0;
+
         /// Saturation update for hysteresis behavior.
         /// \param[in]  cells       Array of n cell indices to be associated with the saturation values.
         virtual

--- a/opm/autodiff/BlackoilSolventModel.hpp
+++ b/opm/autodiff/BlackoilSolventModel.hpp
@@ -164,8 +164,9 @@ namespace Opm {
         using Base::updateWellControls;
         using Base::computeWellConnectionPressures;
         using Base::addWellControlEq;
+	using Base::blockPattern;
 
-        std::vector<ADB>
+        std::vector<ADDB>
         computeRelPerm(const SolutionState& state) const;
 
         void
@@ -181,7 +182,7 @@ namespace Opm {
         SolutionState
         variableStateExtractVars(const ReservoirState& x,
                                  const std::vector<int>& indices,
-                                 std::vector<ADB>& vars) const;
+                                 std::vector<ADDB>& vars) const;
 
         void
         computeAccum(const SolutionState& state,
@@ -198,8 +199,8 @@ namespace Opm {
         void
         computeMassFlux(const int               actph ,
                         const V&                transi,
-                        const ADB&              kr    ,
-                        const ADB&              p     ,
+                        const ADDB&             kr    ,
+                        const ADDB&             p     ,
                         const SolutionState&    state );
 
         const std::vector<PhasePresence>
@@ -245,10 +246,10 @@ namespace Opm {
     {
         explicit BlackoilSolventSolutionState(const int np)
             : DefaultBlackoilSolutionState(np),
-              solvent_saturation( ADB::null())
+              solvent_saturation( ADDB::null())
         {
         }
-        ADB solvent_saturation;
+        ADDB solvent_saturation;
     };
 
 

--- a/opm/autodiff/SolventPropsAdFromDeck.hpp
+++ b/opm/autodiff/SolventPropsAdFromDeck.hpp
@@ -50,6 +50,7 @@ public:
     typedef AutoDiffBlock<double> ADB;
     typedef ADB::V V;
     typedef std::vector<int> Cells;
+    typedef AutoDiffDenseBlock<double, 3> ADDB;
 
     /// Solvent formation volume factor.
     /// \param[in]  pg     Array of n gas pressure values.
@@ -78,6 +79,38 @@ public:
     /// \return                     Array of n solvent relPerm multiplier values.
     ADB solventRelPermMultiplier(const ADB& solventFraction,
               const Cells& cells) const;
+
+
+    // Dense block interfaces.
+
+    /// Solvent formation volume factor.
+    /// \param[in]  pg     Array of n gas pressure values.
+    /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+    /// \return            Array of n formation volume factor values.
+    ADDB bSolvent(const ADDB& pg,
+             const Cells& cells) const;
+
+    /// Solvent viscosity.
+    /// \param[in]  pg     Array of n gas pressure values.
+    /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+    /// \return            Array of n viscosity values.
+    ADDB muSolvent(const ADDB& pg,
+              const Cells& cells) const;
+
+    /// Gas relPerm multipliers
+    /// \param[in]  solventFraction Array of n solvent fraction values.
+    /// \param[in]  cells           Array of n cell indices to be associated with the fraction values.
+    /// \return                     Array of n gas relPerm multiplier values.
+    ADDB gasRelPermMultiplier(const ADDB& solventFraction,
+              const Cells& cells) const;
+
+    /// Solvent relPerm multipliers
+    /// \param[in]  solventFraction Array of n solvent fraction values.
+    /// \param[in]  cells           Array of n cell indices to be associated with the fraction values.
+    /// \return                     Array of n solvent relPerm multiplier values.
+    ADDB solventRelPermMultiplier(const ADDB& solventFraction,
+              const Cells& cells) const;
+
 
     /// Solvent surface density
     /// \param[in]  cells           Array of n cell indices to be associated with the fraction values.

--- a/tests/test_autodiffdense.cpp
+++ b/tests/test_autodiffdense.cpp
@@ -1,0 +1,214 @@
+/*
+  Copyright 2015 SINTEF ICT, Applied Mathematics.
+  Copyright 2015 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#define BOOST_TEST_MODULE AutoDiffDenseTest
+
+#include <opm/autodiff/AutoDiffDense.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+
+const double tolerance = 1.0e-14;
+const int NumDerivs = 2;
+typedef Opm::AutoDiffDense<double, NumDerivs> AdFW;
+typedef AdFW::Derivative Derivative;
+
+
+void checkCloseDerivs(const Derivative& d1, const Derivative& d2, const double tol)
+{
+    for (int dd : { 0, 1 }) {
+        BOOST_CHECK_CLOSE(d1[dd], d2[dd], tol);
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE(Initialisation)
+{
+    AdFW a = AdFW::variable(0, 0.0);
+    AdFW b = AdFW::variable(0, 1.0);
+
+    BOOST_CHECK_CLOSE(a.val(), 0.0, tolerance);
+    BOOST_CHECK_CLOSE(b.val(), 1.0, tolerance);
+    checkCloseDerivs(a.der(), b.der(), tolerance);
+
+    a = b;
+    BOOST_CHECK_EQUAL(a.val(), b.val());
+    checkCloseDerivs(a.der(), b.der(), tolerance);
+
+    AdFW c = AdFW::variable(1, 1.0);
+    BOOST_CHECK_EQUAL(c.val(), 1.0);
+    checkCloseDerivs(c.der(), { 0.0, 1.0 }, tolerance);
+}
+
+
+
+BOOST_AUTO_TEST_CASE(Addition)
+{
+    AdFW a = AdFW::variable(0, 0.0);
+    AdFW b = AdFW::variable(0, 1.0);
+
+    AdFW two_a = a + a;
+    BOOST_CHECK_CLOSE(two_a.val(), 2*a.val(), tolerance);
+    checkCloseDerivs(two_a.der(), 2*a.der(), tolerance);
+
+    double av = a.val();
+    Derivative ad = a.der();
+    a += b;
+    BOOST_CHECK_CLOSE(a.val(), av + b.val(), tolerance);
+    checkCloseDerivs(a.der(), ad + b.der(), tolerance);
+
+    av = a.val();
+    ad = a.der();
+    a += 1;
+    BOOST_CHECK_CLOSE(a.val(), av + 1, tolerance);
+    checkCloseDerivs(a.der(), ad    , tolerance);
+
+    AdFW bpo = b + 1;           // b plus one
+    BOOST_CHECK_CLOSE(bpo.val(), b.val() + 1, tolerance);
+    checkCloseDerivs(bpo.der(), b.der()    , tolerance);
+
+    AdFW opb = 1 + b;           // one plus b
+    BOOST_CHECK_CLOSE(opb.val(), b.val() + 1, tolerance);
+    checkCloseDerivs(opb.der(), b.der()    , tolerance);
+}
+
+
+
+BOOST_AUTO_TEST_CASE(Subtraction)
+{
+    AdFW a = AdFW::variable(0, 0.0);
+    AdFW b = AdFW::variable(0, 1.0);
+
+    AdFW no_a = a - a;
+    BOOST_CHECK_CLOSE(no_a.val(), 0.0, tolerance);
+    checkCloseDerivs(no_a.der(), { 0.0, 0.0 }, tolerance);
+
+    AdFW amb = a - b;
+    BOOST_CHECK_CLOSE(amb.val(), a.val() - b.val(), tolerance);
+    checkCloseDerivs(amb.der(), a.der() - b.der(), tolerance);
+
+    double av = a.val();
+    Derivative ad = a.der();
+    a -= b;
+    BOOST_CHECK_CLOSE(a.val(), av - b.val(), tolerance);
+    checkCloseDerivs(a.der(), ad - b.der(), tolerance);
+
+    av = a.val();
+    ad = a.der();
+    a -= 1;
+    BOOST_CHECK_CLOSE(a.val(), av - 1, tolerance);
+    checkCloseDerivs(a.der(), ad    , tolerance);
+
+    AdFW bmo = b - 1;           // b minus one
+    BOOST_CHECK_CLOSE(bmo.val(), b.val() - 1, tolerance);
+    checkCloseDerivs(bmo.der(), b.der()    , tolerance);
+
+    AdFW omb = 1 - b;           // one minus b
+    BOOST_CHECK_CLOSE(omb.val(), 1 - b.val(), tolerance);
+    checkCloseDerivs(omb.der(),   - b.der(), tolerance);
+}
+
+
+BOOST_AUTO_TEST_CASE(Multiplication)
+{
+    AdFW a = AdFW::variable(0, 0.0);
+    AdFW b = AdFW::variable(0, 1.0);
+
+    AdFW no_a = a * 0;
+    BOOST_CHECK_CLOSE(no_a.val(), 0.0, tolerance);
+    checkCloseDerivs(no_a.der(), { 0.0, 0.0 }, tolerance);
+
+    AdFW atb = a * b;
+    BOOST_CHECK_CLOSE(atb.val(), a.val() * b.val(), tolerance);
+    checkCloseDerivs(atb.der(), a.der()*b.val() + a.val()*b.der(), tolerance);
+
+    double av = a.val();
+    Derivative ad = a.der();
+    a *= b;
+    BOOST_CHECK_CLOSE(a.val(), av * b.val(), tolerance);
+    checkCloseDerivs(a.der(), ad*b.val() + av*b.der(), tolerance);
+
+    av = a.val();
+    ad = a.der();
+    a *= 1;
+    BOOST_CHECK_CLOSE(a.val(), av, tolerance);
+    checkCloseDerivs(a.der(), ad, tolerance);
+
+    AdFW bto = b * 1;           // b times one
+    BOOST_CHECK_CLOSE(bto.val(), b.val(), tolerance);
+    checkCloseDerivs(bto.der(), b.der(), tolerance);
+
+    AdFW otb = 1 * b;           // one times b
+    BOOST_CHECK_CLOSE(otb.val(), b.val(), tolerance);
+    checkCloseDerivs(otb.der(), b.der(), tolerance);
+}
+
+
+BOOST_AUTO_TEST_CASE(Division)
+{
+    AdFW a = AdFW::variable(0, 10.0);
+    AdFW b = AdFW::variable(0, 1.0);
+
+    AdFW aob = a / b;
+    BOOST_CHECK_CLOSE(aob.val(), a.val() * b.val(), tolerance);
+    const Derivative res = ((a.der()*b.val() - a.val()*b.der()) /
+                            (b.val() * b.val()));
+    checkCloseDerivs(aob.der(), res, tolerance);
+
+    double av = a.val();
+    Derivative ad = a.der();
+    a /= b;
+    BOOST_CHECK_CLOSE(a.val(), av * b.val(), tolerance);
+    checkCloseDerivs(a.der(), res, tolerance);
+
+    av = a.val();
+    ad = a.der();
+    a /= 2;
+    BOOST_CHECK_CLOSE(a.val(), av / 2, tolerance);
+    checkCloseDerivs(a.der(), ad / 2, tolerance);
+
+    AdFW bot = b / 2;           // b over two
+    BOOST_CHECK_CLOSE(bot.val(), b.val() / 2, tolerance);
+    checkCloseDerivs(bot.der(), b.der() / 2, tolerance);
+
+    AdFW otb = 2 / b;           // two over b
+    BOOST_CHECK_CLOSE(otb.val(), 2 / b.val(), tolerance);
+    checkCloseDerivs(otb.der(), -2*b.der() / (b.val() * b.val()), tolerance);
+}
+
+
+BOOST_AUTO_TEST_CASE(Polynomial)
+{
+    const AdFW x = AdFW::variable(0, 1.234e-1);
+
+    const AdFW p0 = x * x;
+    BOOST_CHECK_CLOSE(p0.val(), x.val() * x.val(), tolerance);
+    checkCloseDerivs(p0.der(), 2*x.val()*x.der(), tolerance);
+
+    const AdFW p = 10*x*x - x/2.0 + 3.0;
+    BOOST_CHECK_CLOSE(p.val(), 10  *x.val()*x.val() - x.val()/2.0 + 3.0, tolerance);
+    checkCloseDerivs(p.der(), 10*2*x.val()*x.der() - x.der()/2.0      , tolerance);
+}

--- a/tests/test_autodiffdenseblock.cpp
+++ b/tests/test_autodiffdenseblock.cpp
@@ -1,0 +1,210 @@
+/*
+  Copyright 2015 SINTEF ICT, Applied Mathematics.
+  Copyright 2015 Statoil AS.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#define BOOST_TEST_MODULE AutoDiffDenseBlockTest
+
+#include <opm/autodiff/AutoDiffDenseBlock.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace Opm;
+
+
+typedef AutoDiffDenseBlock<double, 3> ADD;
+typedef ADD::Value V;
+typedef ADD::Derivative D;
+
+
+
+BOOST_AUTO_TEST_CASE(ConstantInitialisation)
+{
+    V v(3);
+    v << 0.2, 1.2, 13.4;
+
+    ADD a = ADD::constant(v);
+    BOOST_CHECK(a.value().matrix() == v.matrix());
+
+    const D& da = a.derivative();
+    BOOST_CHECK((da == 0.0).all());
+}
+
+
+
+BOOST_AUTO_TEST_CASE(VariableInitialisation)
+{
+    V v(3);
+    v << 1.0, 2.2, 3.4;
+
+    enum { FirstVar = 0, SecondVar = 1, ThirdVar = 2 };
+
+    ADD x = ADD::variable(FirstVar, v);
+
+    BOOST_CHECK(x.value().matrix() == v.matrix());
+
+    const D& dx = x.derivative();
+    BOOST_CHECK((dx.col(FirstVar) == 1.0).all());
+    BOOST_CHECK((dx.col(SecondVar) == 0.0).all());
+    BOOST_CHECK((dx.col(ThirdVar) == 0.0).all());
+}
+
+
+
+BOOST_AUTO_TEST_CASE(FunctionInitialisation)
+{
+    V v(3);
+    v << 1.0, 2.2, 3.4;
+
+    enum { FirstVar = 0, SecondVar = 1, ThirdVar = 2 };
+
+    D jac = D::Zero(3, 3);
+    jac(0, 0) = -1.0;
+    jac(1, 2) = -1.0;
+    jac(0, 2) = -1.0;
+
+    V v_copy(v);
+    D jac_copy(jac);
+    ADD f = ADD::function(std::move(v_copy), std::move(jac_copy));
+
+    BOOST_CHECK(f.value().matrix() == v.matrix());
+    BOOST_CHECK(f.derivative().matrix() == jac.matrix());
+
+    jac(0, 2) = 23.0;
+
+    BOOST_CHECK(f.derivative().matrix() != jac.matrix());
+}
+
+
+
+BOOST_AUTO_TEST_CASE(Addition)
+{
+    V va(3);
+    va << 0.2, 1.2, 13.4;
+
+    V vx(3);
+    vx << 1.0, 2.2, 3.4;
+
+    enum { FirstVar = 0, SecondVar = 1, ThirdVar = 2 };
+
+    ADD a = ADD::constant(va);
+    ADD x = ADD::variable(FirstVar, vx);
+
+    ADD xpx = x + x;
+
+    BOOST_CHECK((xpx.value() == 2*x.value()).all());
+    BOOST_CHECK((xpx.derivative() == 2*x.derivative()).all());
+
+    V  r = 2*x.value() + a.value();
+    ADD xpxpa = x + x + a;
+    BOOST_CHECK(xpxpa.value().matrix() == r.matrix());
+    BOOST_CHECK((xpxpa.derivative() == 2*x.derivative()).all());
+}
+
+
+
+BOOST_AUTO_TEST_CASE(AssignAddSubtractOperators)
+{
+    // Basic testing of += and -=.
+    V vx(3);
+    vx << 0.2, 1.2, 13.4;
+
+    V vy(3);
+    vy << 1.0, 2.2, 3.4;
+
+    std::vector<V> vals{ vx, vy };
+    std::vector<ADD> vars = ADD::variables(vals);
+
+    const ADD x = vars[0];
+    const ADD y = vars[1];
+
+    ADD z = x;
+    z += y;
+    ADD sum = x + y;
+    const double tolerance = 1e-14;
+    BOOST_CHECK(z.value().isApprox(sum.value(), tolerance));
+    BOOST_CHECK(z.derivative().isApprox(sum.derivative(), tolerance));
+    z -= y;
+    BOOST_CHECK(z.value().isApprox(x.value(), tolerance));
+    BOOST_CHECK(z.derivative().isApprox(x.derivative(), tolerance));
+
+    // Testing the case when the left hand side is constant.
+    ADD yconst = ADD::constant(vy);
+    z = yconst;
+    z -= x;
+    ADD diff = yconst - x;
+    BOOST_CHECK(z.value().isApprox(diff.value(), tolerance));
+    BOOST_CHECK(z.derivative().isApprox(diff.derivative(), tolerance));
+    z += x;
+    BOOST_CHECK(z.value().isApprox(yconst.value(), tolerance));
+    BOOST_CHECK(z.derivative().isApprox(D::Zero(3, 3)));
+}
+
+
+
+BOOST_AUTO_TEST_CASE(Multiplication)
+{
+    V vx(3);
+    vx << 0.2, 1.2, 13.4;
+
+    V vy(3);
+    vy << 1.0, 2.2, 3.4;
+
+    std::vector<V> vals{ vx, vy };
+    std::vector<ADD> vars = ADD::variables(vals);
+
+    const ADD x = vars[0];
+    const ADD y = vars[1];
+
+    const ADD xxy = x * x * y;
+
+    const double tolerance = 1e-14;
+    BOOST_CHECK(xxy.value().isApprox(vx * vx * vy, tolerance));
+    BOOST_CHECK(xxy.derivative().col(0).isApprox(2.0 * vx * vy));
+    BOOST_CHECK(xxy.derivative().col(1).isApprox(vx * vx));
+}
+
+
+
+BOOST_AUTO_TEST_CASE(Division)
+{
+    V vx(3);
+    vx << 0.2, 1.2, 13.4;
+
+    V vy(3);
+    vy << 1.0, 2.2, 3.4;
+
+    std::vector<V> vals{ vx, vy };
+    std::vector<ADD> vars = ADD::variables(vals);
+
+    const ADD x = vars[0];
+    const ADD y = vars[1];
+
+    const ADD xxBy = x * x / y;
+
+    const double tolerance = 1e-14;
+    BOOST_CHECK(xxBy.value().isApprox(vx * vx / vy, tolerance));
+    BOOST_CHECK(xxBy.derivative().col(0).isApprox(2.0 * vx / vy));
+    BOOST_CHECK(xxBy.derivative().col(1).isApprox(-vx * vx / (vy * vy)));
+}

--- a/tests/test_autodiffdenseblock.cpp
+++ b/tests/test_autodiffdenseblock.cpp
@@ -33,9 +33,9 @@
 using namespace Opm;
 
 
-typedef AutoDiffDenseBlock<double, 3> ADD;
-typedef ADD::Value V;
-typedef ADD::Derivative D;
+typedef AutoDiffDenseBlock<double, 3> ADDB;
+typedef ADDB::Value V;
+typedef ADDB::Derivative D;
 
 
 
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(ConstantInitialisation)
     V v(3);
     v << 0.2, 1.2, 13.4;
 
-    ADD a = ADD::constant(v);
+    ADDB a = ADDB::constant(v);
     BOOST_CHECK(a.value().matrix() == v.matrix());
 
     const D& da = a.derivative();
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(VariableInitialisation)
 
     enum { FirstVar = 0, SecondVar = 1, ThirdVar = 2 };
 
-    ADD x = ADD::variable(FirstVar, v);
+    ADDB x = ADDB::variable(FirstVar, v);
 
     BOOST_CHECK(x.value().matrix() == v.matrix());
 
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(FunctionInitialisation)
 
     V v_copy(v);
     D jac_copy(jac);
-    ADD f = ADD::function(std::move(v_copy), std::move(jac_copy));
+    ADDB f = ADDB::function(std::move(v_copy), std::move(jac_copy));
 
     BOOST_CHECK(f.value().matrix() == v.matrix());
     BOOST_CHECK(f.derivative().matrix() == jac.matrix());
@@ -108,16 +108,16 @@ BOOST_AUTO_TEST_CASE(Addition)
 
     enum { FirstVar = 0, SecondVar = 1, ThirdVar = 2 };
 
-    ADD a = ADD::constant(va);
-    ADD x = ADD::variable(FirstVar, vx);
+    ADDB a = ADDB::constant(va);
+    ADDB x = ADDB::variable(FirstVar, vx);
 
-    ADD xpx = x + x;
+    ADDB xpx = x + x;
 
     BOOST_CHECK((xpx.value() == 2*x.value()).all());
     BOOST_CHECK((xpx.derivative() == 2*x.derivative()).all());
 
     V  r = 2*x.value() + a.value();
-    ADD xpxpa = x + x + a;
+    ADDB xpxpa = x + x + a;
     BOOST_CHECK(xpxpa.value().matrix() == r.matrix());
     BOOST_CHECK((xpxpa.derivative() == 2*x.derivative()).all());
 }
@@ -134,14 +134,14 @@ BOOST_AUTO_TEST_CASE(AssignAddSubtractOperators)
     vy << 1.0, 2.2, 3.4;
 
     std::vector<V> vals{ vx, vy };
-    std::vector<ADD> vars = ADD::variables(vals);
+    std::vector<ADDB> vars = ADDB::variables(vals);
 
-    const ADD x = vars[0];
-    const ADD y = vars[1];
+    const ADDB x = vars[0];
+    const ADDB y = vars[1];
 
-    ADD z = x;
+    ADDB z = x;
     z += y;
-    ADD sum = x + y;
+    ADDB sum = x + y;
     const double tolerance = 1e-14;
     BOOST_CHECK(z.value().isApprox(sum.value(), tolerance));
     BOOST_CHECK(z.derivative().isApprox(sum.derivative(), tolerance));
@@ -150,10 +150,10 @@ BOOST_AUTO_TEST_CASE(AssignAddSubtractOperators)
     BOOST_CHECK(z.derivative().isApprox(x.derivative(), tolerance));
 
     // Testing the case when the left hand side is constant.
-    ADD yconst = ADD::constant(vy);
+    ADDB yconst = ADDB::constant(vy);
     z = yconst;
     z -= x;
-    ADD diff = yconst - x;
+    ADDB diff = yconst - x;
     BOOST_CHECK(z.value().isApprox(diff.value(), tolerance));
     BOOST_CHECK(z.derivative().isApprox(diff.derivative(), tolerance));
     z += x;
@@ -172,12 +172,12 @@ BOOST_AUTO_TEST_CASE(Multiplication)
     vy << 1.0, 2.2, 3.4;
 
     std::vector<V> vals{ vx, vy };
-    std::vector<ADD> vars = ADD::variables(vals);
+    std::vector<ADDB> vars = ADDB::variables(vals);
 
-    const ADD x = vars[0];
-    const ADD y = vars[1];
+    const ADDB x = vars[0];
+    const ADDB y = vars[1];
 
-    const ADD xxy = x * x * y;
+    const ADDB xxy = x * x * y;
 
     const double tolerance = 1e-14;
     BOOST_CHECK(xxy.value().isApprox(vx * vx * vy, tolerance));
@@ -196,12 +196,12 @@ BOOST_AUTO_TEST_CASE(Division)
     vy << 1.0, 2.2, 3.4;
 
     std::vector<V> vals{ vx, vy };
-    std::vector<ADD> vars = ADD::variables(vals);
+    std::vector<ADDB> vars = ADDB::variables(vals);
 
-    const ADD x = vars[0];
-    const ADD y = vars[1];
+    const ADDB x = vars[0];
+    const ADDB y = vars[1];
 
-    const ADD xxBy = x * x / y;
+    const ADDB xxBy = x * x / y;
 
     const double tolerance = 1e-14;
     BOOST_CHECK(xxBy.value().isApprox(vx * vx / vy, tolerance));

--- a/tests/test_syntax.cpp
+++ b/tests/test_syntax.cpp
@@ -154,7 +154,7 @@ BOOST_AUTO_TEST_CASE(Division)
     const double atol = 1.0e-14;
 
     AdFW a = AdFW::variable(10.0);
-    AdFW b = AdFW::variable(1.0);
+    AdFW b = AdFW::function(1.0, 4.0);
 
     AdFW aob = a / b;
     BOOST_CHECK_CLOSE(aob.val(), a.val() * b.val(), atol);


### PR DESCRIPTION
Do not merge this PR yet!
 - It is experimental.
 - It changes some fundamental types used in the model.
 - It will cause downstream compile failures (opm-polymer).

I have put it up to show my experiments with the following basic idea: Do not invoke the sparse matrix machinery until absolutely necessary. In this branch, I have added a new AD class using a dense matrix for the derivatives (AutoDiffDenseBlock, called ADD in typedefs). The way it is used, I store cell-centered quantities using this new class, and only convert to the AutoDiffBlock class when I need to compute face-centered quantities. This gives a modest performance improvement, but since the conversion process is quite expensive (taking a significant chunk of the assembly time), and there might be ways to exploit it further, I think there is some worthwhile potential here.

I'd appreciate any comments, about the idea, its execution and implementation, and resulting gains (or not). It should reproduce identical results as before, but there is always a small risk of change so I would appreciate your test run results with this, for example on Norne.