### PR TITLE
BUGFIX: make it run without NNCs in the deck

### DIFF
--- a/opm/autodiff/AutoDiffHelpers.hpp
+++ b/opm/autodiff/AutoDiffHelpers.hpp
@@ -107,11 +107,7 @@ struct HelperOps
             }
             // store the nnc transmissibilities for later usage.
             nnc_trans = Eigen::Map<const V>(nnc->trans().data(), numNNC);
-        } else {
-            nnc_trans.resize(0);
-            nnc_cells.resize(0,0);
         }
-
 
         // std::cout << "nbi = \n" << nbi << std::endl;
         // Create matrices.


### PR DESCRIPTION
Remove resize to make it run when there is no NNC in the deck. 