### PR TITLE
Fixed Eigen array dimensions must be respected in resize().

### DIFF
--- a/opm/autodiff/AutoDiffHelpers.hpp
+++ b/opm/autodiff/AutoDiffHelpers.hpp
@@ -109,7 +109,7 @@ struct HelperOps
             nnc_trans = Eigen::Map<const V>(nnc->trans().data(), numNNC);
         } else {
             nnc_trans.resize(0);
-            nnc_cells.resize(0,0);
+            nnc_cells.resize(0, 2); // Required to have two columns.
         }
 
 


### PR DESCRIPTION
This caused Eigen assert() failures in debug mode when running without NNCs (which apply to all current test cases).

Will self-merge as it is a trivial-yet-critical fix.