### PR TITLE
Pass parallel info to NewtonIteration... classes.

### DIFF
--- a/examples/flow.cpp
+++ b/examples/flow.cpp
@@ -347,9 +347,9 @@ try
     // Solver for Newton iterations.
     std::unique_ptr<NewtonIterationBlackoilInterface> fis_solver;
     if (param.getDefault("use_interleaved", false)) {
-        fis_solver.reset(new NewtonIterationBlackoilInterleaved(param));
+        fis_solver.reset(new NewtonIterationBlackoilInterleaved(param, parallel_information));
     } else if (param.getDefault("use_cpr", true)) {
-        fis_solver.reset(new NewtonIterationBlackoilCPR(param));
+        fis_solver.reset(new NewtonIterationBlackoilCPR(param, parallel_information));
     } else {
         fis_solver.reset(new NewtonIterationBlackoilSimple(param, parallel_information));
     }


### PR DESCRIPTION
I think this is a serious bug for the parallel case, could you please check, @blattms?