### PR TITLE
Prevents initializing std::shared_ptr from nullptr to suit gcc-4.4

### DIFF
--- a/opm/autodiff/AutoDiffHelpers.hpp
+++ b/opm/autodiff/AutoDiffHelpers.hpp
@@ -69,7 +69,7 @@ struct HelperOps
 
     /// Constructs all helper vectors and matrices.
     template<class Grid>
-    HelperOps(const Grid& grid, Opm::EclipseStateConstPtr eclState = EclipseStateConstPtr (nullptr) )
+    HelperOps(const Grid& grid, Opm::EclipseStateConstPtr eclState = EclipseStateConstPtr () )
     {
         using namespace AutoDiffGrid;
         const int nc = numCells(grid);
@@ -84,7 +84,8 @@ struct HelperOps
         int numNNC = 0;
 
         // handle non-neighboring connections
-        std::shared_ptr<const NNC> nnc = eclState ? eclState->getNNC() : nullptr;
+        std::shared_ptr<const NNC> nnc = eclState ? eclState->getNNC()
+            : std::shared_ptr<const Opm::NNC>();
         const bool has_nnc = nnc && nnc->hasNNC();
         if (has_nnc) {
             numNNC = nnc->numNNC();


### PR DESCRIPTION
For g++-4.4 support for nullptr is not complete. Using it
to initialize an empty shared_ptr breaks compilation:
```
/home/mblatt/src/dune/opm/opm-autodiff/opm/autodiff/AutoDiffHelpers.hpp: In constructor ‘Opm::HelperOps::HelperOps(const Grid&, Opm::EclipseStateConstPtr)’:
/home/mblatt/src/dune/opm/opm-autodiff/opm/autodiff/AutoDiffHelpers.hpp:87: error: no match for ternary ‘operator?:’ in ‘(bool)eclState ? eclState->.Opm::EclipseState::getNNC() : nullptr’
/home/mblatt/src/dune/opm/opm-autodiff/opm/autodiff/AutoDiffHelpers.hpp:87: note: candidates are: operator?:(bool, const Opm::NNC* std::__shared_ptr<const Opm::NNC, (__gnu_cxx::_Lock_policy)2u>::*, const Opm::NNC* std::__shared_ptr<const Opm::NNC, (__gnu_cxx::_Lock_policy)2u>::*) <built-in>
/home/mblatt/src/dune/opm/opm-autodiff/opm/autodiff/AutoDiffHelpers.hpp:87: note:                 operator?:(bool, const Opm::NNC* std::__shared_ptr<const Opm::NNC, (__gnu_cxx::_Lock_policy)2u>::*, T*) <built-in>
```
Here no conversion to shared_ptr happens.

```
/home/mblatt/src/dune/opm/opm-autodiff/opm/autodiff/ImpesTPFAAD.cpp: In constructor ‘Opm::HelperOps::HelperOps(const Grid&, Opm::EclipseStateConstPtr) [with Grid = UnstructuredGrid]’:
/home/mblatt/src/dune/opm/opm-autodiff/opm/autodiff/ImpesTPFAAD.cpp:160: error: no matching function for call to ‘std::shared_ptr<const Opm::EclipseState>::shared_ptr(const dune_nullptr_t&)’
/usr/include/c++/4.4/bits/shared_ptr.h:1263: note: candidates are: std::shared_ptr<_Tp>::shared_ptr(std::shared_ptr<_Tp>&&) [with _Tp = const Opm::EclipseState]
/usr/include/c++/4.4/bits/shared_ptr.h:1238: note:                 std::shared_ptr<_Tp>::shared_ptr() [with _Tp = const Opm::EclipseState]
/usr/include/c++/4.4/bits/shared_ptr.h:1236: note:                 std::shared_ptr<const Opm::EclipseState>::shared_ptr(const std::shared_ptr<const Opm::EclipseState>&)
```
Here the DUNE's nullptr implementation is used with std::shared_ptr which are not
compatible.

We fix this by using the emptry constructor of std::shared_ptr to create a nullptr.