### PR TITLE
OPM-218: Fix for restart interval write

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -236,7 +236,8 @@ namespace Opm
     BlackoilOutputWriter::
     writeTimeStep(const SimulatorTimerInterface& timer,
                   const SimulatorState& state,
-                  const WellState& wellState)
+                  const WellState& wellState,
+                  bool substep)
     {
         // VTK output
         if( vtkWriter_ ) {
@@ -248,7 +249,7 @@ namespace Opm
         }
         // ECL output
         if ( eclWriter_ ) {
-            eclWriter_->writeTimeStep(timer, state, wellState);
+            eclWriter_->writeTimeStep(timer, state, wellState, substep);
         }
         // write backup file
         if( backupfile_ )

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -133,7 +133,8 @@ namespace Opm
         /** \copydoc Opm::OutputWriter::writeTimeStep */
         void writeTimeStep(const SimulatorTimerInterface& timer,
                            const SimulatorState& state,
-                           const WellState& )
+                           const WellState&,
+                           bool substep = false)
         {
             outputStateVtk(grid_, state, timer.currentStepNum(), outputDir_);
         }
@@ -162,7 +163,8 @@ namespace Opm
         /** \copydoc Opm::OutputWriter::writeTimeStep */
         void writeTimeStep(const SimulatorTimerInterface& timer,
                            const SimulatorState& reservoirState,
-                           const WellState& wellState)
+                           const WellState& wellState,
+                           bool substep = false)
         {
             const BlackoilState* state =
                 dynamic_cast< const BlackoilState* > (&reservoirState);
@@ -196,7 +198,8 @@ namespace Opm
         /** \copydoc Opm::OutputWriter::writeTimeStep */
         void writeTimeStep(const SimulatorTimerInterface& timer,
                            const SimulatorState& reservoirState,
-                           const WellState& wellState);
+                           const WellState& wellState,
+                           bool substep = false);
 
         /** \brief return output directory */
         const std::string& outputDirectory() const { return outputDir_; }


### PR DESCRIPTION
Added substep as a parameter to writeTimeStep to avoid writing adaptive timesteps for restart files.
Write of restart files does not fully support the writing of substeps, and for now leave out the writing of these to write correct restart files with the same dates as eclipse.
This PR must be merged together with https://github.com/OPM/opm-core/pull/836

