### PR TITLE
optimizing the formInterleavedSystem().

### DIFF
--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
@@ -105,8 +105,6 @@ namespace Opm
             eqs[phase] = eqs[phase] * matbalscale[phase];
         }
 
-        // Form modified system.
-        Eigen::SparseMatrix<double, Eigen::RowMajor> A;
         // calculating the size for b
         int size_b = 0;
         for (int elem = 0; elem < np; ++elem) {

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
@@ -227,9 +227,6 @@ namespace Opm
         }
 
         const int size = s.rows();
-        Span span[3] = { Span(size, 1, 0),
-                         Span(size, 1, size),
-                         Span(size, 1, 2*size) };
         for (int row = 0; row < size; ++row) {
             for (int col_ix = ia[row]; col_ix < ia[row + 1]; ++col_ix) {
                 const int col = ja[col_ix];

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
@@ -205,7 +205,7 @@ namespace Opm
         // corresponding to the jacobians with respect to pressure.
         // Use addition to get to the union structure.
         Eigen::SparseMatrix<double> structure = eqs[0].derivative()[0];
-        for (int phase = 0; phase < np; ++phase) {
+        for (int phase = 1; phase < np; ++phase) {
             structure += eqs[phase].derivative()[0];
         }
 

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -156,7 +156,6 @@ namespace Opm
         }
 
         void formInterleavedSystem(const std::vector<LinearisedBlackoilResidual::ADB>& eqs,
-                                   const Eigen::SparseMatrix<double, Eigen::RowMajor>& A,
                                    Mat& istlA) const;
 
         mutable int iterations_;


### PR DESCRIPTION
It avoids the using of `formEllipticSystem()` and `vercatCollapseJacs()`, which take a significant amount of computing time during the non-linear solutions.

The performance tests are conducted with the single option `use_interleaved=true` and all the other options defaulted. 

Testing with SPE9 indicates more than 10% performance enhancement. Testing with Norne only shows about 7% performance enhancement. It should also be a little more than 10% according to the profiling analysis. (My computer is showing some performance instability, which I am looking for causes. Different running with same parameters can show different performance (can be more than 10% different).)

To run through with Norne with `use_interleaved=true`, PR OPM/opm-core#851 is required. 

This PR is done with @atgeirr together. 
