### PR TITLE
Fix minor memory leak

### DIFF
--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -97,7 +97,8 @@ namespace Opm
         {
             // Construct scalar product.
             typedef Dune::ScalarProductChooser<Vector, POrComm, category> ScalarProductChooser;
-            auto sp = ScalarProductChooser::construct(parallelInformation);
+	    typedef std::unique_ptr<typename ScalarProductChooser::ScalarProduct> SPPointer;
+            SPPointer sp(ScalarProductChooser::construct(parallelInformation));
 
             // Construct preconditioner.
             auto precond = constructPrecond(opA, parallelInformation);

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -97,7 +97,7 @@ namespace Opm
         {
             // Construct scalar product.
             typedef Dune::ScalarProductChooser<Vector, POrComm, category> ScalarProductChooser;
-	    typedef std::unique_ptr<typename ScalarProductChooser::ScalarProduct> SPPointer;
+            typedef std::unique_ptr<typename ScalarProductChooser::ScalarProduct> SPPointer;
             SPPointer sp(ScalarProductChooser::construct(parallelInformation));
 
             // Construct preconditioner.


### PR DESCRIPTION
It appears I misunderstood the return type of the ScalarProductChooser, it happens to be a regular pointer that must be put in a smart pointer manually.