### PR TITLE
Silence unused argument warning.

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilSolvent_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilSolvent_impl.hpp
@@ -92,9 +92,9 @@ namespace Opm
     template <class GridT>
     void SimulatorFullyImplicitBlackoilSolvent<GridT>::
     handleAdditionalWellInflow(SimulatorTimer& timer,
-                                    WellsManager& wells_manager,
-                                    typename BaseType::WellState& well_state,
-                                    const Wells* wells)
+			       WellsManager& /*wells_manager*/,
+			       typename BaseType::WellState& well_state,
+			       const Wells* wells)
     {
         // compute solvent inflow
         if (deck_->hasKeyword("WSOLVENT")) {


### PR DESCRIPTION
The function in question could just as well lose the argument, but that would require a minor rewrite in opm-polymer as well.