### PR TITLE
update scaling factors for mass balance equations.

### DIFF
--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -208,6 +208,9 @@ namespace Opm {
         /// The number of active phases in the model.
         int numPhases() const;
 
+        /// Update the scaling factors for mass balance equations
+        void updateEquationsScaling();
+
     protected:
 
         // ---------  Types and enums  ---------

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -932,8 +932,8 @@ namespace detail {
         {
             if (active_[idx]) {
                 const int pos    = pu.phase_pos[idx];
-                const ADB& tempB = rq_[pos].b;
-                B = 1./tempB.value();
+                const ADB& temp_b = rq_[pos].b;
+                B = 1. / temp_b.value();
                 residual_.matbalscale[idx] = B.mean();
             }
         }

--- a/opm/autodiff/BlackoilModelParameters.cpp
+++ b/opm/autodiff/BlackoilModelParameters.cpp
@@ -47,6 +47,7 @@ namespace Opm
         tolerance_cnv_   = param.getDefault("tolerance_cnv", tolerance_cnv_);
         tolerance_wells_ = param.getDefault("tolerance_wells", tolerance_wells_ );
         solve_welleq_initially_ = param.getDefault("solve_welleq_initially",solve_welleq_initially_);
+        update_equations_scaling_ = param.getDefault("update_equations_scaling", update_equations_scaling_);
     }
 
 
@@ -63,6 +64,7 @@ namespace Opm
         tolerance_cnv_   = 1.0e-2;
         tolerance_wells_ = 1.0e-3;
         solve_welleq_initially_ = true;
+        update_equations_scaling_ = false;
     }
 
 

--- a/opm/autodiff/BlackoilModelParameters.hpp
+++ b/opm/autodiff/BlackoilModelParameters.hpp
@@ -46,6 +46,9 @@ namespace Opm
         /// Solve well equation initially
         bool solve_welleq_initially_;
 
+        /// Update scaling factors for mass balance equations
+        bool update_equations_scaling_;
+
         /// Construct from user parameters or defaults.
         explicit BlackoilModelParameters( const parameter::ParameterGroup& param );
 

--- a/opm/autodiff/LinearisedBlackoilResidual.hpp
+++ b/opm/autodiff/LinearisedBlackoilResidual.hpp
@@ -63,6 +63,8 @@ namespace Opm
         /// pressure specification.
         ADB well_eq;
 
+        std::array<double, 3> matbalscale;
+
         /// The size of the non-linear system.
         int sizeNonLinear() const;
     };

--- a/opm/autodiff/LinearisedBlackoilResidual.hpp
+++ b/opm/autodiff/LinearisedBlackoilResidual.hpp
@@ -63,7 +63,7 @@ namespace Opm
         /// pressure specification.
         ADB well_eq;
 
-        std::array<double, 3> matbalscale;
+        std::vector<double> matbalscale;
 
         /// The size of the non-linear system.
         int sizeNonLinear() const;

--- a/opm/autodiff/NewtonIterationBlackoilCPR.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilCPR.cpp
@@ -104,9 +104,8 @@ namespace Opm
         }
 
         // Scale material balance equations.
-        const double matbalscale[3] = { 1.1169, 1.0031, 0.0031 }; // HACK hardcoded instead of computed.
         for (int phase = 0; phase < np; ++phase) {
-            eqs[phase] = eqs[phase] * matbalscale[phase];
+            eqs[phase] = eqs[phase] * residual.matbalscale[phase];
         }
 
         // Add material balance equations (or other manipulations) to

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
@@ -102,9 +102,8 @@ namespace Opm
         }
 
         // Scale material balance equations.
-        const double matbalscale[3] = { 1.1169, 1.0031, 0.0031 }; // HACK hardcoded instead of computed.
         for (int phase = 0; phase < np; ++phase) {
-            eqs[phase] = eqs[phase] * matbalscale[phase];
+            eqs[phase] = eqs[phase] * residual.matbalscale[phase];
         }
 
         // calculating the size for b


### PR DESCRIPTION
Updating the scaling factors based on average formation volume factors during each time step instead of the hard-coded scaling factors. 

The hard-coded scaling factors are based on SPE9, while it has been working surprisingly well. 

The performance tests are little not stable though, which is still dominated by the general iteration process. 
For some input parameters, such as `solve_welleq_initially` and `use_interleaved` set true, with this PR, it can be faster for about 8%, while it still depends largely on whether some certain solution failures happens. 

For some other parameters, it can be slightly slower.

For SPE9, it can be slower, while for SPE9, the fast solution from my side is that no scaling for the mass balance equations with `use_interleaved`. 

With this PR, another `bool` command line option `update_equations_scaling` is added, which by default is set to be `false`. 