### PR TITLE
Add support for WCONINJH

### DIFF
--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -470,14 +470,14 @@ namespace Opm
                 WellMap::const_iterator i = wmap.find(wells->name[w]);
                 if (i != wmap.end()) {
                     WellConstPtr wp = i->second;
-                    const WellInjectionProperties& i = wp->getInjectionProperties(step);
-                    if (!i.predictionMode) {
+                    const WellInjectionProperties& injector = wp->getInjectionProperties(step);
+                    if (!injector.predictionMode) {
                         //History matching WCONINJEH
                         static const double invalid_alq = -std::numeric_limits<double>::max();
                         static const int invalid_vfp = -std::numeric_limits<int>::max();
                         // For WCONINJEH the BHP limit is set to a large number
                         // or a value specified using WELTARG
-                        double bhp_limit = (i.BHPLimit > 0) ? i.BHPLimit : std::numeric_limits<double>::max();
+                        double bhp_limit = (injector.BHPLimit > 0) ? injector.BHPLimit : std::numeric_limits<double>::max();
                         const int ok_bhp =
                                 well_controls_add_new(BHP, bhp_limit,
                                                       invalid_alq, invalid_vfp,


### PR DESCRIPTION
Explicitly adds bhp control on rate controlled history matching injector. The default bhp limit is a large number to make sure that the well does not switch. Alternatively bhp limit can be specified using
`WELTARG`. This is typically done to make sure the bhp limit stays within the pressure limits in the PVT tables. Support for `WELTARG` is also added to the history matching producers (`WCONHIST`) 

Tested to make sure that it does not effect the SPEs and norne. 