### PR TITLE
Fixes parallel sat oilmax size

### DIFF
--- a/opm/autodiff/RedistributeDataHandles.hpp
+++ b/opm/autodiff/RedistributeDataHandles.hpp
@@ -245,9 +245,10 @@ public:
           size_(1)
     {
         // satOilMax might be non empty. In this case we will need to send it, too.
+        // It has to have the same size as the cellPvtRegionIdx_
         if ( sendProps.satOilMax_.size()>0 )
         {
-            recvProps_.satOilMax_.resize(recvProps_.satOilMax_.size(),
+            recvProps_.satOilMax_.resize(recvProps_.cellPvtRegionIdx_.size(),
                                          -std::numeric_limits<double>::max());
             ++size_;
         }


### PR DESCRIPTION
Previously, we tried to make an empty container bigger by
resizing it with its current size. Of course this is wrong and does
not change anything. With this commit we use the size of another
container which already has the correct size.