### PR TITLE
Autodiff matrix types

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -33,7 +33,7 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/autodiff/NewtonIterationBlackoilSimple.cpp
 	opm/autodiff/NewtonIterationUtilities.cpp
 	opm/autodiff/GridHelpers.cpp
-#	opm/autodiff/ImpesTPFAAD.cpp
+	opm/autodiff/ImpesTPFAAD.cpp
 	opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
 #	opm/autodiff/SimulatorIncompTwophaseAd.cpp
 #	opm/autodiff/TransportSolverTwophaseAd.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -35,8 +35,8 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/autodiff/GridHelpers.cpp
 	opm/autodiff/ImpesTPFAAD.cpp
 	opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
-#	opm/autodiff/SimulatorIncompTwophaseAd.cpp
-#	opm/autodiff/TransportSolverTwophaseAd.cpp
+	opm/autodiff/SimulatorIncompTwophaseAd.cpp
+	opm/autodiff/TransportSolverTwophaseAd.cpp
 	opm/autodiff/BlackoilPropsAdFromDeck.cpp
 #	opm/autodiff/SolventPropsAdFromDeck.cpp
 	opm/autodiff/BlackoilModelParameters.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -38,7 +38,7 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/autodiff/SimulatorIncompTwophaseAd.cpp
 	opm/autodiff/TransportSolverTwophaseAd.cpp
 	opm/autodiff/BlackoilPropsAdFromDeck.cpp
-#	opm/autodiff/SolventPropsAdFromDeck.cpp
+	opm/autodiff/SolventPropsAdFromDeck.cpp
 	opm/autodiff/BlackoilModelParameters.cpp
 	opm/autodiff/WellDensitySegmented.cpp
 	opm/autodiff/LinearisedBlackoilResidual.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -33,12 +33,12 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/autodiff/NewtonIterationBlackoilSimple.cpp
 	opm/autodiff/NewtonIterationUtilities.cpp
 	opm/autodiff/GridHelpers.cpp
-	opm/autodiff/ImpesTPFAAD.cpp
+#	opm/autodiff/ImpesTPFAAD.cpp
 	opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
-	opm/autodiff/SimulatorIncompTwophaseAd.cpp
-	opm/autodiff/TransportSolverTwophaseAd.cpp
+#	opm/autodiff/SimulatorIncompTwophaseAd.cpp
+#	opm/autodiff/TransportSolverTwophaseAd.cpp
 	opm/autodiff/BlackoilPropsAdFromDeck.cpp
-	opm/autodiff/SolventPropsAdFromDeck.cpp
+#	opm/autodiff/SolventPropsAdFromDeck.cpp
 	opm/autodiff/BlackoilModelParameters.cpp
 	opm/autodiff/WellDensitySegmented.cpp
 	opm/autodiff/LinearisedBlackoilResidual.cpp
@@ -83,20 +83,20 @@ endif()
 # originally generated with the command:
 # find tutorials examples -name '*.c*' -printf '\t%p\n' | sort
 list (APPEND EXAMPLE_SOURCE_FILES
-	examples/find_zero.cpp
+#	examples/find_zero.cpp
 	examples/flow.cpp
-	examples/flow_solvent.cpp
-	examples/sim_2p_incomp_ad.cpp
-	examples/sim_simple.cpp
-	examples/opm_init_check.cpp
+#	examples/flow_solvent.cpp
+#	examples/sim_2p_incomp_ad.cpp
+#	examples/sim_simple.cpp
+#	examples/opm_init_check.cpp
 	)
 
 # programs listed here will not only be compiled, but also marked for
 # installation
 list (APPEND PROGRAM_SOURCE_FILES
-	examples/sim_2p_incomp_ad.cpp
+#	examples/sim_2p_incomp_ad.cpp
 	examples/flow.cpp
-        examples/opm_init_check.cpp
+#        examples/opm_init_check.cpp
 	)
 
 # originally generated with the command:

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -88,15 +88,15 @@ list (APPEND EXAMPLE_SOURCE_FILES
 	examples/flow_solvent.cpp
 	examples/sim_2p_incomp_ad.cpp
 	examples/sim_simple.cpp
-#	examples/opm_init_check.cpp
+	examples/opm_init_check.cpp
 	)
 
 # programs listed here will not only be compiled, but also marked for
 # installation
 list (APPEND PROGRAM_SOURCE_FILES
-#	examples/sim_2p_incomp_ad.cpp
+	examples/sim_2p_incomp_ad.cpp
 	examples/flow.cpp
-#        examples/opm_init_check.cpp
+	examples/opm_init_check.cpp
 	)
 
 # originally generated with the command:

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -83,11 +83,11 @@ endif()
 # originally generated with the command:
 # find tutorials examples -name '*.c*' -printf '\t%p\n' | sort
 list (APPEND EXAMPLE_SOURCE_FILES
-#	examples/find_zero.cpp
+	examples/find_zero.cpp
 	examples/flow.cpp
-#	examples/flow_solvent.cpp
-#	examples/sim_2p_incomp_ad.cpp
-#	examples/sim_simple.cpp
+	examples/flow_solvent.cpp
+	examples/sim_2p_incomp_ad.cpp
+	examples/sim_simple.cpp
 #	examples/opm_init_check.cpp
 	)
 

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -51,6 +51,7 @@ list (APPEND MAIN_SOURCE_FILES
 # find tests -name '*.cpp' -a ! -wholename '*/not-unit/*' -printf '\t%p\n' | sort
 list (APPEND TEST_SOURCE_FILES
 	tests/test_autodiffhelpers.cpp
+	tests/test_autodiffmatrix.cpp
 	tests/test_block.cpp
 	tests/test_boprops_ad.cpp
 	tests/test_rateconverter.cpp
@@ -104,6 +105,7 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/autodiff/AdditionalObjectDeleter.hpp
 	opm/autodiff/AutoDiffBlock.hpp
 	opm/autodiff/AutoDiffHelpers.hpp
+	opm/autodiff/AutoDiffMatrix.hpp
 	opm/autodiff/AutoDiff.hpp
 	opm/autodiff/BackupRestore.hpp
 	opm/autodiff/BlackoilModel.hpp

--- a/examples/sim_simple.cpp
+++ b/examples/sim_simple.cpp
@@ -228,7 +228,8 @@ try
         return EXIT_FAILURE;
     }
     // const Eigen::VectorXd dp = solver.solve(residual.value().matrix());
-    const V dp = solver.solve(residual.value().matrix()).array();
+    ADB::V residual_v = residual.value();
+    const V dp = solver.solve(residual_v.matrix()).array();
     if (solver.info() != Eigen::Success) {
         std::cerr << "Pressure/flow solve failure\n";
         return EXIT_FAILURE;
@@ -285,7 +286,8 @@ try
             std::cerr << "Transport Jacobian decomposition error\n";
             return EXIT_FAILURE;
         }
-        const V ds = solver.solve(transport_residual.value().matrix()).array();
+        ADB::V transport_residual_v = transport_residual.value();
+        const V ds = solver.solve(transport_residual_v.matrix()).array();
         if (solver.info() != Eigen::Success) {
             std::cerr << "Transport solve failure\n";
             return EXIT_FAILURE;

--- a/examples/sim_simple.cpp
+++ b/examples/sim_simple.cpp
@@ -116,7 +116,6 @@ try
 {
     typedef Opm::AutoDiffBlock<double> ADB;
     typedef ADB::V V;
-    typedef ADB::M M;
     typedef Eigen::SparseMatrix<double> S;
 
     Opm::time::StopWatch clock;

--- a/opm/autodiff/AutoDiffBlock.hpp
+++ b/opm/autodiff/AutoDiffBlock.hpp
@@ -158,7 +158,7 @@ namespace Opm
             }
             // ... then set the one corrresponding to this variable to identity.
             assert(blocksizes[index] == num_elem);
-	    jac[index] = M(M::IdentityMatrix, val.size());
+            jac[index] = M(M::IdentityMatrix, val.size());
             // if(val.size()>0)
             // {
             //     // if val is empty the following will run into an assertion
@@ -343,7 +343,7 @@ namespace Opm
             // D D1 = val_.matrix().asDiagonal();
             // D D2 = rhs.val_.matrix().asDiagonal();
             M D1(val_.matrix().asDiagonal());
-	    M D2(rhs.val_.matrix().asDiagonal());
+            M D2(rhs.val_.matrix().asDiagonal());
             for (int block = 0; block < num_blocks; ++block) {
                 assert(jac_[block].rows() == rhs.jac_[block].rows());
                 assert(jac_[block].cols() == rhs.jac_[block].cols());
@@ -382,8 +382,8 @@ namespace Opm
             // D D2 = rhs.val_.matrix().asDiagonal();
             // D D3 = (1.0/(rhs.val_*rhs.val_)).matrix().asDiagonal();
             M D1(val_.matrix().asDiagonal());
-	    M D2(rhs.val_.matrix().asDiagonal());
-	    M D3((1.0/(rhs.val_*rhs.val_)).matrix().asDiagonal());
+            M D2(rhs.val_.matrix().asDiagonal());
+            M D3((1.0/(rhs.val_*rhs.val_)).matrix().asDiagonal());
             for (int block = 0; block < num_blocks; ++block) {
                 assert(jac_[block].rows() == rhs.jac_[block].rows());
                 assert(jac_[block].cols() == rhs.jac_[block].cols());
@@ -412,8 +412,8 @@ namespace Opm
             int num_blocks = jac_.size();
             os << "Value =\n" << val_ << "\n\nJacobian =\n";
             for (int i = 0; i < num_blocks; ++i) {
-		Eigen::SparseMatrix<double> m;
-		jac_[i].toSparse(m);
+                Eigen::SparseMatrix<double> m;
+                jac_[i].toSparse(m);
                 os << "Sub Jacobian #" << i << '\n' << m << "\n";
             }
             return os;

--- a/opm/autodiff/AutoDiffBlock.hpp
+++ b/opm/autodiff/AutoDiffBlock.hpp
@@ -28,6 +28,9 @@
 
 #include <opm/core/utility/platform_dependent/reenable_warnings.h>
 
+#include <opm/autodiff/AutoDiffMatrix.hpp>
+
+
 #include <utility>
 #include <vector>
 #include <cassert>
@@ -94,7 +97,7 @@ namespace Opm
         /// Underlying type for values.
         typedef Eigen::Array<Scalar, Eigen::Dynamic, 1> V;
         /// Underlying type for jacobians.
-        typedef Eigen::SparseMatrix<Scalar> M;
+        typedef AutoDiffMatrix M;
 
         /// Construct an empty AutoDiffBlock.
         static AutoDiffBlock null()
@@ -155,22 +158,23 @@ namespace Opm
             }
             // ... then set the one corrresponding to this variable to identity.
             assert(blocksizes[index] == num_elem);
-            if(val.size()>0)
-            {
-                // if val is empty the following will run into an assertion
-                // with Eigen
-                jac[index].reserve(Eigen::VectorXi::Constant(val.size(), 1));
-                for (typename M::Index row = 0; row < val.size(); ++row) {
-                    jac[index].insert(row, row) = Scalar(1.0);
-                }
-            }
-            else
-            {
-                // Do some check. Empty jacobian only make sense for empty val.
-                for (int i = 0; i < num_blocks; ++i) {
-                    assert(jac[i].size()==0);
-            }
-            }
+	    jac[index] = M(M::IdentityMatrix, val.size());
+            // if(val.size()>0)
+            // {
+            //     // if val is empty the following will run into an assertion
+            //     // with Eigen
+            //     jac[index].reserve(Eigen::VectorXi::Constant(val.size(), 1));
+            //     for (typename M::Index row = 0; row < val.size(); ++row) {
+            //         jac[index].insert(row, row) = Scalar(1.0);
+            //     }
+            // }
+            // else
+            // {
+            //     // Do some check. Empty jacobian only make sense for empty val.
+            //     for (int i = 0; i < num_blocks; ++i) {
+            //         assert(jac[i].size()==0);
+            // }
+            // }
             return AutoDiffBlock(std::move(val), std::move(jac));
         }
 
@@ -254,7 +258,8 @@ namespace Opm
                 const int num_blocks = rhs.numBlocks();
                 jac_.resize(num_blocks);
                 for (int block = 0; block < num_blocks; ++block) {
-                    jac_[block] = -rhs.jac_[block];
+                    // jac_[block] = -rhs.jac_[block];
+                    jac_[block] = rhs.jac_[block] * (-1.0);
                 }
             } else if (!rhs.jac_.empty()) {
                 assert (numBlocks()    == rhs.numBlocks());
@@ -334,9 +339,11 @@ namespace Opm
             int num_blocks = numBlocks();
             std::vector<M> jac(num_blocks);
             assert(numBlocks() == rhs.numBlocks());
-            typedef Eigen::DiagonalMatrix<Scalar, Eigen::Dynamic> D;
-            D D1 = val_.matrix().asDiagonal();
-            D D2 = rhs.val_.matrix().asDiagonal();
+            // typedef Eigen::DiagonalMatrix<Scalar, Eigen::Dynamic> D;
+            // D D1 = val_.matrix().asDiagonal();
+            // D D2 = rhs.val_.matrix().asDiagonal();
+            M D1(val_.matrix().asDiagonal());
+	    M D2(rhs.val_.matrix().asDiagonal());
             for (int block = 0; block < num_blocks; ++block) {
                 assert(jac_[block].rows() == rhs.jac_[block].rows());
                 assert(jac_[block].cols() == rhs.jac_[block].cols());
@@ -371,9 +378,12 @@ namespace Opm
             std::vector<M> jac(num_blocks);
             assert(numBlocks() == rhs.numBlocks());
             typedef Eigen::DiagonalMatrix<Scalar, Eigen::Dynamic> D;
-            D D1 = val_.matrix().asDiagonal();
-            D D2 = rhs.val_.matrix().asDiagonal();
-            D D3 = (1.0/(rhs.val_*rhs.val_)).matrix().asDiagonal();
+            // D D1 = val_.matrix().asDiagonal();
+            // D D2 = rhs.val_.matrix().asDiagonal();
+            // D D3 = (1.0/(rhs.val_*rhs.val_)).matrix().asDiagonal();
+            M D1(val_.matrix().asDiagonal());
+	    M D2(rhs.val_.matrix().asDiagonal());
+	    M D3((1.0/(rhs.val_*rhs.val_)).matrix().asDiagonal());
             for (int block = 0; block < num_blocks; ++block) {
                 assert(jac_[block].rows() == rhs.jac_[block].rows());
                 assert(jac_[block].cols() == rhs.jac_[block].cols());
@@ -381,15 +391,14 @@ namespace Opm
                     jac[block] = M( D3.rows(), jac_[block].cols() );
                 }
                 else if( jac_[block].nonZeros() == 0 ) {
-                    jac[block] = D3 * ( D1*rhs.jac_[block]);
-                    jac[block] *= -1.0;
+                    jac[block] =  D3 * ( D1*rhs.jac_[block]) * (-1.0);
                 }
                 else if ( rhs.jac_[block].nonZeros() == 0 )
                 {
                     jac[block] = D3 * (D2*jac_[block]);
                 }
                 else {
-                    jac[block] = D3 * (D2*jac_[block] - D1*rhs.jac_[block]);
+                    jac[block] = D3 * (D2*jac_[block] + (D1*rhs.jac_[block]*(-1.0)));
                 }
             }
             return function(val_ / rhs.val_, std::move(jac));
@@ -489,9 +498,26 @@ namespace Opm
     }
 
 
-    /// Multiply with sparse matrix from the left.
+    /// Multiply with AutoDiffMatrix from the left.
     template <typename Scalar>
     AutoDiffBlock<Scalar> operator*(const typename AutoDiffBlock<Scalar>::M& lhs,
+                                    const AutoDiffBlock<Scalar>& rhs)
+    {
+        int num_blocks = rhs.numBlocks();
+        std::vector<typename AutoDiffBlock<Scalar>::M> jac(num_blocks);
+        assert(lhs.cols() == rhs.value().rows());
+        for (int block = 0; block < num_blocks; ++block) {
+            // jac[block] = lhs*rhs.derivative()[block];
+            fastSparseProduct(lhs, rhs.derivative()[block], jac[block]);
+        }
+        typename AutoDiffBlock<Scalar>::V val = lhs*rhs.value().matrix();
+        return AutoDiffBlock<Scalar>::function(std::move(val), std::move(jac));
+    }
+
+
+    /// Multiply with Eigen sparse matrix from the left.
+    template <typename Scalar>
+    AutoDiffBlock<Scalar> operator*(const Eigen::SparseMatrix<Scalar>& lhs,
                                     const AutoDiffBlock<Scalar>& rhs)
     {
         int num_blocks = rhs.numBlocks();

--- a/opm/autodiff/AutoDiffBlock.hpp
+++ b/opm/autodiff/AutoDiffBlock.hpp
@@ -339,9 +339,6 @@ namespace Opm
             int num_blocks = numBlocks();
             std::vector<M> jac(num_blocks);
             assert(numBlocks() == rhs.numBlocks());
-            // typedef Eigen::DiagonalMatrix<Scalar, Eigen::Dynamic> D;
-            // D D1 = val_.matrix().asDiagonal();
-            // D D2 = rhs.val_.matrix().asDiagonal();
             M D1(val_.matrix().asDiagonal());
             M D2(rhs.val_.matrix().asDiagonal());
             for (int block = 0; block < num_blocks; ++block) {
@@ -377,10 +374,6 @@ namespace Opm
             int num_blocks = numBlocks();
             std::vector<M> jac(num_blocks);
             assert(numBlocks() == rhs.numBlocks());
-            typedef Eigen::DiagonalMatrix<Scalar, Eigen::Dynamic> D;
-            // D D1 = val_.matrix().asDiagonal();
-            // D D2 = rhs.val_.matrix().asDiagonal();
-            // D D3 = (1.0/(rhs.val_*rhs.val_)).matrix().asDiagonal();
             M D1(val_.matrix().asDiagonal());
             M D2(rhs.val_.matrix().asDiagonal());
             M D3((1.0/(rhs.val_*rhs.val_)).matrix().asDiagonal());

--- a/opm/autodiff/AutoDiffBlock.hpp
+++ b/opm/autodiff/AutoDiffBlock.hpp
@@ -412,7 +412,9 @@ namespace Opm
             int num_blocks = jac_.size();
             os << "Value =\n" << val_ << "\n\nJacobian =\n";
             for (int i = 0; i < num_blocks; ++i) {
-                os << "Sub Jacobian #" << i << '\n' << jac_[i] << "\n";
+		Eigen::SparseMatrix<double> m;
+		jac_[i].toSparse(m);
+                os << "Sub Jacobian #" << i << '\n' << m << "\n";
             }
             return os;
         }

--- a/opm/autodiff/AutoDiffBlock.hpp
+++ b/opm/autodiff/AutoDiffBlock.hpp
@@ -159,22 +159,6 @@ namespace Opm
             // ... then set the one corrresponding to this variable to identity.
             assert(blocksizes[index] == num_elem);
             jac[index] = M(M::IdentityMatrix, val.size());
-            // if(val.size()>0)
-            // {
-            //     // if val is empty the following will run into an assertion
-            //     // with Eigen
-            //     jac[index].reserve(Eigen::VectorXi::Constant(val.size(), 1));
-            //     for (typename M::Index row = 0; row < val.size(); ++row) {
-            //         jac[index].insert(row, row) = Scalar(1.0);
-            //     }
-            // }
-            // else
-            // {
-            //     // Do some check. Empty jacobian only make sense for empty val.
-            //     for (int i = 0; i < num_blocks; ++i) {
-            //         assert(jac[i].size()==0);
-            // }
-            // }
             return AutoDiffBlock(std::move(val), std::move(jac));
         }
 
@@ -258,7 +242,6 @@ namespace Opm
                 const int num_blocks = rhs.numBlocks();
                 jac_.resize(num_blocks);
                 for (int block = 0; block < num_blocks; ++block) {
-                    // jac_[block] = -rhs.jac_[block];
                     jac_[block] = rhs.jac_[block] * (-1.0);
                 }
             } else if (!rhs.jac_.empty()) {
@@ -502,7 +485,6 @@ namespace Opm
         std::vector<typename AutoDiffBlock<Scalar>::M> jac(num_blocks);
         assert(lhs.cols() == rhs.value().rows());
         for (int block = 0; block < num_blocks; ++block) {
-            // jac[block] = lhs*rhs.derivative()[block];
             fastSparseProduct(lhs, rhs.derivative()[block], jac[block]);
         }
         typename AutoDiffBlock<Scalar>::V val = lhs*rhs.value().matrix();
@@ -519,7 +501,6 @@ namespace Opm
         std::vector<typename AutoDiffBlock<Scalar>::M> jac(num_blocks);
         assert(lhs.cols() == rhs.value().rows());
         for (int block = 0; block < num_blocks; ++block) {
-            // jac[block] = lhs*rhs.derivative()[block];
             fastSparseProduct(lhs, rhs.derivative()[block], jac[block]);
         }
         typename AutoDiffBlock<Scalar>::V val = lhs*rhs.value().matrix();

--- a/opm/autodiff/AutoDiffHelpers.hpp
+++ b/opm/autodiff/AutoDiffHelpers.hpp
@@ -464,9 +464,11 @@ collapseJacs(const AutoDiffBlock<double>& x, Matrix& jacobian)
 	jac1.toSparse(jac);
         for (Eigen::SparseMatrix<double>::Index k = 0; k < jac.outerSize(); ++k) {
             for (Eigen::SparseMatrix<double>::InnerIterator i(jac, k); i ; ++i) {
-                t.push_back(Tri(i.row(),
-                                i.col() + block_col_start,
-                                i.value()));
+		if (i.value() != 0.0) {
+		    t.push_back(Tri(i.row(),
+				    i.col() + block_col_start,
+				    i.value()));
+		}
             }
         }
         block_col_start += jac.cols();

--- a/opm/autodiff/AutoDiffHelpers.hpp
+++ b/opm/autodiff/AutoDiffHelpers.hpp
@@ -251,7 +251,7 @@ struct HelperOps
         }
 
     private:
-	Eigen::SparseMatrix<double> select_;
+        Eigen::SparseMatrix<double> select_;
     };
 
 
@@ -460,15 +460,15 @@ collapseJacs(const AutoDiffBlock<double>& x, Matrix& jacobian)
     int block_col_start = 0;
     for (int block = 0; block < nb; ++block) {
         const ADB::M& jac1 = x.derivative()[block];
-	Eigen::SparseMatrix<double> jac;
-	jac1.toSparse(jac);
+        Eigen::SparseMatrix<double> jac;
+        jac1.toSparse(jac);
         for (Eigen::SparseMatrix<double>::Index k = 0; k < jac.outerSize(); ++k) {
             for (Eigen::SparseMatrix<double>::InnerIterator i(jac, k); i ; ++i) {
-		if (i.value() != 0.0) {
-		    t.push_back(Tri(i.row(),
-				    i.col() + block_col_start,
-				    i.value()));
-		}
+                if (i.value() != 0.0) {
+                    t.push_back(Tri(i.row(),
+                                    i.col() + block_col_start,
+                                    i.value()));
+                }
             }
         }
         block_col_start += jac.cols();
@@ -588,8 +588,8 @@ vertcatCollapseJacs(const std::vector<AutoDiffBlock<double> >& x)
         if (!x[elem].derivative().empty()) {
             for (int block = 0; block < num_blocks; ++block) {
                 // const ADB::M& jac = x[elem].derivative()[block];
-		M jac;
-		x[elem].derivative()[block].toSparse(jac);
+                M jac;
+                x[elem].derivative()[block].toSparse(jac);
                 for (M::Index k = 0; k < jac.outerSize(); ++k) {
                     for (M::InnerIterator i(jac, k); i ; ++i) {
                         t.push_back(Tri(i.row() + block_row_start,

--- a/opm/autodiff/AutoDiffHelpers.hpp
+++ b/opm/autodiff/AutoDiffHelpers.hpp
@@ -39,7 +39,6 @@ namespace Opm
 /// operations on (AD or regular) vectors of data.
 struct HelperOps
 {
-    // typedef AutoDiffBlock<double>::M M;
     typedef Eigen::SparseMatrix<double> M;
     typedef AutoDiffBlock<double>::V V;
 
@@ -337,11 +336,9 @@ superset(const Eigen::Array<Scalar, Eigen::Dynamic, 1>& x,
 /// elements of d on the diagonal.
 /// Need to mark this as inline since it is defined in a header and not a template.
 inline
-//AutoDiffBlock<double>::M
 Eigen::SparseMatrix<double>
 spdiag(const AutoDiffBlock<double>::V& d)
 {
-    // typedef AutoDiffBlock<double>::M M;
     typedef Eigen::SparseMatrix<double> M;
 
     const int n = d.size();
@@ -587,7 +584,6 @@ vertcatCollapseJacs(const std::vector<AutoDiffBlock<double> >& x)
             int block_col_start = 0;
             if (!x[elem].derivative().empty()) {
                 for (int block = 0; block < num_blocks; ++block) {
-                    // const ADB::M& jac = x[elem].derivative()[block];
                     x[elem].derivative()[block].toSparse(jac);
                     for (M::Index k = 0; k < jac.outerSize(); ++k) {
                         for (M::InnerIterator i(jac, k); i ; ++i) {

--- a/opm/autodiff/AutoDiffHelpers.hpp
+++ b/opm/autodiff/AutoDiffHelpers.hpp
@@ -496,7 +496,6 @@ collapseJacs(const AutoDiffBlock<double>& x)
 }
 
 
-    /*
 
 /// Returns the vertical concatenation [ x; y ] of the inputs.
 inline
@@ -519,7 +518,6 @@ vertcat(const AutoDiffBlock<double>& x,
 }
 
 
-    */
 
 
 /// Returns the vertical concatenation [ x[0]; x[1]; ...; x[n-1] ] of the inputs.

--- a/opm/autodiff/AutoDiffMatrix.hpp
+++ b/opm/autodiff/AutoDiffMatrix.hpp
@@ -1,0 +1,248 @@
+/*
+  Copyright 2014 SINTEF ICT, Applied Mathematics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_AUTODIFFMATRIX_HEADER_INCLUDED
+#define OPM_AUTODIFFMATRIX_HEADER_INCLUDED
+
+#include <opm/core/utility/platform_dependent/disable_warnings.h>
+
+#include <Eigen/Eigen>
+#include <Eigen/Sparse>
+
+#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+
+
+namespace Opm
+{
+
+    /// Implementation details for class AutoDiffMatrix.
+    namespace AutoDiffMatrixDetail
+    {
+
+
+        class Zero;
+        class Identity;
+        class Diagonal;
+        class Sparse;
+        typedef std::shared_ptr<Zero> ZeroMat;
+        typedef std::shared_ptr<Identity> IdentityMat;
+        typedef std::shared_ptr<Diagonal> DiagonalMat;
+        typedef std::shared_ptr<Sparse> SparseMat;
+
+
+
+
+
+
+        class Interface
+        {
+        public:
+            typedef std::shared_ptr<Interface> Mat;
+
+            virtual ~Interface()
+            {
+            }
+
+            virtual Mat operator+(const Mat& rhs) = 0;
+            virtual Mat addIdentity(const IdentityMat& rhs) = 0;
+            virtual Mat addDiagonal(const DiagonalMat& rhs) = 0;
+            virtual Mat addSparse(const SparsMate& rhs) = 0;
+
+            virtual Mat operator*(const Mat& rhs) = 0;
+            virtual Mat leftMulDiagonal(const DiagonalMat& rhs) = 0;
+            virtual Mat leftMulSparse(const SparseMat& rhs) = 0;
+        };
+
+
+
+
+
+
+        class Zero : public Interface
+        {
+        public:
+            virtual Mat operator+(const Mat& rhs)
+            {
+                return rhs;
+            }
+
+            virtual Mat addIdentity(const IdentityMat& rhs)
+            {
+                return rhs;
+            }
+
+            virtual Mat addDiagonal(const DiagonalMat& rhs)
+            {
+                return rhs;
+            }
+
+            virtual Mat addSparse(const SparseMat& rhs)
+            {
+                return rhs;
+            }
+
+
+            virtual Mat operator*(const Mat& rhs)
+            {
+                return std::make_shared<Zero>();
+            }
+
+            virtual Mat leftMulDiagonal(const DiagonalMat& rhs)
+            {
+                return std::make_shared<Zero>();
+            }
+
+            virtual Mat leftMulSparse(const SparseMat& rhs)
+            {
+                return std::make_shared<Zero>();
+            }
+        };
+
+
+
+
+
+        class Identity : public Interface
+        {
+        public:
+            virtual Mat operator+(const Mat& rhs)
+            {
+                return rhs->addIdentity(*this);
+            }
+
+            virtual Mat addIdentity(const IdentityMat& rhs)
+            {
+                return rhs;
+            }
+
+            virtual Mat addDiagonal(const DiagonalMat& rhs)
+            {
+                return rhs;
+            }
+
+            virtual Mat addSparse(const SparseMat& rhs)
+            {
+                return rhs;
+            }
+
+
+            virtual Mat operator*(const Mat& rhs)
+            {
+                return std::make_shared<Zero>();
+            }
+
+            virtual Mat leftMulDiagonal(const DiagonalMat& rhs)
+            {
+                return std::make_shared<Zero>();
+            }
+
+            virtual Mat leftMulSparse(const SparseMat& rhs)
+            {
+                return std::make_shared<Zero>();
+            }
+        };
+
+
+
+
+
+        class Diagonal : public Interface
+        {
+        public:
+            virtual Mat operator+(const Mat& rhs)
+            {
+                return (*rhs) + (*this);
+            }
+            operator+(const IdentityMat& rhs)
+            {
+                // TODO return Diagnonal(...);
+            }
+            operator+(const DiagonalMat& rhs)
+            {
+                // TODO return Diagonal(...);
+            }
+            operator+(const SparseMat& rhs)
+            {
+                // TODO return Sparse(...);
+            }
+
+            virtual Mat operator*(const Mat& rhs)
+            {
+                return (*rhs) * (;
+            }
+            Mat operator*(const IdentityMat& rhs)
+            {
+                return *this;
+            }
+            Mat operator*(const DiagonalMat& rhs)
+            {
+                // TODO return Diagonal(...);
+            }
+            Mat operator*(const SparseMat& rhs)
+            {
+                // TODO return Sparse(...);
+            }
+        };
+
+
+
+
+
+        class Sparse : public Interface
+        {
+            virtual Mat operator+(const Mat& rhs)
+            {
+                return (*rhs) + (*this);
+            }
+            operator+(const IdentityMat& rhs)
+            {
+                // TODO return Sparse(...);
+            }
+            operator+(const DiagonalMat& rhs)
+            {
+                // TODO return Sparse(...);
+            }
+            operator+(const SparseMat& rhs)
+            {
+                // TODO return Sparse(...);
+            }
+
+            virtual Mat operator*(const Mat& rhs)
+            {
+                return rhs;
+            }
+            Mat operator*(const IdentityMat& rhs)
+            {
+                return *this;
+            }
+            Mat operator*(const DiagonalMat& rhs)
+            {
+                // TODO return Sparse(...);
+            }
+            Mat operator*(const SparseMat& rhs)
+            {
+                // TODO return Sparse(...);
+            }
+        };
+
+    } // namespace AutoDiffMatrixDetail
+} // namespace Opm
+
+
+#endif // OPM_AUTODIFFMATRIX_HEADER_INCLUDED

--- a/opm/autodiff/AutoDiffMatrix.hpp
+++ b/opm/autodiff/AutoDiffMatrix.hpp
@@ -462,8 +462,7 @@ namespace Opm
             retval.type_ = S;
             retval.rows_ = lhs.rows_;
             retval.cols_ = rhs.cols_;
-            retval.sparse_[0] = Sparse(retval.rows_, retval.cols_);
-            fastDiagSparseProduct(lhs.diag_, rhs.sparse_[0], retval.sparse_[0]);
+            retval.sparse_[0] = std::move(fastDiagSparseProduct(lhs.diag_, rhs.sparse_[0]));
             return retval;
         }
 
@@ -475,8 +474,7 @@ namespace Opm
             retval.type_ = S;
             retval.rows_ = lhs.rows_;
             retval.cols_ = rhs.cols_;
-            retval.sparse_[0] = Sparse(retval.rows_, retval.cols_);
-            fastSparseDiagProduct(lhs.sparse_[0], rhs.diag_, retval.sparse_[0]);
+            retval.sparse_[0] = std::move(fastSparseDiagProduct(lhs.sparse_[0], rhs.diag_));
             return retval;
         }
 
@@ -488,8 +486,7 @@ namespace Opm
             retval.type_ = S;
             retval.rows_ = lhs.rows_;
             retval.cols_ = rhs.cols_;
-            retval.sparse_[0] = Sparse(retval.rows_, retval.cols_);
-            fastSparseProduct(lhs.sparse_[0], rhs.sparse_[0], retval.sparse_[0]);
+            retval.sparse_[0] = std::move(fastSparseProduct<Sparse>(lhs.sparse_[0], rhs.sparse_[0]));
             return retval;
         }
 

--- a/opm/autodiff/AutoDiffMatrix.hpp
+++ b/opm/autodiff/AutoDiffMatrix.hpp
@@ -414,12 +414,12 @@ namespace Opm
         }
 
 
-
-        void toSparse(Eigen::SparseMatrix<double>& s) const
+        template<class Scalar, int Options, class Index>
+        void toSparse(Eigen::SparseMatrix<Scalar, Options, Index>& s) const
         {
             switch (type_) {
             case Z:
-                s = Eigen::SparseMatrix<double>(rows_, cols_);
+                s = Eigen::SparseMatrix<Scalar, Options, Index>(rows_, cols_);
                 return;
             case I:
                 s = spdiag(Eigen::VectorXd::Ones(rows_));

--- a/opm/autodiff/AutoDiffMatrix.hpp
+++ b/opm/autodiff/AutoDiffMatrix.hpp
@@ -87,6 +87,26 @@ namespace Opm
 
 
 
+        AutoDiffMatrix(const AutoDiffMatrix& other) = default;
+        AutoDiffMatrix& operator=(const AutoDiffMatrix& other) = default;
+
+
+
+        AutoDiffMatrix(AutoDiffMatrix&& other)
+        {
+            swap(other);
+        }
+
+
+
+        AutoDiffMatrix& operator=(AutoDiffMatrix&& other)
+        {
+            swap(other);
+            return *this;
+        }
+
+
+
         void swap(AutoDiffMatrix& other)
         {
             std::swap(type_, other.type_);

--- a/opm/autodiff/AutoDiffMatrix.hpp
+++ b/opm/autodiff/AutoDiffMatrix.hpp
@@ -1,5 +1,5 @@
 /*
-  Copyright 2014 SINTEF ICT, Applied Mathematics.
+  Copyright 2014, 2015 SINTEF ICT, Applied Mathematics.
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -31,217 +31,308 @@
 namespace Opm
 {
 
-    /// Implementation details for class AutoDiffMatrix.
-    namespace AutoDiffMatrixDetail
+    class AutoDiffMatrix
     {
-
-
-        class Zero;
-        class Identity;
-        class Diagonal;
-        class Sparse;
-        typedef std::shared_ptr<Zero> ZeroMat;
-        typedef std::shared_ptr<Identity> IdentityMat;
-        typedef std::shared_ptr<Diagonal> DiagonalMat;
-        typedef std::shared_ptr<Sparse> SparseMat;
+    public:
+	AutoDiffMatrix()
+	    : type_(Z),
+	      rows_(0),
+	      cols_(0)
+	{
+	}
 
 
 
+	enum CreationType { ZeroMatrix, IdentityMatrix };
+
+
+	AutoDiffMatrix(const CreationType t, const int rows)
+	    : type_(t == ZeroMatrix ? Z : I),
+	      rows_(rows),
+	      cols_(rows)
+	{
+	}
 
 
 
-        class Interface
-        {
-        public:
-            typedef std::shared_ptr<Interface> Mat;
-
-            virtual ~Interface()
-            {
-            }
-
-            virtual Mat operator+(const Mat& rhs) = 0;
-            virtual Mat addIdentity(const IdentityMat& rhs) = 0;
-            virtual Mat addDiagonal(const DiagonalMat& rhs) = 0;
-            virtual Mat addSparse(const SparsMate& rhs) = 0;
-
-            virtual Mat operator*(const Mat& rhs) = 0;
-            virtual Mat leftMulDiagonal(const DiagonalMat& rhs) = 0;
-            virtual Mat leftMulSparse(const SparseMat& rhs) = 0;
-        };
+	explicit AutoDiffMatrix(const Eigen::DiagonalMatrix<double, Eigen::Dynamic>& d)
+	    : type_(D),
+	      rows_(d.rows()),
+	      cols_(d.cols()),
+	      d_(d)
+	{
+	}
 
 
 
+	explicit AutoDiffMatrix(const Eigen::SparseMatrix<double>& s)
+	    : type_(S),
+	      rows_(s.rows()),
+	      cols_(s.cols()),
+	      s_(s)
+	{
+	}
 
 
 
-        class Zero : public Interface
-        {
-        public:
-            virtual Mat operator+(const Mat& rhs)
-            {
-                return rhs;
-            }
+	AutoDiffMatrix operator+(const AutoDiffMatrix& rhs) const
+	{
+	    switch (type_) {
+	    case Z:
+		return rhs;
+	    case I:
+		switch (rhs.type_) {
+		case Z:
+		    return *this;
+		case I:
+		    return sumII(*this, rhs);
+		case D:
+		    return rhs + (*this);
+		case S:
+		    return rhs + (*this);
+		}
+	    case D:
+		switch (rhs.type_) {
+		case Z:
+		    return *this;
+		case I:
+		    return sumDI(*this, rhs);
+		case D:
+		    return sumDD(*this, rhs);
+		case S:
+		    return rhs + (*this);
+		}
+	    case S:
+		switch (rhs.type_) {
+		case Z:
+		    return *this;
+		case I:
+		    return sumSI(*this, rhs);
+		case D:
+		    return sumSD(*this, rhs);
+		case S:
+		    return sumSS(*this, rhs);
+		}
+	    }
+	}
 
-            virtual Mat addIdentity(const IdentityMat& rhs)
-            {
-                return rhs;
-            }
-
-            virtual Mat addDiagonal(const DiagonalMat& rhs)
-            {
-                return rhs;
-            }
-
-            virtual Mat addSparse(const SparseMat& rhs)
-            {
-                return rhs;
-            }
-
-
-            virtual Mat operator*(const Mat& rhs)
-            {
-                return std::make_shared<Zero>();
-            }
-
-            virtual Mat leftMulDiagonal(const DiagonalMat& rhs)
-            {
-                return std::make_shared<Zero>();
-            }
-
-            virtual Mat leftMulSparse(const SparseMat& rhs)
-            {
-                return std::make_shared<Zero>();
-            }
-        };
-
-
-
-
-
-        class Identity : public Interface
-        {
-        public:
-            virtual Mat operator+(const Mat& rhs)
-            {
-                return rhs->addIdentity(*this);
-            }
-
-            virtual Mat addIdentity(const IdentityMat& rhs)
-            {
-                return rhs;
-            }
-
-            virtual Mat addDiagonal(const DiagonalMat& rhs)
-            {
-                return rhs;
-            }
-
-            virtual Mat addSparse(const SparseMat& rhs)
-            {
-                return rhs;
-            }
-
-
-            virtual Mat operator*(const Mat& rhs)
-            {
-                return std::make_shared<Zero>();
-            }
-
-            virtual Mat leftMulDiagonal(const DiagonalMat& rhs)
-            {
-                return std::make_shared<Zero>();
-            }
-
-            virtual Mat leftMulSparse(const SparseMat& rhs)
-            {
-                return std::make_shared<Zero>();
-            }
-        };
-
-
-
-
-
-        class Diagonal : public Interface
-        {
-        public:
-            virtual Mat operator+(const Mat& rhs)
-            {
-                return (*rhs) + (*this);
-            }
-            operator+(const IdentityMat& rhs)
-            {
-                // TODO return Diagnonal(...);
-            }
-            operator+(const DiagonalMat& rhs)
-            {
-                // TODO return Diagonal(...);
-            }
-            operator+(const SparseMat& rhs)
-            {
-                // TODO return Sparse(...);
-            }
-
-            virtual Mat operator*(const Mat& rhs)
-            {
-                return (*rhs) * (;
-            }
-            Mat operator*(const IdentityMat& rhs)
-            {
-                return *this;
-            }
-            Mat operator*(const DiagonalMat& rhs)
-            {
-                // TODO return Diagonal(...);
-            }
-            Mat operator*(const SparseMat& rhs)
-            {
-                // TODO return Sparse(...);
-            }
-        };
+	AutoDiffMatrix operator*(const AutoDiffMatrix& rhs) const
+	{
+	    switch (type_) {
+	    case Z:
+		return *this;
+	    case I:
+		switch (rhs.type_) {
+		case Z:
+		    return rhs;
+		case I:
+		    return rhs;
+		case D:
+		    return rhs;
+		case S:
+		    return rhs;
+		}
+	    case D:
+		switch (rhs.type_) {
+		case Z:
+		    return rhs;
+		case I:
+		    return *this;
+		case D:
+		    return prodDD(*this, rhs);
+		case S:
+		    return prodDS(*this, rhs);
+		}
+	    case S:
+		switch (rhs.type_) {
+		case Z:
+		    return rhs;
+		case I:
+		    return *this;
+		case D:
+		    return prodSD(*this, rhs);
+		case S:
+		    return prodSS(*this, rhs);
+		}
+	    }
+	}
 
 
 
 
 
-        class Sparse : public Interface
-        {
-            virtual Mat operator+(const Mat& rhs)
-            {
-                return (*rhs) + (*this);
-            }
-            operator+(const IdentityMat& rhs)
-            {
-                // TODO return Sparse(...);
-            }
-            operator+(const DiagonalMat& rhs)
-            {
-                // TODO return Sparse(...);
-            }
-            operator+(const SparseMat& rhs)
-            {
-                // TODO return Sparse(...);
-            }
+	static AutoDiffMatrix sumII(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+	{
+	    assert(lhs.type_ == I);
+	    assert(rhs.type_ == I);
+	    AutoDiffMatrix retval;
+	    retval.type_ = D;
+	    retval.rows_ = lhs.rows_;
+	    retval.cols_ = rhs.cols_;
+	    retval.d_ = Eigen::VectorXd::Constant(lhs.rows_, 2.0).asDiagonal();
+	    return retval;
+	}
 
-            virtual Mat operator*(const Mat& rhs)
-            {
-                return rhs;
-            }
-            Mat operator*(const IdentityMat& rhs)
-            {
-                return *this;
-            }
-            Mat operator*(const DiagonalMat& rhs)
-            {
-                // TODO return Sparse(...);
-            }
-            Mat operator*(const SparseMat& rhs)
-            {
-                // TODO return Sparse(...);
-            }
-        };
+	static AutoDiffMatrix sumDI(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+	{
+	    assert(lhs.type_ == D);
+	    assert(rhs.type_ == I);
+	    AutoDiffMatrix retval = lhs;
+	    for (int r = 0; r < lhs.rows_; ++r) {
+		retval.d_.diagonal()(r) += 1.0;
+	    }
+	    return retval;
+	}
 
-    } // namespace AutoDiffMatrixDetail
+	static AutoDiffMatrix sumDD(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+	{
+	    assert(lhs.type_ == D);
+	    assert(rhs.type_ == D);
+	    AutoDiffMatrix retval = lhs;
+	    for (int r = 0; r < lhs.rows_; ++r) {
+		retval.d_.diagonal()(r) += rhs.d_.diagonal()(r);
+	    }
+	    return retval;
+	}
+
+	static AutoDiffMatrix sumSI(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+	{
+	    assert(lhs.type_ == S);
+	    assert(rhs.type_ == I);
+	    AutoDiffMatrix retval;
+	    Eigen::SparseMatrix<double> ident = spdiag(Eigen::VectorXd::Ones(lhs.rows_));
+	    retval.type_ = S;
+	    retval.rows_ = lhs.rows_;
+	    retval.cols_ = rhs.cols_;
+	    retval.s_ = lhs.s_ + ident;
+	    return retval;
+	}
+
+	static AutoDiffMatrix sumSD(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+	{
+	    assert(lhs.type_ == S);
+	    assert(rhs.type_ == D);
+	    AutoDiffMatrix retval;
+	    Eigen::SparseMatrix<double> diag = spdiag(rhs.d_.diagonal());
+	    retval.type_ = S;
+	    retval.rows_ = lhs.rows_;
+	    retval.cols_ = rhs.cols_;
+	    retval.s_ = lhs.s_ + diag;
+	    return retval;
+	}
+
+	static AutoDiffMatrix sumSS(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+	{
+	    assert(lhs.type_ == S);
+	    assert(rhs.type_ == S);
+	    AutoDiffMatrix retval;
+	    retval.type_ = S;
+	    retval.rows_ = lhs.rows_;
+	    retval.cols_ = rhs.cols_;
+	    retval.s_ = lhs.s_ + rhs.s_;
+	    return retval;
+	}
+
+
+
+
+
+	static AutoDiffMatrix prodDD(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+	{
+	    assert(lhs.type_ == D);
+	    assert(rhs.type_ == D);
+	    AutoDiffMatrix retval = lhs;
+	    for (int r = 0; r < lhs.rows_; ++r) {
+		retval.d_.diagonal().array() *= rhs.d_.diagonal().array();
+	    }
+	    return retval;
+	}
+
+	static AutoDiffMatrix prodDS(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+	{
+	    assert(lhs.type_ == S);
+	    assert(rhs.type_ == D);
+	    AutoDiffMatrix retval;
+	    Eigen::SparseMatrix<double> diag = spdiag(rhs.d_.diagonal());
+	    retval.type_ = S;
+	    retval.rows_ = lhs.rows_;
+	    retval.cols_ = rhs.cols_;
+	    retval.s_ = lhs.s_ * diag;
+	    return retval;
+	}
+
+	static AutoDiffMatrix prodSD(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+	{
+	    assert(lhs.type_ == S);
+	    assert(rhs.type_ == D);
+	    AutoDiffMatrix retval;
+	    Eigen::SparseMatrix<double> diag = spdiag(rhs.d_.diagonal());
+	    retval.type_ = S;
+	    retval.rows_ = lhs.rows_;
+	    retval.cols_ = rhs.cols_;
+	    retval.s_ = diag * lhs.s_;
+	    return retval;
+	}
+
+	static AutoDiffMatrix prodSS(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+	{
+	    assert(lhs.type_ == S);
+	    assert(rhs.type_ == S);
+	    AutoDiffMatrix retval;
+	    retval.type_ = S;
+	    retval.rows_ = lhs.rows_;
+	    retval.cols_ = rhs.cols_;
+	    retval.s_ = lhs.s_ * rhs.s_;
+	    return retval;
+	}
+
+
+
+	void toSparse(Eigen::SparseMatrix<double>& s) const
+	{
+	    switch (type_) {
+	    case Z:
+		s = Eigen::SparseMatrix<double>(rows_, cols_);
+		return;
+	    case I:
+		s = spdiag(Eigen::VectorXd::Ones(rows_));
+		return;
+	    case D:
+		s = spdiag(d_.diagonal());
+		return;
+	    case S:
+		s = s_;
+		return;
+	    }
+	}
+
+    private:
+	enum MatrixType { Z, I, D, S };
+	MatrixType type_;
+	int rows_;
+	int cols_;
+	Eigen::DiagonalMatrix<double, Eigen::Dynamic> d_;
+	Eigen::SparseMatrix<double> s_;
+
+
+	template <class V>
+	static inline
+	Eigen::SparseMatrix<double>
+	spdiag(const V& d)
+	{
+	    typedef Eigen::SparseMatrix<double> M;
+	    const int n = d.size();
+	    M mat(n, n);
+	    mat.reserve(Eigen::ArrayXi::Ones(n, 1));
+	    for (M::Index i = 0; i < n; ++i) {
+		mat.insert(i, i) = d[i];
+	    }
+
+	    return mat;
+	}
+
+    };
+
 } // namespace Opm
 
 

--- a/opm/autodiff/AutoDiffMatrix.hpp
+++ b/opm/autodiff/AutoDiffMatrix.hpp
@@ -491,7 +491,9 @@ namespace Opm
             M mat(n, n);
             mat.reserve(Eigen::ArrayXi::Ones(n, 1));
             for (M::Index i = 0; i < n; ++i) {
-                mat.insert(i, i) = d[i];
+                if (d[i] != 0.0) {
+                    mat.insert(i, i) = d[i];
+                }
             }
 
             return mat;

--- a/opm/autodiff/AutoDiffMatrix.hpp
+++ b/opm/autodiff/AutoDiffMatrix.hpp
@@ -28,6 +28,8 @@
 #include <opm/core/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/autodiff/fastSparseProduct.hpp>
+#include <vector>
+
 
 namespace Opm
 {
@@ -35,434 +37,445 @@ namespace Opm
     class AutoDiffMatrix
     {
     public:
-	AutoDiffMatrix()
-	    : type_(Z),
-	      rows_(0),
-	      cols_(0)
-	{
-	}
-
-
-
-	AutoDiffMatrix(const int rows, const int cols)
-	    : type_(Z),
-	      rows_(rows),
-	      cols_(cols)
-	{
-	}
-
-
-
-	enum CreationType { ZeroMatrix, IdentityMatrix };
-
-
-	AutoDiffMatrix(const CreationType t, const int rows)
-	    : type_(t == ZeroMatrix ? Z : I),
-	      rows_(rows),
-	      cols_(rows)
-	{
-	}
-
-
-
-	explicit AutoDiffMatrix(const Eigen::DiagonalMatrix<double, Eigen::Dynamic>& d)
-	    : type_(D),
-	      rows_(d.rows()),
-	      cols_(d.cols()),
-	      d_(d)
-	{
-	}
-
-
-
-	explicit AutoDiffMatrix(const Eigen::SparseMatrix<double>& s)
-	    : type_(S),
-	      rows_(s.rows()),
-	      cols_(s.cols()),
-	      s_(s)
-	{
-	}
-
-
-
-	AutoDiffMatrix operator+(const AutoDiffMatrix& rhs) const
-	{
-	    assert(rows_ == rhs.rows_);
-	    assert(cols_ == rhs.cols_);
-	    switch (type_) {
-	    case Z:
-		return rhs;
-	    case I:
-		switch (rhs.type_) {
-		case Z:
-		    return *this;
-		case I:
-		    return sumII(*this, rhs);
-		case D:
-		    return rhs + (*this);
-		case S:
-		    return rhs + (*this);
-		}
-	    case D:
-		switch (rhs.type_) {
-		case Z:
-		    return *this;
-		case I:
-		    return sumDI(*this, rhs);
-		case D:
-		    return sumDD(*this, rhs);
-		case S:
-		    return rhs + (*this);
-		}
-	    case S:
-		switch (rhs.type_) {
-		case Z:
-		    return *this;
-		case I:
-		    return sumSI(*this, rhs);
-		case D:
-		    return sumSD(*this, rhs);
-		case S:
-		    return sumSS(*this, rhs);
-		}
-	    }
-	}
-
-	AutoDiffMatrix operator*(const AutoDiffMatrix& rhs) const
-	{
-	    assert(cols_ == rhs.rows_);
-	    switch (type_) {
-	    case Z:
-		return AutoDiffMatrix(rows_, rhs.cols_);
-	    case I:
-		switch (rhs.type_) {
-		case Z:
-		    return rhs;
-		case I:
-		    return rhs;
-		case D:
-		    return rhs;
-		case S:
-		    return rhs;
-		}
-	    case D:
-		switch (rhs.type_) {
-		case Z:
-		    return AutoDiffMatrix(rows_, rhs.cols_);
-		case I:
-		    return *this;
-		case D:
-		    return prodDD(*this, rhs);
-		case S:
-		    return prodDS(*this, rhs);
-		}
-	    case S:
-		switch (rhs.type_) {
-		case Z:
-		    return AutoDiffMatrix(rows_, rhs.cols_);
-		case I:
-		    return *this;
-		case D:
-		    return prodSD(*this, rhs);
-		case S:
-		    return prodSS(*this, rhs);
-		}
-	    }
-	}
-
-
-
-
-
-
-
-	AutoDiffMatrix& operator+=(const AutoDiffMatrix& rhs)
-	{
-	    *this = *this + rhs;
-	    return *this;
-	}
-
-
-
-
-
-
-	AutoDiffMatrix& operator-=(const AutoDiffMatrix& rhs)
-	{
-	    *this = *this + rhs * -1.0;
-	    return *this;
-	}
-
-
-
-
-
-
-	AutoDiffMatrix operator*(const double rhs) const
-	{
-	    switch (type_) {
-	    case Z:
-		return *this;
-	    case I:
-		{
-		    AutoDiffMatrix retval(*this);
-		    retval.type_ = D;
-		    retval.d_ = rhs * Eigen::VectorXd::Ones(rows_).asDiagonal();
-		    return retval;
-		}
-	    case D:
-		{
-		    AutoDiffMatrix retval(*this);
-		    retval.d_ = rhs * retval.d_;
-		    return retval;
-		}
-	    case S:
-		{
-		    AutoDiffMatrix retval(*this);
-		    retval.s_ *= rhs;
-		    return retval;
-		}
-	    }
-	}
-
-
-
-
-
-
-	Eigen::VectorXd operator*(const Eigen::VectorXd& rhs) const
-	{
-	    assert(cols_ == rhs.size());
-	    switch (type_) {
-	    case Z:
-		return Eigen::VectorXd::Zero(rows_);
-	    case I:
-		return rhs;
-	    case D:
-		return d_ * rhs;
-	    case S:
-		return s_ * rhs;
-	    }
-	}
-
-
-
-
-
-
-	static AutoDiffMatrix sumII(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
-	{
-	    assert(lhs.type_ == I);
-	    assert(rhs.type_ == I);
-	    AutoDiffMatrix retval;
-	    retval.type_ = D;
-	    retval.rows_ = lhs.rows_;
-	    retval.cols_ = rhs.cols_;
-	    retval.d_ = Eigen::VectorXd::Constant(lhs.rows_, 2.0).asDiagonal();
-	    return retval;
-	}
-
-	static AutoDiffMatrix sumDI(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
-	{
-	    assert(lhs.type_ == D);
-	    assert(rhs.type_ == I);
-	    AutoDiffMatrix retval = lhs;
-	    for (int r = 0; r < lhs.rows_; ++r) {
-		retval.d_.diagonal()(r) += 1.0;
-	    }
-	    return retval;
-	}
-
-	static AutoDiffMatrix sumDD(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
-	{
-	    assert(lhs.type_ == D);
-	    assert(rhs.type_ == D);
-	    AutoDiffMatrix retval = lhs;
-	    for (int r = 0; r < lhs.rows_; ++r) {
-		retval.d_.diagonal()(r) += rhs.d_.diagonal()(r);
-	    }
-	    return retval;
-	}
-
-	static AutoDiffMatrix sumSI(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
-	{
-	    assert(lhs.type_ == S);
-	    assert(rhs.type_ == I);
-	    AutoDiffMatrix retval;
-	    Eigen::SparseMatrix<double> ident = spdiag(Eigen::VectorXd::Ones(lhs.rows_));
-	    retval.type_ = S;
-	    retval.rows_ = lhs.rows_;
-	    retval.cols_ = rhs.cols_;
-	    retval.s_ = lhs.s_ + ident;
-	    return retval;
-	}
-
-	static AutoDiffMatrix sumSD(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
-	{
-	    assert(lhs.type_ == S);
-	    assert(rhs.type_ == D);
-	    AutoDiffMatrix retval;
-	    Eigen::SparseMatrix<double> diag = spdiag(rhs.d_.diagonal());
-	    retval.type_ = S;
-	    retval.rows_ = lhs.rows_;
-	    retval.cols_ = rhs.cols_;
-	    retval.s_ = lhs.s_ + diag;
-	    return retval;
-	}
-
-	static AutoDiffMatrix sumSS(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
-	{
-	    assert(lhs.type_ == S);
-	    assert(rhs.type_ == S);
-	    AutoDiffMatrix retval;
-	    retval.type_ = S;
-	    retval.rows_ = lhs.rows_;
-	    retval.cols_ = rhs.cols_;
-	    retval.s_ = lhs.s_ + rhs.s_;
-	    return retval;
-	}
-
-
-
-
-
-	static AutoDiffMatrix prodDD(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
-	{
-	    assert(lhs.type_ == D);
-	    assert(rhs.type_ == D);
-	    AutoDiffMatrix retval;
-	    retval.type_ = D;
-	    retval.rows_ = lhs.rows_;
-	    retval.cols_ = rhs.cols_;
-	    retval.d_ = (lhs.d_.diagonal().array() * rhs.d_.diagonal().array()).matrix().asDiagonal();
-	    return retval;
-	}
-
-	static AutoDiffMatrix prodDS(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
-	{
-	    assert(lhs.type_ == D);
-	    assert(rhs.type_ == S);
-	    AutoDiffMatrix retval;
-	    // Eigen::SparseMatrix<double> diag = spdiag(lhs.d_.diagonal());
-	    retval.type_ = S;
-	    retval.rows_ = lhs.rows_;
-	    retval.cols_ = rhs.cols_;
-	    // fastSparseProduct(diag, rhs.s_, retval.s_);
-	    fastDiagSparseProduct(lhs.d_, rhs.s_, retval.s_);
-	    // retval.s_ = lhs.d_ * rhs.s_;
-	    return retval;
-	}
-
-	static AutoDiffMatrix prodSD(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
-	{
-	    assert(lhs.type_ == S);
-	    assert(rhs.type_ == D);
-	    AutoDiffMatrix retval;
-	    // Eigen::SparseMatrix<double> diag = spdiag(rhs.d_.diagonal());
-	    retval.type_ = S;
-	    retval.rows_ = lhs.rows_;
-	    retval.cols_ = rhs.cols_;
-	    // fastSparseProduct(lhs.s_, diag, retval.s_);
-	    fastSparseDiagProduct(lhs.s_, rhs.d_, retval.s_);
-	    // retval.s_ = lhs.s_ * rhs.d_;
-	    return retval;
-	}
-
-	static AutoDiffMatrix prodSS(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
-	{
-	    assert(lhs.type_ == S);
-	    assert(rhs.type_ == S);
-	    AutoDiffMatrix retval;
-	    retval.type_ = S;
-	    retval.rows_ = lhs.rows_;
-	    retval.cols_ = rhs.cols_;
-	    fastSparseProduct(lhs.s_, rhs.s_, retval.s_);
-	    return retval;
-	}
-
-
-
-	void toSparse(Eigen::SparseMatrix<double>& s) const
-	{
-	    switch (type_) {
-	    case Z:
-		s = Eigen::SparseMatrix<double>(rows_, cols_);
-		return;
-	    case I:
-		s = spdiag(Eigen::VectorXd::Ones(rows_));
-		return;
-	    case D:
-		s = spdiag(d_.diagonal());
-		return;
-	    case S:
-		s = s_;
-		return;
-	    }
-	}
-
-
-	int rows() const
-	{
-	    return rows_;
-	}
-
-	int cols() const
-	{
-	    return cols_;
-	}
-
-	int nonZeros() const
-	{
-	    switch (type_) {
-	    case Z:
-		return 0;
-	    case I:
-		return rows_;
-	    case D:
-		return rows_;
-	    case S:
-		return s_.nonZeros();
-	    }
-	}
-
-
-	double coeff(const int row, const int col) const
-	{
-	    switch (type_) {
-	    case Z:
-		return 0.0;
-	    case I:
-		return (row == col) ? 1.0 : 0.0;
-	    case D:
-		return (row == col) ? d_.diagonal()(row) : 0.0;
-	    case S:
-		return s_.coeff(row, col);
-	    }
-	}
+        AutoDiffMatrix()
+            : type_(Z),
+              rows_(0),
+              cols_(0)
+        {
+        }
+
+
+
+        AutoDiffMatrix(const int rows, const int cols)
+            : type_(Z),
+              rows_(rows),
+              cols_(cols)
+        {
+        }
+
+
+
+        enum CreationType { ZeroMatrix, IdentityMatrix };
+
+
+        AutoDiffMatrix(const CreationType t, const int rows)
+            : type_(t == ZeroMatrix ? Z : I),
+              rows_(rows),
+              cols_(rows)
+        {
+        }
+
+
+
+        explicit AutoDiffMatrix(const Eigen::DiagonalMatrix<double, Eigen::Dynamic>& d)
+            : type_(D),
+              rows_(d.rows()),
+              cols_(d.cols()),
+              d_(d.diagonal().array().data(), d.diagonal().array().data() + d.rows())
+        {
+        }
+
+
+
+        explicit AutoDiffMatrix(const Eigen::SparseMatrix<double>& s)
+            : type_(S),
+              rows_(s.rows()),
+              cols_(s.cols()),
+              s_(s)
+        {
+        }
+
+
+
+        void swap(AutoDiffMatrix& other)
+        {
+            std::swap(type_, other.type_);
+            std::swap(rows_, other.rows_);
+            std::swap(cols_, other.cols_);
+            d_.swap(other.d_);
+            s_.swap(other.s_);
+        }
+
+
+
+        AutoDiffMatrix operator+(const AutoDiffMatrix& rhs) const
+        {
+            assert(rows_ == rhs.rows_);
+            assert(cols_ == rhs.cols_);
+            switch (type_) {
+            case Z:
+                return rhs;
+            case I:
+                switch (rhs.type_) {
+                case Z:
+                    return *this;
+                case I:
+                    return sumII(*this, rhs);
+                case D:
+                    return rhs + (*this);
+                case S:
+                    return rhs + (*this);
+                }
+            case D:
+                switch (rhs.type_) {
+                case Z:
+                    return *this;
+                case I:
+                    return sumDI(*this, rhs);
+                case D:
+                    return sumDD(*this, rhs);
+                case S:
+                    return rhs + (*this);
+                }
+            case S:
+                switch (rhs.type_) {
+                case Z:
+                    return *this;
+                case I:
+                    return sumSI(*this, rhs);
+                case D:
+                    return sumSD(*this, rhs);
+                case S:
+                    return sumSS(*this, rhs);
+                }
+            }
+        }
+
+        AutoDiffMatrix operator*(const AutoDiffMatrix& rhs) const
+        {
+            assert(cols_ == rhs.rows_);
+            switch (type_) {
+            case Z:
+                return AutoDiffMatrix(rows_, rhs.cols_);
+            case I:
+                switch (rhs.type_) {
+                case Z:
+                    return rhs;
+                case I:
+                    return rhs;
+                case D:
+                    return rhs;
+                case S:
+                    return rhs;
+                }
+            case D:
+                switch (rhs.type_) {
+                case Z:
+                    return AutoDiffMatrix(rows_, rhs.cols_);
+                case I:
+                    return *this;
+                case D:
+                    return prodDD(*this, rhs);
+                case S:
+                    return prodDS(*this, rhs);
+                }
+            case S:
+                switch (rhs.type_) {
+                case Z:
+                    return AutoDiffMatrix(rows_, rhs.cols_);
+                case I:
+                    return *this;
+                case D:
+                    return prodSD(*this, rhs);
+                case S:
+                    return prodSS(*this, rhs);
+                }
+            }
+        }
+
+
+
+
+
+
+
+        AutoDiffMatrix& operator+=(const AutoDiffMatrix& rhs)
+        {
+            *this = *this + rhs;
+            return *this;
+        }
+
+
+
+
+
+
+        AutoDiffMatrix& operator-=(const AutoDiffMatrix& rhs)
+        {
+            *this = *this + rhs * -1.0;
+            return *this;
+        }
+
+
+
+
+
+
+        AutoDiffMatrix operator*(const double rhs) const
+        {
+            switch (type_) {
+            case Z:
+                return *this;
+            case I:
+                {
+                    AutoDiffMatrix retval(*this);
+                    retval.type_ = D;
+                    retval.d_.assign(rows_, rhs);
+                    return retval;
+                }
+            case D:
+                {
+                    AutoDiffMatrix retval(*this);
+                    for (double& elem : retval.d_) {
+                        elem *= rhs;
+                    }
+                    return retval;
+                }
+            case S:
+                {
+                    AutoDiffMatrix retval(*this);
+                    retval.s_ *= rhs;
+                    return retval;
+                }
+            }
+        }
+
+
+
+
+
+
+        Eigen::VectorXd operator*(const Eigen::VectorXd& rhs) const
+        {
+            assert(cols_ == rhs.size());
+            switch (type_) {
+            case Z:
+                return Eigen::VectorXd::Zero(rows_);
+            case I:
+                return rhs;
+            case D:
+                return Eigen::Map<const Eigen::VectorXd>(d_.data(), rows_) * rhs;
+            case S:
+                return s_ * rhs;
+            }
+        }
+
+
+
+
+
+
+        static AutoDiffMatrix sumII(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+        {
+            assert(lhs.type_ == I);
+            assert(rhs.type_ == I);
+            AutoDiffMatrix retval;
+            retval.type_ = D;
+            retval.rows_ = lhs.rows_;
+            retval.cols_ = rhs.cols_;
+            retval.d_.assign(lhs.rows_, 2.0);
+            return retval;
+        }
+
+        static AutoDiffMatrix sumDI(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+        {
+            static_cast<void>(rhs); // Silence release-mode warning.
+            assert(lhs.type_ == D);
+            assert(rhs.type_ == I);
+            AutoDiffMatrix retval = lhs;
+            for (int r = 0; r < lhs.rows_; ++r) {
+                retval.d_[r] += 1.0;
+            }
+            return retval;
+        }
+
+        static AutoDiffMatrix sumDD(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+        {
+            assert(lhs.type_ == D);
+            assert(rhs.type_ == D);
+            AutoDiffMatrix retval = lhs;
+            for (int r = 0; r < lhs.rows_; ++r) {
+                retval.d_[r] += rhs.d_[r];
+            }
+            return retval;
+        }
+
+        static AutoDiffMatrix sumSI(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+        {
+            assert(lhs.type_ == S);
+            assert(rhs.type_ == I);
+            AutoDiffMatrix retval;
+            Eigen::SparseMatrix<double> ident = spdiag(Eigen::VectorXd::Ones(lhs.rows_));
+            retval.type_ = S;
+            retval.rows_ = lhs.rows_;
+            retval.cols_ = rhs.cols_;
+            retval.s_ = lhs.s_ + ident;
+            return retval;
+        }
+
+        static AutoDiffMatrix sumSD(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+        {
+            assert(lhs.type_ == S);
+            assert(rhs.type_ == D);
+            AutoDiffMatrix retval;
+            Eigen::SparseMatrix<double> diag = spdiag(rhs.d_);
+            retval.type_ = S;
+            retval.rows_ = lhs.rows_;
+            retval.cols_ = rhs.cols_;
+            retval.s_ = lhs.s_ + diag;
+            return retval;
+        }
+
+        static AutoDiffMatrix sumSS(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+        {
+            assert(lhs.type_ == S);
+            assert(rhs.type_ == S);
+            AutoDiffMatrix retval;
+            retval.type_ = S;
+            retval.rows_ = lhs.rows_;
+            retval.cols_ = rhs.cols_;
+            retval.s_ = lhs.s_ + rhs.s_;
+            return retval;
+        }
+
+
+
+
+
+        static AutoDiffMatrix prodDD(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+        {
+            assert(lhs.type_ == D);
+            assert(rhs.type_ == D);
+            AutoDiffMatrix retval;
+            retval.type_ = D;
+            retval.rows_ = lhs.rows_;
+            retval.cols_ = rhs.cols_;
+            retval.d_.resize(lhs.rows_);
+            for (int r = 0; r < lhs.rows_; ++r) {
+                retval.d_[r] = lhs.d_[r] * rhs.d_[r];
+            }
+            return retval;
+        }
+
+        static AutoDiffMatrix prodDS(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+        {
+            assert(lhs.type_ == D);
+            assert(rhs.type_ == S);
+            AutoDiffMatrix retval;
+            retval.type_ = S;
+            retval.rows_ = lhs.rows_;
+            retval.cols_ = rhs.cols_;
+            fastDiagSparseProduct(lhs.d_, rhs.s_, retval.s_);
+            return retval;
+        }
+
+        static AutoDiffMatrix prodSD(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+        {
+            assert(lhs.type_ == S);
+            assert(rhs.type_ == D);
+            AutoDiffMatrix retval;
+            retval.type_ = S;
+            retval.rows_ = lhs.rows_;
+            retval.cols_ = rhs.cols_;
+            fastSparseDiagProduct(lhs.s_, rhs.d_, retval.s_);
+            return retval;
+        }
+
+        static AutoDiffMatrix prodSS(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+        {
+            assert(lhs.type_ == S);
+            assert(rhs.type_ == S);
+            AutoDiffMatrix retval;
+            retval.type_ = S;
+            retval.rows_ = lhs.rows_;
+            retval.cols_ = rhs.cols_;
+            fastSparseProduct(lhs.s_, rhs.s_, retval.s_);
+            return retval;
+        }
+
+
+
+        void toSparse(Eigen::SparseMatrix<double>& s) const
+        {
+            switch (type_) {
+            case Z:
+                s = Eigen::SparseMatrix<double>(rows_, cols_);
+                return;
+            case I:
+                s = spdiag(Eigen::VectorXd::Ones(rows_));
+                return;
+            case D:
+                s = spdiag(d_);
+                return;
+            case S:
+                s = s_;
+                return;
+            }
+        }
+
+
+        int rows() const
+        {
+            return rows_;
+        }
+
+        int cols() const
+        {
+            return cols_;
+        }
+
+        int nonZeros() const
+        {
+            switch (type_) {
+            case Z:
+                return 0;
+            case I:
+                return rows_;
+            case D:
+                return rows_;
+            case S:
+                return s_.nonZeros();
+            }
+        }
+
+
+        double coeff(const int row, const int col) const
+        {
+            switch (type_) {
+            case Z:
+                return 0.0;
+            case I:
+                return (row == col) ? 1.0 : 0.0;
+            case D:
+                return (row == col) ? d_[row] : 0.0;
+            case S:
+                return s_.coeff(row, col);
+            }
+        }
 
     private:
-	enum MatrixType { Z, I, D, S };
-	MatrixType type_;
-	int rows_;
-	int cols_;
-	Eigen::DiagonalMatrix<double, Eigen::Dynamic> d_;
-	Eigen::SparseMatrix<double> s_;
+        enum MatrixType { Z, I, D, S };
+        MatrixType type_;
+        int rows_;
+        int cols_;
+        std::vector<double> d_;
+        Eigen::SparseMatrix<double> s_;
 
-	template <class V>
-	static inline
-	Eigen::SparseMatrix<double>
-	spdiag(const V& d)
-	{
-	    typedef Eigen::SparseMatrix<double> M;
-	    const int n = d.size();
-	    M mat(n, n);
-	    mat.reserve(Eigen::ArrayXi::Ones(n, 1));
-	    for (M::Index i = 0; i < n; ++i) {
-		mat.insert(i, i) = d[i];
-	    }
+        template <class V>
+        static inline
+        Eigen::SparseMatrix<double>
+        spdiag(const V& d)
+        {
+            typedef Eigen::SparseMatrix<double> M;
+            const int n = d.size();
+            M mat(n, n);
+            mat.reserve(Eigen::ArrayXi::Ones(n, 1));
+            for (M::Index i = 0; i < n; ++i) {
+                mat.insert(i, i) = d[i];
+            }
 
-	    return mat;
-	}
+            return mat;
+        }
 
     };
 
@@ -471,21 +484,21 @@ namespace Opm
 
     inline void fastSparseProduct(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs, AutoDiffMatrix& res)
     {
-	res = lhs * rhs;
+        res = lhs * rhs;
     }
 
 
     inline void fastSparseProduct(const Eigen::SparseMatrix<double>& lhs, const AutoDiffMatrix& rhs, AutoDiffMatrix& res)
     {
-	res = AutoDiffMatrix(lhs) * rhs;
+        res = AutoDiffMatrix(lhs) * rhs;
     }
 
 
     inline AutoDiffMatrix operator*(const Eigen::SparseMatrix<double>& lhs, const AutoDiffMatrix& rhs)
     {
-	AutoDiffMatrix retval;
-	fastSparseProduct(lhs, rhs, retval);
-	return retval;
+        AutoDiffMatrix retval;
+        fastSparseProduct(lhs, rhs, retval);
+        return retval;
     }
 
 } // namespace Opm

--- a/opm/autodiff/AutoDiffMatrix.hpp
+++ b/opm/autodiff/AutoDiffMatrix.hpp
@@ -47,10 +47,10 @@ namespace Opm
 
 
 
-        AutoDiffMatrix(const int rows, const int cols)
+        AutoDiffMatrix(const int num_rows, const int num_cols)
             : type_(Z),
-              rows_(rows),
-              cols_(cols)
+              rows_(num_rows),
+              cols_(num_cols)
         {
         }
 
@@ -59,10 +59,10 @@ namespace Opm
         enum CreationType { ZeroMatrix, IdentityMatrix };
 
 
-        AutoDiffMatrix(const CreationType t, const int rows)
+        AutoDiffMatrix(const CreationType t, const int num_rows)
             : type_(t == ZeroMatrix ? Z : I),
-              rows_(rows),
-              cols_(rows)
+              rows_(num_rows),
+              cols_(num_rows)
         {
         }
 

--- a/opm/autodiff/AutoDiffMatrix.hpp
+++ b/opm/autodiff/AutoDiffMatrix.hpp
@@ -393,12 +393,11 @@ namespace Opm
         {
             assert(lhs.type_ == S);
             assert(rhs.type_ == I);
-            Sparse ident = spdiag(Eigen::VectorXd::Ones(lhs.rows_));
             AutoDiffMatrix retval;
             retval.type_ = S;
             retval.rows_ = lhs.rows_;
             retval.cols_ = rhs.cols_;
-            retval.s_ = lhs.s_ + ident;
+            retval.s_ = lhs.s_ + spdiag(Eigen::VectorXd::Ones(lhs.rows_));;
             return retval;
         }
 
@@ -406,12 +405,11 @@ namespace Opm
         {
             assert(lhs.type_ == S);
             assert(rhs.type_ == D);
-            Sparse diag = spdiag(rhs.d_);
             AutoDiffMatrix retval;
             retval.type_ = S;
             retval.rows_ = lhs.rows_;
             retval.cols_ = rhs.cols_;
-            retval.s_ = lhs.s_ + diag;
+            retval.s_ = lhs.s_ + spdiag(rhs.d_);
             return retval;
         }
 
@@ -419,11 +417,8 @@ namespace Opm
         {
             assert(lhs.type_ == S);
             assert(rhs.type_ == S);
-            AutoDiffMatrix retval;
-            retval.type_ = S;
-            retval.rows_ = lhs.rows_;
-            retval.cols_ = rhs.cols_;
-            retval.s_ = lhs.s_ + rhs.s_;
+            AutoDiffMatrix retval = lhs;
+            retval.s_ += rhs.s_;
             return retval;
         }
 
@@ -435,13 +430,9 @@ namespace Opm
         {
             assert(lhs.type_ == D);
             assert(rhs.type_ == D);
-            AutoDiffMatrix retval;
-            retval.type_ = D;
-            retval.rows_ = lhs.rows_;
-            retval.cols_ = rhs.cols_;
-            retval.d_.resize(lhs.rows_);
+            AutoDiffMatrix retval = lhs;
             for (int r = 0; r < lhs.rows_; ++r) {
-                retval.d_[r] = lhs.d_[r] * rhs.d_[r];
+                retval.d_[r] *= rhs.d_[r];
             }
             return retval;
         }

--- a/opm/autodiff/AutoDiffMatrix.hpp
+++ b/opm/autodiff/AutoDiffMatrix.hpp
@@ -27,6 +27,7 @@
 
 #include <opm/core/utility/platform_dependent/reenable_warnings.h>
 
+#include <opm/core/utility/ErrorMacros.hpp>
 #include <opm/autodiff/fastSparseProduct.hpp>
 #include <vector>
 
@@ -136,6 +137,8 @@ namespace Opm
                     return rhs + (*this);
                 case S:
                     return rhs + (*this);
+                default:
+                    OPM_THROW(std::logic_error, "Invalid AutoDiffMatrix type encountered: " << rhs.type_);
                 }
             case D:
                 switch (rhs.type_) {
@@ -147,6 +150,8 @@ namespace Opm
                     return sumDD(*this, rhs);
                 case S:
                     return rhs + (*this);
+                default:
+                    OPM_THROW(std::logic_error, "Invalid AutoDiffMatrix type encountered: " << rhs.type_);
                 }
             case S:
                 switch (rhs.type_) {
@@ -158,7 +163,11 @@ namespace Opm
                     return sumSD(*this, rhs);
                 case S:
                     return sumSS(*this, rhs);
+                default:
+                    OPM_THROW(std::logic_error, "Invalid AutoDiffMatrix type encountered: " << rhs.type_);
                 }
+            default:
+                OPM_THROW(std::logic_error, "Invalid AutoDiffMatrix type encountered: " << rhs.type_);
             }
         }
 
@@ -178,6 +187,8 @@ namespace Opm
                     return rhs;
                 case S:
                     return rhs;
+                default:
+                    OPM_THROW(std::logic_error, "Invalid AutoDiffMatrix type encountered: " << rhs.type_);
                 }
             case D:
                 switch (rhs.type_) {
@@ -189,6 +200,8 @@ namespace Opm
                     return prodDD(*this, rhs);
                 case S:
                     return prodDS(*this, rhs);
+                default:
+                    OPM_THROW(std::logic_error, "Invalid AutoDiffMatrix type encountered: " << rhs.type_);
                 }
             case S:
                 switch (rhs.type_) {
@@ -200,7 +213,11 @@ namespace Opm
                     return prodSD(*this, rhs);
                 case S:
                     return prodSS(*this, rhs);
+                default:
+                    OPM_THROW(std::logic_error, "Invalid AutoDiffMatrix type encountered: " << rhs.type_);
                 }
+            default:
+                OPM_THROW(std::logic_error, "Invalid AutoDiffMatrix type encountered: " << rhs.type_);
             }
         }
 
@@ -258,6 +275,8 @@ namespace Opm
                     retval.s_ *= rhs;
                     return retval;
                 }
+            default:
+                OPM_THROW(std::logic_error, "Invalid AutoDiffMatrix type encountered: " << type_);
             }
         }
 
@@ -292,6 +311,8 @@ namespace Opm
                     retval.s_ /= rhs;
                     return retval;
                 }
+            default:
+                OPM_THROW(std::logic_error, "Invalid AutoDiffMatrix type encountered: " << type_);
             }
         }
 
@@ -312,6 +333,8 @@ namespace Opm
                 return Eigen::Map<const Eigen::VectorXd>(d_.data(), rows_) * rhs;
             case S:
                 return s_ * rhs;
+            default:
+                OPM_THROW(std::logic_error, "Invalid AutoDiffMatrix type encountered: " << type_);
             }
         }
 
@@ -490,6 +513,8 @@ namespace Opm
                 return rows_;
             case S:
                 return s_.nonZeros();
+            default:
+                OPM_THROW(std::logic_error, "Invalid AutoDiffMatrix type encountered: " << type_);
             }
         }
 
@@ -505,6 +530,8 @@ namespace Opm
                 return (row == col) ? d_[row] : 0.0;
             case S:
                 return s_.coeff(row, col);
+            default:
+                OPM_THROW(std::logic_error, "Invalid AutoDiffMatrix type encountered: " << type_);
             }
         }
 

--- a/opm/autodiff/AutoDiffMatrix.hpp
+++ b/opm/autodiff/AutoDiffMatrix.hpp
@@ -106,7 +106,11 @@ namespace Opm
 
 
         AutoDiffMatrix(AutoDiffMatrix&& other)
-            : AutoDiffMatrix()
+            : type_(Z),
+              rows_(0),
+              cols_(0),
+              diag_(),
+              sparse_()
         {
             swap(other);
         }

--- a/opm/autodiff/AutoDiffMatrix.hpp
+++ b/opm/autodiff/AutoDiffMatrix.hpp
@@ -330,10 +330,11 @@ namespace Opm
 	{
 	    assert(lhs.type_ == D);
 	    assert(rhs.type_ == D);
-	    AutoDiffMatrix retval = lhs;
-	    for (int r = 0; r < lhs.rows_; ++r) {
-		retval.d_.diagonal().array() *= rhs.d_.diagonal().array();
-	    }
+	    AutoDiffMatrix retval;
+	    retval.type_ = D;
+	    retval.rows_ = lhs.rows_;
+	    retval.cols_ = rhs.cols_;
+	    retval.d_ = (lhs.d_.diagonal().array() * rhs.d_.diagonal().array()).matrix().asDiagonal();
 	    return retval;
 	}
 

--- a/opm/autodiff/AutoDiffMatrix.hpp
+++ b/opm/autodiff/AutoDiffMatrix.hpp
@@ -126,7 +126,7 @@ namespace Opm
             std::swap(rows_, other.rows_);
             std::swap(cols_, other.cols_);
             d_.swap(other.d_);
-            std::swap(s_, other.s_);
+            s_.swap(other.s_);
         }
 
 

--- a/opm/autodiff/AutoDiffMatrix.hpp
+++ b/opm/autodiff/AutoDiffMatrix.hpp
@@ -132,7 +132,7 @@ namespace Opm
                 case Z:
                     return *this;
                 case I:
-                    return sumII(*this, rhs);
+                    return addII(*this, rhs);
                 case D:
                     return rhs + (*this);
                 case S:
@@ -145,9 +145,9 @@ namespace Opm
                 case Z:
                     return *this;
                 case I:
-                    return sumDI(*this, rhs);
+                    return addDI(*this, rhs);
                 case D:
-                    return sumDD(*this, rhs);
+                    return addDD(*this, rhs);
                 case S:
                     return rhs + (*this);
                 default:
@@ -158,11 +158,11 @@ namespace Opm
                 case Z:
                     return *this;
                 case I:
-                    return sumSI(*this, rhs);
+                    return addSI(*this, rhs);
                 case D:
-                    return sumSD(*this, rhs);
+                    return addSD(*this, rhs);
                 case S:
-                    return sumSS(*this, rhs);
+                    return addSS(*this, rhs);
                 default:
                     OPM_THROW(std::logic_error, "Invalid AutoDiffMatrix type encountered: " << rhs.type_);
                 }
@@ -197,9 +197,9 @@ namespace Opm
                 case I:
                     return *this;
                 case D:
-                    return prodDD(*this, rhs);
+                    return mulDD(*this, rhs);
                 case S:
-                    return prodDS(*this, rhs);
+                    return mulDS(*this, rhs);
                 default:
                     OPM_THROW(std::logic_error, "Invalid AutoDiffMatrix type encountered: " << rhs.type_);
                 }
@@ -210,9 +210,9 @@ namespace Opm
                 case I:
                     return *this;
                 case D:
-                    return prodSD(*this, rhs);
+                    return mulSD(*this, rhs);
                 case S:
-                    return prodSS(*this, rhs);
+                    return mulSS(*this, rhs);
                 default:
                     OPM_THROW(std::logic_error, "Invalid AutoDiffMatrix type encountered: " << rhs.type_);
                 }
@@ -343,7 +343,7 @@ namespace Opm
 
 
 
-        static AutoDiffMatrix sumII(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+        static AutoDiffMatrix addII(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
         {
             assert(lhs.type_ == I);
             assert(rhs.type_ == I);
@@ -355,7 +355,7 @@ namespace Opm
             return retval;
         }
 
-        static AutoDiffMatrix sumDI(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+        static AutoDiffMatrix addDI(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
         {
             static_cast<void>(rhs); // Silence release-mode warning.
             assert(lhs.type_ == D);
@@ -367,7 +367,7 @@ namespace Opm
             return retval;
         }
 
-        static AutoDiffMatrix sumDD(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+        static AutoDiffMatrix addDD(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
         {
             assert(lhs.type_ == D);
             assert(rhs.type_ == D);
@@ -378,7 +378,7 @@ namespace Opm
             return retval;
         }
 
-        static AutoDiffMatrix sumSI(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+        static AutoDiffMatrix addSI(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
         {
             assert(lhs.type_ == S);
             assert(rhs.type_ == I);
@@ -391,7 +391,7 @@ namespace Opm
             return retval;
         }
 
-        static AutoDiffMatrix sumSD(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+        static AutoDiffMatrix addSD(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
         {
             assert(lhs.type_ == S);
             assert(rhs.type_ == D);
@@ -404,7 +404,7 @@ namespace Opm
             return retval;
         }
 
-        static AutoDiffMatrix sumSS(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+        static AutoDiffMatrix addSS(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
         {
             assert(lhs.type_ == S);
             assert(rhs.type_ == S);
@@ -420,7 +420,7 @@ namespace Opm
 
 
 
-        static AutoDiffMatrix prodDD(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+        static AutoDiffMatrix mulDD(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
         {
             assert(lhs.type_ == D);
             assert(rhs.type_ == D);
@@ -435,7 +435,7 @@ namespace Opm
             return retval;
         }
 
-        static AutoDiffMatrix prodDS(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+        static AutoDiffMatrix mulDS(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
         {
             assert(lhs.type_ == D);
             assert(rhs.type_ == S);
@@ -447,7 +447,7 @@ namespace Opm
             return retval;
         }
 
-        static AutoDiffMatrix prodSD(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+        static AutoDiffMatrix mulSD(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
         {
             assert(lhs.type_ == S);
             assert(rhs.type_ == D);
@@ -459,7 +459,7 @@ namespace Opm
             return retval;
         }
 
-        static AutoDiffMatrix prodSS(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
+        static AutoDiffMatrix mulSS(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
         {
             assert(lhs.type_ == S);
             assert(rhs.type_ == S);

--- a/opm/autodiff/AutoDiffMatrix.hpp
+++ b/opm/autodiff/AutoDiffMatrix.hpp
@@ -265,6 +265,40 @@ namespace Opm
 
 
 
+        AutoDiffMatrix operator/(const double rhs) const
+        {
+            switch (type_) {
+            case Z:
+                return *this;
+            case I:
+                {
+                    AutoDiffMatrix retval(*this);
+                    retval.type_ = D;
+                    retval.d_.assign(rows_, 1.0/rhs);
+                    return retval;
+                }
+            case D:
+                {
+                    AutoDiffMatrix retval(*this);
+                    for (double& elem : retval.d_) {
+                        elem /= rhs;
+                    }
+                    return retval;
+                }
+            case S:
+                {
+                    AutoDiffMatrix retval(*this);
+                    retval.s_ /= rhs;
+                    return retval;
+                }
+            }
+        }
+
+
+
+
+
+
         Eigen::VectorXd operator*(const Eigen::VectorXd& rhs) const
         {
             assert(cols_ == rhs.size());

--- a/opm/autodiff/AutoDiffMatrix.hpp
+++ b/opm/autodiff/AutoDiffMatrix.hpp
@@ -75,7 +75,7 @@ namespace Opm
             : type_(D),
               rows_(d.rows()),
               cols_(d.cols()),
-              diag_(Diag(d.diagonal().array().data(), d.diagonal().array().data() + d.rows()))
+              diag_(d.diagonal().array().data(), d.diagonal().array().data() + d.rows())
         {
         }
 
@@ -137,7 +137,7 @@ namespace Opm
             std::swap(rows_, other.rows_);
             std::swap(cols_, other.cols_);
             diag_.swap(other.diag_);
-            sparse_[0].swap(other.sparse_[0]);
+            std::swap(sparse_, other.sparse_);
         }
 
 
@@ -280,7 +280,7 @@ namespace Opm
                 {
                     AutoDiffMatrix retval(*this);
                     retval.type_ = D;
-                    retval.diag_ = Diag(rows_, rhs);
+                    retval.diag_.assign(rows_, rhs);
                     return retval;
                 }
             case D:
@@ -352,13 +352,9 @@ namespace Opm
             case I:
                 return rhs;
             case D:
-                {
-                    return Eigen::Map<const Eigen::VectorXd>(diag_.data(), rows_) * rhs;
-                }
+                return Eigen::Map<const Eigen::VectorXd>(diag_.data(), rows_) * rhs;
             case S:
-                {
-                    return sparse_[0] * rhs;
-                }
+                return sparse_[0] * rhs;
             default:
                 OPM_THROW(std::logic_error, "Invalid AutoDiffMatrix type encountered: " << type_);
             }
@@ -531,7 +527,7 @@ namespace Opm
             case D:
                 return rows_;
             case S:
-                return sparse_->nonZeros();
+                return sparse_[0].nonZeros();
             default:
                 OPM_THROW(std::logic_error, "Invalid AutoDiffMatrix type encountered: " << type_);
             }
@@ -548,7 +544,7 @@ namespace Opm
             case D:
                 return (row == col) ? diag_[row] : 0.0;
             case S:
-                return sparse_->coeff(row, col);
+                return sparse_[0].coeff(row, col);
             default:
                 OPM_THROW(std::logic_error, "Invalid AutoDiffMatrix type encountered: " << type_);
             }

--- a/opm/autodiff/AutoDiffMatrix.hpp
+++ b/opm/autodiff/AutoDiffMatrix.hpp
@@ -343,11 +343,13 @@ namespace Opm
 	    assert(lhs.type_ == D);
 	    assert(rhs.type_ == S);
 	    AutoDiffMatrix retval;
-	    Eigen::SparseMatrix<double> diag = spdiag(lhs.d_.diagonal());
+	    // Eigen::SparseMatrix<double> diag = spdiag(lhs.d_.diagonal());
 	    retval.type_ = S;
 	    retval.rows_ = lhs.rows_;
 	    retval.cols_ = rhs.cols_;
-	    fastSparseProduct(diag, rhs.s_, retval.s_);
+	    // fastSparseProduct(diag, rhs.s_, retval.s_);
+	    fastDiagSparseProduct(lhs.d_, rhs.s_, retval.s_);
+	    // retval.s_ = lhs.d_ * rhs.s_;
 	    return retval;
 	}
 
@@ -356,11 +358,13 @@ namespace Opm
 	    assert(lhs.type_ == S);
 	    assert(rhs.type_ == D);
 	    AutoDiffMatrix retval;
-	    Eigen::SparseMatrix<double> diag = spdiag(rhs.d_.diagonal());
+	    // Eigen::SparseMatrix<double> diag = spdiag(rhs.d_.diagonal());
 	    retval.type_ = S;
 	    retval.rows_ = lhs.rows_;
 	    retval.cols_ = rhs.cols_;
-	    fastSparseProduct(lhs.s_, diag, retval.s_);
+	    // fastSparseProduct(lhs.s_, diag, retval.s_);
+	    fastSparseDiagProduct(lhs.s_, rhs.d_, retval.s_);
+	    // retval.s_ = lhs.s_ * rhs.d_;
 	    return retval;
 	}
 

--- a/opm/autodiff/AutoDiffMatrix.hpp
+++ b/opm/autodiff/AutoDiffMatrix.hpp
@@ -93,6 +93,7 @@ namespace Opm
 
 
         AutoDiffMatrix(AutoDiffMatrix&& other)
+            : AutoDiffMatrix()
         {
             swap(other);
         }

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -230,7 +230,7 @@ namespace Opm {
             WellOps(const Wells* wells);
             // M w2p;              // well -> perf (scatter)
             // M p2w;              // perf -> well (gather)
-	    Eigen::SparseMatrix<double> w2p;              // well -> perf (scatter)
+            Eigen::SparseMatrix<double> w2p;              // well -> perf (scatter)
             Eigen::SparseMatrix<double> p2w;              // perf -> well (gather)
         };
 

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -228,8 +228,10 @@ namespace Opm {
 
         struct WellOps {
             WellOps(const Wells* wells);
-            M w2p;              // well -> perf (scatter)
-            M p2w;              // perf -> well (gather)
+            // M w2p;              // well -> perf (scatter)
+            // M p2w;              // perf -> well (gather)
+	    Eigen::SparseMatrix<double> w2p;              // well -> perf (scatter)
+            Eigen::SparseMatrix<double> p2w;              // perf -> well (gather)
         };
 
         // ---------  Data members  ---------

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -228,8 +228,6 @@ namespace Opm {
 
         struct WellOps {
             WellOps(const Wells* wells);
-            // M w2p;              // well -> perf (scatter)
-            // M p2w;              // perf -> well (gather)
             Eigen::SparseMatrix<double> w2p;              // well -> perf (scatter)
             Eigen::SparseMatrix<double> p2w;              // perf -> well (gather)
         };

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -327,8 +327,8 @@ namespace detail {
     {
         if( wells )
         {
-            w2p = M(wells->well_connpos[ wells->number_of_wells ], wells->number_of_wells);
-            p2w = M(wells->number_of_wells, wells->well_connpos[ wells->number_of_wells ]);
+            w2p = Eigen::SparseMatrix<double>(wells->well_connpos[ wells->number_of_wells ], wells->number_of_wells);
+            p2w = Eigen::SparseMatrix<double>(wells->number_of_wells, wells->well_connpos[ wells->number_of_wells ]);
 
             const int        nw   = wells->number_of_wells;
             const int* const wpos = wells->well_connpos;
@@ -1441,7 +1441,10 @@ namespace detail {
                 eqs.push_back(residual_.well_eq);
                 ADB total_residual = vertcatCollapseJacs(eqs);
                 const std::vector<M>& Jn = total_residual.derivative();
-                const Eigen::SparseLU< M > solver(Jn[0]);
+	        typedef Eigen::SparseMatrix<double> Sp;
+	        Sp Jn0;
+	        Jn[0].toSparse(Jn0);
+                const Eigen::SparseLU< Sp > solver(Jn0);
                 const Eigen::VectorXd& dx = solver.solve(total_residual.value().matrix());
                 assert(dx.size() == (well_state.numWells() * (well_state.numPhases()+1)));
                 updateWellState(dx.array(), well_state);
@@ -1517,7 +1520,7 @@ namespace detail {
         //Target vars
         ADB::V bhp_targets  = ADB::V::Zero(nw);
         ADB::V rate_targets = ADB::V::Zero(nw);
-        ADB::M rate_distr(nw, np*nw);
+	Eigen::SparseMatrix<double> rate_distr(nw, np*nw);
 
         //Selection variables
         std::vector<int> bhp_elems;
@@ -1630,7 +1633,7 @@ namespace detail {
         // For wells that are dead (not flowing), and therefore not communicating
         // with the reservoir, we set the equation to be equal to the well's total
         // flow. This will be a solution only if the target rate is also zero.
-        M rate_summer(nw, np*nw);
+	Eigen::SparseMatrix<double> rate_summer(nw, np*nw);
         for (int w = 0; w < nw; ++w) {
             for (int phase = 0; phase < np; ++phase) {
                 rate_summer.insert(w, phase*nw + w) = 1.0;
@@ -2175,7 +2178,7 @@ namespace detail {
         const V high_potential = (dp.value().abs() >= threshold_pressures_by_interior_face_).template cast<double>();
 
         // Create a sparse vector that nullifies the low potential elements.
-        const M keep_high_potential = spdiag(high_potential);
+        const M keep_high_potential(high_potential.matrix().asDiagonal());
 
         // Find the current sign for the threshold modification
         const V sign_dp = sign(dp.value());
@@ -2641,7 +2644,7 @@ namespace detail {
                 pm[i] = rock_comp_props_->poroMult(p.value()[i]);
                 dpm[i] = rock_comp_props_->poroMultDeriv(p.value()[i]);
             }
-            ADB::M dpm_diag = spdiag(dpm);
+            ADB::M dpm_diag(dpm.matrix().asDiagonal());
             const int num_blocks = p.numBlocks();
             std::vector<ADB::M> jacs(num_blocks);
             for (int block = 0; block < num_blocks; ++block) {
@@ -2669,7 +2672,7 @@ namespace detail {
                 tm[i] = rock_comp_props_->transMult(p.value()[i]);
                 dtm[i] = rock_comp_props_->transMultDeriv(p.value()[i]);
             }
-            ADB::M dtm_diag = spdiag(dtm);
+            ADB::M dtm_diag(dtm.matrix().asDiagonal());
             const int num_blocks = p.numBlocks();
             std::vector<ADB::M> jacs(num_blocks);
             for (int block = 0; block < num_blocks; ++block) {

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1445,7 +1445,8 @@ namespace detail {
                 Sp Jn0;
                 Jn[0].toSparse(Jn0);
                 const Eigen::SparseLU< Sp > solver(Jn0);
-                const Eigen::VectorXd& dx = solver.solve(total_residual.value().matrix());
+                ADB::V total_residual_v = total_residual.value();
+                const Eigen::VectorXd& dx = solver.solve(total_residual_v.matrix());
                 assert(dx.size() == (well_state.numWells() * (well_state.numPhases()+1)));
                 updateWellState(dx.array(), well_state);
                 updateWellControls(well_state);

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -797,7 +797,7 @@ namespace detail {
         // get reasonable initial conditions for the wells
         updateWellControls(well_state);
 
-        // Create the primary variables.      
+        // Create the primary variables.
         SolutionState state = asImpl().variableState(reservoir_state, well_state);
 
         if (initial_assembly) {
@@ -978,7 +978,7 @@ namespace detail {
                 selectInjectingPerforations[c] = 1;
             else
                 selectProducingPerforations[c] = 1;
-        }   
+        }
 
         // HANDLE FLOW INTO WELLBORE
         // compute phase volumetric rates at standard conditions
@@ -1441,9 +1441,9 @@ namespace detail {
                 eqs.push_back(residual_.well_eq);
                 ADB total_residual = vertcatCollapseJacs(eqs);
                 const std::vector<M>& Jn = total_residual.derivative();
-	        typedef Eigen::SparseMatrix<double> Sp;
-	        Sp Jn0;
-	        Jn[0].toSparse(Jn0);
+                typedef Eigen::SparseMatrix<double> Sp;
+                Sp Jn0;
+                Jn[0].toSparse(Jn0);
                 const Eigen::SparseLU< Sp > solver(Jn0);
                 const Eigen::VectorXd& dx = solver.solve(total_residual.value().matrix());
                 assert(dx.size() == (well_state.numWells() * (well_state.numPhases()+1)));
@@ -1520,7 +1520,7 @@ namespace detail {
         //Target vars
         ADB::V bhp_targets  = ADB::V::Zero(nw);
         ADB::V rate_targets = ADB::V::Zero(nw);
-	Eigen::SparseMatrix<double> rate_distr(nw, np*nw);
+        Eigen::SparseMatrix<double> rate_distr(nw, np*nw);
 
         //Selection variables
         std::vector<int> bhp_elems;
@@ -1633,7 +1633,7 @@ namespace detail {
         // For wells that are dead (not flowing), and therefore not communicating
         // with the reservoir, we set the equation to be equal to the well's total
         // flow. This will be a solution only if the target rate is also zero.
-	Eigen::SparseMatrix<double> rate_summer(nw, np*nw);
+        Eigen::SparseMatrix<double> rate_summer(nw, np*nw);
         for (int w = 0; w < nw; ++w) {
             for (int phase = 0; phase < np; ++phase) {
                 rate_summer.insert(w, phase*nw + w) = 1.0;

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -384,7 +384,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         if (pw.derivative().empty()) {
             return ADB::constant(std::move(mu));
         } else {
-            // ADB::M dmudp_diag = spdiag(dmudp);
             ADB::M dmudp_diag(dmudp.matrix().asDiagonal());
             const int num_blocks = pw.numBlocks();
             std::vector<ADB::M> jacs(num_blocks);
@@ -421,8 +420,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         props_[phase_usage_.phase_pos[Oil]]->mu(n, pvt_region_.data(), po.value().data(), T.value().data(), rs.value().data(),
                                                 &cond[0], mu.data(), dmudp.data(), dmudr.data());
 
-        // ADB::M dmudp_diag = spdiag(dmudp);
-        // ADB::M dmudr_diag = spdiag(dmudr);
         ADB::M dmudp_diag(dmudp.matrix().asDiagonal());
         ADB::M dmudr_diag(dmudr.matrix().asDiagonal());
         const int num_blocks = po.numBlocks();
@@ -431,7 +428,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             fastSparseProduct(dmudp_diag, po.derivative()[block], jacs[block]);
             ADB::M temp;
             fastSparseProduct(dmudr_diag, rs.derivative()[block], temp);
-            // jacs[block] += temp;
             jacs[block] = jacs[block] + temp;
         }
         return ADB::function(std::move(mu), std::move(jacs));
@@ -463,8 +459,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         props_[phase_usage_.phase_pos[Gas]]->mu(n, pvt_region_.data(), pg.value().data(), T.value().data(), rv.value().data(),&cond[0],
                                                   mu.data(), dmudp.data(), dmudr.data());
 
-        // ADB::M dmudp_diag = spdiag(dmudp);
-        // ADB::M dmudr_diag = spdiag(dmudr);
         ADB::M dmudp_diag(dmudp.matrix().asDiagonal());
         ADB::M dmudr_diag(dmudr.matrix().asDiagonal());
         const int num_blocks = pg.numBlocks();
@@ -473,7 +467,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             fastSparseProduct(dmudp_diag, pg.derivative()[block], jacs[block]);
             ADB::M temp;
             fastSparseProduct(dmudr_diag, rv.derivative()[block], temp);
-            // jacs[block] += temp;
             jacs[block] = jacs[block] + temp;
         }
         return ADB::function(std::move(mu), std::move(jacs));
@@ -507,7 +500,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         props_[phase_usage_.phase_pos[Water]]->b(n, pvt_region_.data(), pw.value().data(), T.value().data(), rs,
                                                  b.data(), dbdp.data(), dbdr.data());
 
-        // ADB::M dbdp_diag = spdiag(dbdp);
         ADB::M dbdp_diag(dbdp.matrix().asDiagonal());
         const int num_blocks = pw.numBlocks();
         std::vector<ADB::M> jacs(num_blocks);
@@ -544,8 +536,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         props_[phase_usage_.phase_pos[Oil]]->b(n, pvt_region_.data(), po.value().data(), T.value().data(), rs.value().data(),
                                                &cond[0], b.data(), dbdp.data(), dbdr.data());
 
-        // ADB::M dbdp_diag = spdiag(dbdp);
-        // ADB::M dbdr_diag = spdiag(dbdr);
         ADB::M dbdp_diag(dbdp.matrix().asDiagonal());
         ADB::M dbdr_diag(dbdr.matrix().asDiagonal());
         const int num_blocks = po.numBlocks();
@@ -554,7 +544,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             fastSparseProduct(dbdp_diag, po.derivative()[block], jacs[block]);
             ADB::M temp;
             fastSparseProduct(dbdr_diag, rs.derivative()[block], temp);
-            // jacs[block] += temp;
             jacs[block] = jacs[block] + temp;
         }
         return ADB::function(std::move(b), std::move(jacs));
@@ -587,8 +576,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         props_[phase_usage_.phase_pos[Gas]]->b(n, pvt_region_.data(), pg.value().data(), T.value().data(), rv.value().data(), &cond[0],
                                                b.data(), dbdp.data(), dbdr.data());
 
-        // ADB::M dbdp_diag = spdiag(dbdp);
-        // ADB::M dbdr_diag = spdiag(dbdr);
         ADB::M dbdp_diag(dbdp.matrix().asDiagonal());
         ADB::M dbdr_diag(dbdr.matrix().asDiagonal());
         const int num_blocks = pg.numBlocks();
@@ -597,7 +584,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             fastSparseProduct(dbdp_diag, pg.derivative()[block], jacs[block]);
             ADB::M temp;
             fastSparseProduct(dbdr_diag, rv.derivative()[block], temp);
-            // jacs[block] += temp;
             jacs[block] = jacs[block] + temp;
         }
         return ADB::function(std::move(b), std::move(jacs));
@@ -623,7 +609,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         V rbub(n);
         V drbubdp(n);
         props_[phase_usage_.phase_pos[Oil]]->rsSat(n, pvt_region_.data(), po.value().data(), rbub.data(), drbubdp.data());
-        // ADB::M drbubdp_diag = spdiag(drbubdp);
         ADB::M drbubdp_diag(drbubdp.matrix().asDiagonal());
         const int num_blocks = po.numBlocks();
         std::vector<ADB::M> jacs(num_blocks);
@@ -665,7 +650,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         V rv(n);
         V drvdp(n);
         props_[phase_usage_.phase_pos[Gas]]->rvSat(n, pvt_region_.data(), po.value().data(), rv.data(), drvdp.data());
-        // ADB::M drvdp_diag = spdiag(drvdp);
         ADB::M drvdp_diag(drvdp.matrix().asDiagonal());
         const int num_blocks = po.numBlocks();
         std::vector<ADB::M> jacs(num_blocks);
@@ -742,12 +726,11 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
                     const int phase2_pos = phase_usage_.phase_pos[phase2];
                     // Assemble dkr1/ds2.
                     const int column = phase1_pos + np*phase2_pos; // Recall: Fortran ordering from props_.relperm()
-                    // ADB::M dkr1_ds2_diag = spdiag(dkr.col(column));
+
                     ADB::M dkr1_ds2_diag(dkr.col(column).matrix().asDiagonal());
                     for (int block = 0; block < num_blocks; ++block) {
                         ADB::M temp;
                         fastSparseProduct(dkr1_ds2_diag, s[phase2]->derivative()[block], temp);
-                        // jacs[block] += temp;
                         jacs[block] = jacs[block] + temp;
                     }
                 }
@@ -805,12 +788,10 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
                     const int phase2_pos = phase_usage_.phase_pos[phase2];
                     // Assemble dpc1/ds2.
                     const int column = phase1_pos + nActivePhases*phase2_pos; // Recall: Fortran ordering from props_.relperm()
-                    // ADB::M dpc1_ds2_diag = spdiag(dpc.col(column));
                     ADB::M dpc1_ds2_diag(dpc.col(column).matrix().asDiagonal());
                     for (int block = 0; block < nBlocks; ++block) {
                         ADB::M temp;
                         fastSparseProduct(dpc1_ds2_diag, s[phase2]->derivative()[block], temp);
-                        // jacs[block] += temp;
                         jacs[block] = jacs[block] + temp;
                     }
                 }
@@ -912,7 +893,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
                     dfactor_dso[i] = vap*std::pow(so_i/satOilMax_[cells[i]], vap-1.0)/satOilMax_[cells[i]];
                 }
             }
-            // ADB::M dfactor_dso_diag = spdiag(dfactor_dso);
             ADB::M dfactor_dso_diag(dfactor_dso.matrix().asDiagonal());
             const int num_blocks = so.numBlocks();
             std::vector<ADB::M> jacs(num_blocks);

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -384,7 +384,8 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         if (pw.derivative().empty()) {
             return ADB::constant(std::move(mu));
         } else {
-            ADB::M dmudp_diag = spdiag(dmudp);
+            // ADB::M dmudp_diag = spdiag(dmudp);
+            ADB::M dmudp_diag(dmudp.matrix().asDiagonal());
             const int num_blocks = pw.numBlocks();
             std::vector<ADB::M> jacs(num_blocks);
             for (int block = 0; block < num_blocks; ++block) {
@@ -420,15 +421,18 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         props_[phase_usage_.phase_pos[Oil]]->mu(n, pvt_region_.data(), po.value().data(), T.value().data(), rs.value().data(),
                                                 &cond[0], mu.data(), dmudp.data(), dmudr.data());
 
-        ADB::M dmudp_diag = spdiag(dmudp);
-        ADB::M dmudr_diag = spdiag(dmudr);
+        // ADB::M dmudp_diag = spdiag(dmudp);
+        // ADB::M dmudr_diag = spdiag(dmudr);
+        ADB::M dmudp_diag(dmudp.matrix().asDiagonal());
+        ADB::M dmudr_diag(dmudr.matrix().asDiagonal());
         const int num_blocks = po.numBlocks();
         std::vector<ADB::M> jacs(num_blocks);
         for (int block = 0; block < num_blocks; ++block) {
             fastSparseProduct(dmudp_diag, po.derivative()[block], jacs[block]);
             ADB::M temp;
             fastSparseProduct(dmudr_diag, rs.derivative()[block], temp);
-            jacs[block] += temp;
+            // jacs[block] += temp;
+	    jacs[block] = jacs[block] + temp;
         }
         return ADB::function(std::move(mu), std::move(jacs));
     }
@@ -459,15 +463,18 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         props_[phase_usage_.phase_pos[Gas]]->mu(n, pvt_region_.data(), pg.value().data(), T.value().data(), rv.value().data(),&cond[0],
                                                   mu.data(), dmudp.data(), dmudr.data());
 
-        ADB::M dmudp_diag = spdiag(dmudp);
-        ADB::M dmudr_diag = spdiag(dmudr);
+        // ADB::M dmudp_diag = spdiag(dmudp);
+        // ADB::M dmudr_diag = spdiag(dmudr);
+        ADB::M dmudp_diag(dmudp.matrix().asDiagonal());
+        ADB::M dmudr_diag(dmudr.matrix().asDiagonal());
         const int num_blocks = pg.numBlocks();
         std::vector<ADB::M> jacs(num_blocks);
         for (int block = 0; block < num_blocks; ++block) {
             fastSparseProduct(dmudp_diag, pg.derivative()[block], jacs[block]);
             ADB::M temp;
             fastSparseProduct(dmudr_diag, rv.derivative()[block], temp);
-            jacs[block] += temp;
+            // jacs[block] += temp;
+	    jacs[block] = jacs[block] + temp;
         }
         return ADB::function(std::move(mu), std::move(jacs));
     }
@@ -500,7 +507,8 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         props_[phase_usage_.phase_pos[Water]]->b(n, pvt_region_.data(), pw.value().data(), T.value().data(), rs,
                                                  b.data(), dbdp.data(), dbdr.data());
 
-        ADB::M dbdp_diag = spdiag(dbdp);
+        // ADB::M dbdp_diag = spdiag(dbdp);
+        ADB::M dbdp_diag(dbdp.matrix().asDiagonal());
         const int num_blocks = pw.numBlocks();
         std::vector<ADB::M> jacs(num_blocks);
         for (int block = 0; block < num_blocks; ++block) {
@@ -536,15 +544,18 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         props_[phase_usage_.phase_pos[Oil]]->b(n, pvt_region_.data(), po.value().data(), T.value().data(), rs.value().data(),
                                                &cond[0], b.data(), dbdp.data(), dbdr.data());
 
-        ADB::M dbdp_diag = spdiag(dbdp);
-        ADB::M dbdr_diag = spdiag(dbdr);
+        // ADB::M dbdp_diag = spdiag(dbdp);
+        // ADB::M dbdr_diag = spdiag(dbdr);
+        ADB::M dbdp_diag(dbdp.matrix().asDiagonal());
+        ADB::M dbdr_diag(dbdr.matrix().asDiagonal());
         const int num_blocks = po.numBlocks();
         std::vector<ADB::M> jacs(num_blocks);
         for (int block = 0; block < num_blocks; ++block) {
             fastSparseProduct(dbdp_diag, po.derivative()[block], jacs[block]);
             ADB::M temp;
             fastSparseProduct(dbdr_diag, rs.derivative()[block], temp);
-            jacs[block] += temp;
+            // jacs[block] += temp;
+	    jacs[block] = jacs[block] + temp;
         }
         return ADB::function(std::move(b), std::move(jacs));
     }
@@ -576,15 +587,18 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         props_[phase_usage_.phase_pos[Gas]]->b(n, pvt_region_.data(), pg.value().data(), T.value().data(), rv.value().data(), &cond[0],
                                                b.data(), dbdp.data(), dbdr.data());
 
-        ADB::M dbdp_diag = spdiag(dbdp);
-        ADB::M dbdr_diag = spdiag(dbdr);
+        // ADB::M dbdp_diag = spdiag(dbdp);
+        // ADB::M dbdr_diag = spdiag(dbdr);
+        ADB::M dbdp_diag(dbdp.matrix().asDiagonal());
+        ADB::M dbdr_diag(dbdr.matrix().asDiagonal());
         const int num_blocks = pg.numBlocks();
         std::vector<ADB::M> jacs(num_blocks);
         for (int block = 0; block < num_blocks; ++block) {
             fastSparseProduct(dbdp_diag, pg.derivative()[block], jacs[block]);
             ADB::M temp;
             fastSparseProduct(dbdr_diag, rv.derivative()[block], temp);
-            jacs[block] += temp;
+            // jacs[block] += temp;
+	    jacs[block] = jacs[block] + temp;
         }
         return ADB::function(std::move(b), std::move(jacs));
     }
@@ -609,7 +623,8 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         V rbub(n);
         V drbubdp(n);
         props_[phase_usage_.phase_pos[Oil]]->rsSat(n, pvt_region_.data(), po.value().data(), rbub.data(), drbubdp.data());
-        ADB::M drbubdp_diag = spdiag(drbubdp);
+        // ADB::M drbubdp_diag = spdiag(drbubdp);
+        ADB::M drbubdp_diag(drbubdp.matrix().asDiagonal());
         const int num_blocks = po.numBlocks();
         std::vector<ADB::M> jacs(num_blocks);
         for (int block = 0; block < num_blocks; ++block) {
@@ -650,7 +665,8 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         V rv(n);
         V drvdp(n);
         props_[phase_usage_.phase_pos[Gas]]->rvSat(n, pvt_region_.data(), po.value().data(), rv.data(), drvdp.data());
-        ADB::M drvdp_diag = spdiag(drvdp);
+        // ADB::M drvdp_diag = spdiag(drvdp);
+        ADB::M drvdp_diag(drvdp.matrix().asDiagonal());
         const int num_blocks = po.numBlocks();
         std::vector<ADB::M> jacs(num_blocks);
         for (int block = 0; block < num_blocks; ++block) {
@@ -726,11 +742,13 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
                     const int phase2_pos = phase_usage_.phase_pos[phase2];
                     // Assemble dkr1/ds2.
                     const int column = phase1_pos + np*phase2_pos; // Recall: Fortran ordering from props_.relperm()
-                    ADB::M dkr1_ds2_diag = spdiag(dkr.col(column));
+                    // ADB::M dkr1_ds2_diag = spdiag(dkr.col(column));
+                    ADB::M dkr1_ds2_diag(dkr.col(column).matrix().asDiagonal());
                     for (int block = 0; block < num_blocks; ++block) {
                         ADB::M temp;
                         fastSparseProduct(dkr1_ds2_diag, s[phase2]->derivative()[block], temp);
-                        jacs[block] += temp;
+                        // jacs[block] += temp;
+                        jacs[block] = jacs[block] + temp;
                     }
                 }
                 ADB::V val = kr.col(phase1_pos);
@@ -787,11 +805,13 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
                     const int phase2_pos = phase_usage_.phase_pos[phase2];
                     // Assemble dpc1/ds2.
                     const int column = phase1_pos + nActivePhases*phase2_pos; // Recall: Fortran ordering from props_.relperm()
-                    ADB::M dpc1_ds2_diag = spdiag(dpc.col(column));
+                    // ADB::M dpc1_ds2_diag = spdiag(dpc.col(column));
+                    ADB::M dpc1_ds2_diag(dpc.col(column).matrix().asDiagonal());
                     for (int block = 0; block < nBlocks; ++block) {
                         ADB::M temp;
                         fastSparseProduct(dpc1_ds2_diag, s[phase2]->derivative()[block], temp);
-                        jacs[block] += temp;
+                        // jacs[block] += temp;
+                        jacs[block] = jacs[block] + temp;
                     }
                 }
                 ADB::V val = pc.col(phase1_pos);
@@ -892,7 +912,8 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
                     dfactor_dso[i] = vap*std::pow(so_i/satOilMax_[cells[i]], vap-1.0)/satOilMax_[cells[i]];
                 }
             }
-            ADB::M dfactor_dso_diag = spdiag(dfactor_dso);
+            // ADB::M dfactor_dso_diag = spdiag(dfactor_dso);
+            ADB::M dfactor_dso_diag(dfactor_dso.matrix().asDiagonal());
             const int num_blocks = so.numBlocks();
             std::vector<ADB::M> jacs(num_blocks);
             for (int block = 0; block < num_blocks; ++block) {

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -432,7 +432,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             ADB::M temp;
             fastSparseProduct(dmudr_diag, rs.derivative()[block], temp);
             // jacs[block] += temp;
-	    jacs[block] = jacs[block] + temp;
+            jacs[block] = jacs[block] + temp;
         }
         return ADB::function(std::move(mu), std::move(jacs));
     }
@@ -474,7 +474,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             ADB::M temp;
             fastSparseProduct(dmudr_diag, rv.derivative()[block], temp);
             // jacs[block] += temp;
-	    jacs[block] = jacs[block] + temp;
+            jacs[block] = jacs[block] + temp;
         }
         return ADB::function(std::move(mu), std::move(jacs));
     }
@@ -555,7 +555,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             ADB::M temp;
             fastSparseProduct(dbdr_diag, rs.derivative()[block], temp);
             // jacs[block] += temp;
-	    jacs[block] = jacs[block] + temp;
+            jacs[block] = jacs[block] + temp;
         }
         return ADB::function(std::move(b), std::move(jacs));
     }
@@ -598,7 +598,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             ADB::M temp;
             fastSparseProduct(dbdr_diag, rv.derivative()[block], temp);
             // jacs[block] += temp;
-	    jacs[block] = jacs[block] + temp;
+            jacs[block] = jacs[block] + temp;
         }
         return ADB::function(std::move(b), std::move(jacs));
     }
@@ -822,7 +822,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         }
         return adbCapPressures;
     }
-                                  
+
     /// Saturation update for hysteresis behavior.
     /// \param[in]  cells       Array of n cell indices to be associated with the saturation values.
     void BlackoilPropsAdFromDeck::updateSatHyst(const std::vector<double>& saturation,
@@ -831,7 +831,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         const int n = cells.size();
         satprops_->updateSatHyst(n, cells.data(), saturation.data());
     }
-    
+
     /// Update for max oil saturation.
     void BlackoilPropsAdFromDeck::updateSatOilMax(const std::vector<double>& saturation)
     {
@@ -863,7 +863,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         }
     }
 
-    
+
     /// Apply correction to rs/rv according to kw VAPPARS
     /// \param[in/out] r     Array of n rs/rv values.
     /// \param[in]     so    Array of n oil saturation values.
@@ -874,7 +874,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
                                            const std::vector<int>& cells,
                                            const double vap) const
     {
-        if (!satOilMax_.empty() && vap > 0.0) { 
+        if (!satOilMax_.empty() && vap > 0.0) {
             const int n = cells.size();
             V factor = V::Ones(n, 1);
             const double eps_sqrt = std::sqrt(std::numeric_limits<double>::epsilon());
@@ -883,12 +883,12 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
                     // guard against too small saturation values.
                     const double so_i= std::max(so[i],eps_sqrt);
                     factor[i] = std::pow(so_i/satOilMax_[cells[i]], vap);
-                } 
+                }
             }
             r = factor*r;
         }
     }
-    
+
     /// Apply correction to rs/rv according to kw VAPPARS
     /// \param[in/out] r     Array of n rs/rv values.
     /// \param[in]     so    Array of n oil saturation values.
@@ -899,7 +899,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
                                            const std::vector<int>& cells,
                                            const double vap) const
     {
-        if (!satOilMax_.empty() && vap > 0.0) { 
+        if (!satOilMax_.empty() && vap > 0.0) {
             const int n = cells.size();
             V factor = V::Ones(n, 1);
             const double eps_sqrt = std::sqrt(std::numeric_limits<double>::epsilon());

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
@@ -208,9 +208,13 @@ namespace Opm
         // Find sparsity structure as union of basic block sparsity structures,
         // corresponding to the jacobians with respect to pressure.
         // Use addition to get to the union structure.
-        Eigen::SparseMatrix<double> structure = eqs[0].derivative()[0];
+	typedef Eigen::SparseMatrix<double> Sp;
+        Sp structure;
+	eqs[0].derivative()[0].toSparse(structure);
         for (int phase = 1; phase < np; ++phase) {
-            structure += eqs[phase].derivative()[0];
+	    Sp s0;
+	    eqs[phase].derivative()[0].toSparse(s0);
+	    structure += s0;
         }
 
         Eigen::SparseMatrix<double, Eigen::RowMajor> s = structure;

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
@@ -211,10 +211,12 @@ namespace Opm
         typedef Eigen::SparseMatrix<double> Sp;
         Sp structure;
         eqs[0].derivative()[0].toSparse(structure);
-        for (int phase = 1; phase < np; ++phase) {
+        {
             Sp s0;
-            eqs[phase].derivative()[0].toSparse(s0);
-            structure += s0;
+            for (int phase = 1; phase < np; ++phase) {
+                eqs[phase].derivative()[0].toSparse(s0);
+                structure += s0;
+            }
         }
 
         Eigen::SparseMatrix<double, Eigen::RowMajor> s = structure;

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
@@ -208,13 +208,13 @@ namespace Opm
         // Find sparsity structure as union of basic block sparsity structures,
         // corresponding to the jacobians with respect to pressure.
         // Use addition to get to the union structure.
-	typedef Eigen::SparseMatrix<double> Sp;
+        typedef Eigen::SparseMatrix<double> Sp;
         Sp structure;
-	eqs[0].derivative()[0].toSparse(structure);
+        eqs[0].derivative()[0].toSparse(structure);
         for (int phase = 1; phase < np; ++phase) {
-	    Sp s0;
-	    eqs[phase].derivative()[0].toSparse(s0);
-	    structure += s0;
+            Sp s0;
+            eqs[phase].derivative()[0].toSparse(s0);
+            structure += s0;
         }
 
         Eigen::SparseMatrix<double, Eigen::RowMajor> s = structure;

--- a/opm/autodiff/NewtonIterationBlackoilSimple.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilSimple.cpp
@@ -47,7 +47,6 @@ namespace Opm
     NewtonIterationBlackoilSimple::SolutionVector
     NewtonIterationBlackoilSimple::computeNewtonIncrement(const LinearisedBlackoilResidual& residual) const
     {
-        /*
         typedef LinearisedBlackoilResidual::ADB ADB;
         const int np = residual.material_balance_eq.size();
         ADB mass_res = residual.material_balance_eq[0];
@@ -57,7 +56,8 @@ namespace Opm
         const ADB well_res = vertcat(residual.well_flux_eq, residual.well_eq);
         const ADB total_residual = collapseJacs(vertcat(mass_res, well_res));
 
-        const Eigen::SparseMatrix<double, Eigen::RowMajor> matr = total_residual.derivative()[0];
+        Eigen::SparseMatrix<double, Eigen::RowMajor> matr;
+        total_residual.derivative()[0].toSparse(matr);
 
         SolutionVector dx(SolutionVector::Zero(total_residual.size()));
         Opm::LinearSolverInterface::LinearSolverReport rep
@@ -74,7 +74,6 @@ namespace Opm
                       "Linear solver convergence failure.");
         }
         return dx;
-        */
     }
 
     const boost::any& NewtonIterationBlackoilSimple::parallelInformation() const

--- a/opm/autodiff/NewtonIterationBlackoilSimple.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilSimple.cpp
@@ -47,6 +47,7 @@ namespace Opm
     NewtonIterationBlackoilSimple::SolutionVector
     NewtonIterationBlackoilSimple::computeNewtonIncrement(const LinearisedBlackoilResidual& residual) const
     {
+	/*
         typedef LinearisedBlackoilResidual::ADB ADB;
         const int np = residual.material_balance_eq.size();
         ADB mass_res = residual.material_balance_eq[0];
@@ -73,6 +74,7 @@ namespace Opm
                       "Linear solver convergence failure.");
         }
         return dx;
+	*/
     }
 
     const boost::any& NewtonIterationBlackoilSimple::parallelInformation() const

--- a/opm/autodiff/NewtonIterationBlackoilSimple.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilSimple.cpp
@@ -47,7 +47,7 @@ namespace Opm
     NewtonIterationBlackoilSimple::SolutionVector
     NewtonIterationBlackoilSimple::computeNewtonIncrement(const LinearisedBlackoilResidual& residual) const
     {
-	/*
+        /*
         typedef LinearisedBlackoilResidual::ADB ADB;
         const int np = residual.material_balance_eq.size();
         ADB mass_res = residual.material_balance_eq[0];
@@ -74,7 +74,7 @@ namespace Opm
                       "Linear solver convergence failure.");
         }
         return dx;
-	*/
+        */
     }
 
     const boost::any& NewtonIterationBlackoilSimple::parallelInformation() const

--- a/opm/autodiff/NewtonIterationUtilities.cpp
+++ b/opm/autodiff/NewtonIterationUtilities.cpp
@@ -62,9 +62,9 @@ namespace Opm
         const std::vector<M>& Jn = eqs[n].derivative();
 
         // Use sparse LU to solve the block submatrices i.e compute inv(D)
-	typedef Eigen::SparseMatrix<double> Sp;
-	Sp Jnn;
-	Jn[n].toSparse(Jnn);
+        typedef Eigen::SparseMatrix<double> Sp;
+        Sp Jnn;
+        Jn[n].toSparse(Jnn);
 #if HAVE_UMFPACK
         const Eigen::UmfPackLU<Sp> solver(Jnn);
 #else
@@ -109,8 +109,8 @@ namespace Opm
                 M Bu;
                 fastSparseProduct(B, u, Bu);
                 // J -= Bu;
-		Bu = Bu * -1.0;
-		J = J + Bu;
+                Bu = Bu * -1.0;
+                J = J + Bu;
             }
         }
 
@@ -150,9 +150,9 @@ namespace Opm
         const M& C = eq_coll.derivative()[0];
 
         // Use sparse LU to solve the block submatrices
-	typedef Eigen::SparseMatrix<double> Sp;
-	Sp D;
-	D1.toSparse(D);
+        typedef Eigen::SparseMatrix<double> Sp;
+        Sp D;
+        D1.toSparse(D);
 #if HAVE_UMFPACK
         const Eigen::UmfPackLU<Sp> solver(D);
 #else
@@ -198,7 +198,7 @@ namespace Opm
                             Eigen::SparseMatrix<double, Eigen::RowMajor>& A,
                             V& b)
     {
-	/*
+        /*
         if (num_phases != 3) {
             OPM_THROW(std::logic_error, "formEllipticSystem() requires 3 phases.");
         }
@@ -278,7 +278,7 @@ namespace Opm
         // Create output as product of L with equations.
         A = L * total_residual.derivative()[0];
         b = L * total_residual.value().matrix();
-	*/
+        */
     }
 
 

--- a/opm/autodiff/NewtonIterationUtilities.cpp
+++ b/opm/autodiff/NewtonIterationUtilities.cpp
@@ -111,7 +111,6 @@ namespace Opm
                 // Subtract Bu (B*inv(D)*C)
                 M Bu;
                 fastSparseProduct(B, u, Bu);
-                // J -= Bu;
                 J = J + (Bu * -1.0);
             }
         }

--- a/opm/autodiff/NewtonIterationUtilities.cpp
+++ b/opm/autodiff/NewtonIterationUtilities.cpp
@@ -76,6 +76,7 @@ namespace Opm
         const Sp Di = solver.solve(id);
 
         // compute inv(D)*bn for the update of the right hand side
+        // Note: Eigen version > 3.2 requires a non-const reference to solve.
         ADB::V eqs_n_v = eqs[n].value();
         const Eigen::VectorXd& Dibn = solver.solve(eqs_n_v.matrix());
 

--- a/opm/autodiff/NewtonIterationUtilities.cpp
+++ b/opm/autodiff/NewtonIterationUtilities.cpp
@@ -112,8 +112,7 @@ namespace Opm
                 M Bu;
                 fastSparseProduct(B, u, Bu);
                 // J -= Bu;
-                Bu = Bu * -1.0;
-                J = J + Bu;
+                J = J + (Bu * -1.0);
             }
         }
 

--- a/opm/autodiff/SolventPropsAdFromDeck.cpp
+++ b/opm/autodiff/SolventPropsAdFromDeck.cpp
@@ -26,6 +26,8 @@ namespace Opm
 {
 // Making these typedef to make the code more readable.
 typedef SolventPropsAdFromDeck::ADB ADB;
+typedef Eigen::SparseMatrix<double> S;
+typedef Eigen::DiagonalMatrix<double, Eigen::Dynamic> D;
 typedef SolventPropsAdFromDeck::V V;
 typedef Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> Block;
 
@@ -135,11 +137,11 @@ ADB SolventPropsAdFromDeck::muSolvent(const ADB& pg,
                          - tempInvB * inverseBmu_[regionIdx].derivative(pg_i)) / (tempInvBmu * tempInvBmu);
     }
 
-    ADB::M dmudp_diag = spdiag(dmudp);
+    ADB::M dmudp_diag(dmudp.matrix().asDiagonal());
     const int num_blocks = pg.numBlocks();
     std::vector<ADB::M> jacs(num_blocks);
     for (int block = 0; block < num_blocks; ++block) {
-        fastSparseProduct(dmudp_diag, pg.derivative()[block], jacs[block]);
+        jacs[block] = dmudp_diag * pg.derivative()[block];
     }
     return ADB::function(std::move(mu), std::move(jacs));
 }
@@ -159,7 +161,7 @@ ADB SolventPropsAdFromDeck::bSolvent(const ADB& pg,
         dbdp[i] = b_[regionIdx].derivative(pg_i);
     }
 
-    ADB::M dbdp_diag = spdiag(dbdp);
+    ADB::M dbdp_diag(dbdp.matrix().asDiagonal());
     const int num_blocks = pg.numBlocks();
     std::vector<ADB::M> jacs(num_blocks);
     for (int block = 0; block < num_blocks; ++block) {
@@ -182,7 +184,7 @@ ADB SolventPropsAdFromDeck::gasRelPermMultiplier(const ADB& solventFraction,
         dkrgdsf[i] = krg_[regionIdx].derivative(solventFraction_i);
     }
 
-    ADB::M dkrgdsf_diag = spdiag(dkrgdsf);
+    ADB::M dkrgdsf_diag(dkrgdsf.matrix().asDiagonal());
     const int num_blocks = solventFraction.numBlocks();
     std::vector<ADB::M> jacs(num_blocks);
     for (int block = 0; block < num_blocks; ++block) {
@@ -205,7 +207,7 @@ ADB SolventPropsAdFromDeck::solventRelPermMultiplier(const ADB& solventFraction,
         dkrsdsf[i] = krs_[regionIdx].derivative(solventFraction_i);
     }
 
-    ADB::M dkrsdsf_diag = spdiag(dkrsdsf);
+    ADB::M dkrsdsf_diag(dkrsdsf.matrix().asDiagonal());
     const int num_blocks = solventFraction.numBlocks();
     std::vector<ADB::M> jacs(num_blocks);
     for (int block = 0; block < num_blocks; ++block) {

--- a/opm/autodiff/VFPInjProperties.cpp
+++ b/opm/autodiff/VFPInjProperties.cpp
@@ -144,8 +144,10 @@ VFPInjProperties::ADB VFPInjProperties::bhp(const std::vector<int>& table_id,
     }
 
     //Create diagonal matrices from ADB::Vs
-    ADB::M dthp_diag = spdiag(dthp);
-    ADB::M dflo_diag = spdiag(dflo);
+    // ADB::M dthp_diag = spdiag(dthp);
+    // ADB::M dflo_diag = spdiag(dflo);
+    ADB::M dthp_diag(dthp.matrix().asDiagonal());
+    ADB::M dflo_diag(dflo.matrix().asDiagonal());
 
     //Calculate the Jacobians
     const int num_blocks = block_pattern.size();

--- a/opm/autodiff/VFPInjProperties.cpp
+++ b/opm/autodiff/VFPInjProperties.cpp
@@ -144,8 +144,6 @@ VFPInjProperties::ADB VFPInjProperties::bhp(const std::vector<int>& table_id,
     }
 
     //Create diagonal matrices from ADB::Vs
-    // ADB::M dthp_diag = spdiag(dthp);
-    // ADB::M dflo_diag = spdiag(dflo);
     ADB::M dthp_diag(dthp.matrix().asDiagonal());
     ADB::M dflo_diag(dflo.matrix().asDiagonal());
 

--- a/opm/autodiff/VFPProdProperties.cpp
+++ b/opm/autodiff/VFPProdProperties.cpp
@@ -143,11 +143,16 @@ VFPProdProperties::ADB VFPProdProperties::bhp(const std::vector<int>& table_id,
     }
 
     //Create diagonal matrices from ADB::Vs
-    ADB::M dthp_diag = spdiag(dthp);
-    ADB::M dwfr_diag = spdiag(dwfr);
-    ADB::M dgfr_diag = spdiag(dgfr);
-    ADB::M dalq_diag = spdiag(dalq);
-    ADB::M dflo_diag = spdiag(dflo);
+    // ADB::M dthp_diag = spdiag(dthp);
+    // ADB::M dwfr_diag = spdiag(dwfr);
+    // ADB::M dgfr_diag = spdiag(dgfr);
+    // ADB::M dalq_diag = spdiag(dalq);
+    // ADB::M dflo_diag = spdiag(dflo);
+    ADB::M dthp_diag(dthp.matrix().asDiagonal());
+    ADB::M dwfr_diag(dwfr.matrix().asDiagonal());
+    ADB::M dgfr_diag(dgfr.matrix().asDiagonal());
+    ADB::M dalq_diag(dalq.matrix().asDiagonal());
+    ADB::M dflo_diag(dflo.matrix().asDiagonal());
 
     //Calculate the Jacobians
     const int num_blocks = block_pattern.size();

--- a/opm/autodiff/VFPProdProperties.cpp
+++ b/opm/autodiff/VFPProdProperties.cpp
@@ -143,11 +143,6 @@ VFPProdProperties::ADB VFPProdProperties::bhp(const std::vector<int>& table_id,
     }
 
     //Create diagonal matrices from ADB::Vs
-    // ADB::M dthp_diag = spdiag(dthp);
-    // ADB::M dwfr_diag = spdiag(dwfr);
-    // ADB::M dgfr_diag = spdiag(dgfr);
-    // ADB::M dalq_diag = spdiag(dalq);
-    // ADB::M dflo_diag = spdiag(dflo);
     ADB::M dthp_diag(dthp.matrix().asDiagonal());
     ADB::M dwfr_diag(dwfr.matrix().asDiagonal());
     ADB::M dgfr_diag(dgfr.matrix().asDiagonal());

--- a/opm/autodiff/fastSparseProduct.hpp
+++ b/opm/autodiff/fastSparseProduct.hpp
@@ -56,16 +56,16 @@ struct QuickSort< 0 >
 };
 
 
-template<typename ResultType, typename Lhs, typename Rhs>
-ResultType fastSparseProduct(const Lhs& lhs, const Rhs& rhs)
+template<typename Lhs, typename Rhs, typename ResultType>
+void fastSparseProduct(const Lhs& lhs, const Rhs& rhs, ResultType& res)
 {
   // initialize result
-  ResultType res(lhs.rows(), rhs.cols());
+  res = ResultType(lhs.rows(), rhs.cols());
 
   // if one of the matrices does not contain non zero elements
   // the result will only contain an empty matrix
   if( lhs.nonZeros() == 0 || rhs.nonZeros() == 0 )
-    return res;
+    return;
 
   typedef typename Eigen::internal::remove_all<Lhs>::type::Scalar Scalar;
   typedef typename Eigen::internal::remove_all<Lhs>::type::Index Index;
@@ -137,19 +137,17 @@ ResultType fastSparseProduct(const Lhs& lhs, const Rhs& rhs)
 
   }
   res.finalize();
-
-  return res;
 }
 
 
 
 
-inline
-Eigen::SparseMatrix<double>
-fastDiagSparseProduct(const std::vector<double>& lhs,
-                      const Eigen::SparseMatrix<double>& rhs)
+inline void fastDiagSparseProduct(// const Eigen::DiagonalMatrix<double, Eigen::Dynamic>& lhs,
+                                  const std::vector<double>& lhs,
+                                  const Eigen::SparseMatrix<double>& rhs,
+                                  Eigen::SparseMatrix<double>& res)
 {
-    Eigen::SparseMatrix<double> res = rhs;
+    res = rhs;
 
     // Multiply rows by diagonal lhs.
     int n = res.cols();
@@ -159,19 +157,17 @@ fastDiagSparseProduct(const std::vector<double>& lhs,
             it.valueRef() *= lhs[it.row()]; // lhs.diagonal()(it.row());
         }
     }
-
-    return res;
 }
 
 
 
 
-inline
-Eigen::SparseMatrix<double>
-fastSparseDiagProduct(const Eigen::SparseMatrix<double>& lhs,
-                      const std::vector<double>& rhs)
+inline void fastSparseDiagProduct(const Eigen::SparseMatrix<double>& lhs,
+                                  // const Eigen::DiagonalMatrix<double, Eigen::Dynamic>& rhs,
+                                  const std::vector<double>& rhs,
+                                  Eigen::SparseMatrix<double>& res)
 {
-    Eigen::SparseMatrix<double> res = lhs;
+    res = lhs;
 
     // Multiply columns by diagonal rhs.
     int n = res.cols();
@@ -181,8 +177,6 @@ fastSparseDiagProduct(const Eigen::SparseMatrix<double>& lhs,
             it.valueRef() *= rhs[col]; // rhs.diagonal()(col);
         }
     }
-
-    return res;
 }
 
 

--- a/opm/autodiff/fastSparseProduct.hpp
+++ b/opm/autodiff/fastSparseProduct.hpp
@@ -153,7 +153,7 @@ inline void fastDiagSparseProduct(const Eigen::DiagonalMatrix<double, Eigen::Dyn
     for (int col = 0; col < n; ++col) {
 	typedef Eigen::SparseMatrix<double>::InnerIterator It;
 	for (It it(res, col); it; ++it) {
-	    it.valueRef() *= rhs.diagonal()(it.row());
+	    it.valueRef() *= lhs.diagonal()(it.row());
 	}
     }
 }

--- a/opm/autodiff/fastSparseProduct.hpp
+++ b/opm/autodiff/fastSparseProduct.hpp
@@ -141,6 +141,44 @@ void fastSparseProduct(const Lhs& lhs, const Rhs& rhs, ResultType& res)
 
 
 
+
+inline void fastDiagSparseProduct(const Eigen::DiagonalMatrix<double, Eigen::Dynamic>& lhs,
+				  const Eigen::SparseMatrix<double>& rhs,
+				  Eigen::SparseMatrix<double>& res)
+{
+    res = rhs;
+
+    // Multiply rows by diagonal lhs.
+    int n = res.cols();
+    for (int col = 0; col < n; ++col) {
+	typedef Eigen::SparseMatrix<double>::InnerIterator It;
+	for (It it(res, col); it; ++it) {
+	    it.valueRef() *= rhs.diagonal()(it.row());
+	}
+    }
+}
+
+
+
+
+inline void fastSparseDiagProduct(const Eigen::SparseMatrix<double>& lhs,
+				  const Eigen::DiagonalMatrix<double, Eigen::Dynamic>& rhs,
+				  Eigen::SparseMatrix<double>& res)
+{
+    res = lhs;
+
+    // Multiply columns by diagonal rhs.
+    int n = res.cols();
+    for (int col = 0; col < n; ++col) {
+	typedef Eigen::SparseMatrix<double>::InnerIterator It;
+	for (It it(res, col); it; ++it) {
+	    it.valueRef() *= rhs.diagonal()(col);
+	}
+    }
+}
+
+
+
 } // end namespace Opm
 
 #endif // OPM_FASTSPARSEPRODUCT_HEADER_INCLUDED

--- a/opm/autodiff/fastSparseProduct.hpp
+++ b/opm/autodiff/fastSparseProduct.hpp
@@ -151,7 +151,6 @@ inline void fastDiagSparseProduct(// const Eigen::DiagonalMatrix<double, Eigen::
 
     // Multiply rows by diagonal lhs.
     int n = res.cols();
-#pragma omp parallel for
     for (int col = 0; col < n; ++col) {
         typedef Eigen::SparseMatrix<double>::InnerIterator It;
         for (It it(res, col); it; ++it) {
@@ -172,7 +171,6 @@ inline void fastSparseDiagProduct(const Eigen::SparseMatrix<double>& lhs,
 
     // Multiply columns by diagonal rhs.
     int n = res.cols();
-#pragma omp parallel for
     for (int col = 0; col < n; ++col) {
         typedef Eigen::SparseMatrix<double>::InnerIterator It;
         for (It it(res, col); it; ++it) {

--- a/opm/autodiff/fastSparseProduct.hpp
+++ b/opm/autodiff/fastSparseProduct.hpp
@@ -151,6 +151,7 @@ inline void fastDiagSparseProduct(// const Eigen::DiagonalMatrix<double, Eigen::
 
     // Multiply rows by diagonal lhs.
     int n = res.cols();
+#pragma omp parallel for
     for (int col = 0; col < n; ++col) {
         typedef Eigen::SparseMatrix<double>::InnerIterator It;
         for (It it(res, col); it; ++it) {
@@ -171,6 +172,7 @@ inline void fastSparseDiagProduct(const Eigen::SparseMatrix<double>& lhs,
 
     // Multiply columns by diagonal rhs.
     int n = res.cols();
+#pragma omp parallel for
     for (int col = 0; col < n; ++col) {
         typedef Eigen::SparseMatrix<double>::InnerIterator It;
         for (It it(res, col); it; ++it) {

--- a/opm/autodiff/fastSparseProduct.hpp
+++ b/opm/autodiff/fastSparseProduct.hpp
@@ -142,7 +142,8 @@ void fastSparseProduct(const Lhs& lhs, const Rhs& rhs, ResultType& res)
 
 
 
-inline void fastDiagSparseProduct(const Eigen::DiagonalMatrix<double, Eigen::Dynamic>& lhs,
+inline void fastDiagSparseProduct(// const Eigen::DiagonalMatrix<double, Eigen::Dynamic>& lhs,
+                                  const std::vector<double>& lhs,
 				  const Eigen::SparseMatrix<double>& rhs,
 				  Eigen::SparseMatrix<double>& res)
 {
@@ -153,7 +154,7 @@ inline void fastDiagSparseProduct(const Eigen::DiagonalMatrix<double, Eigen::Dyn
     for (int col = 0; col < n; ++col) {
 	typedef Eigen::SparseMatrix<double>::InnerIterator It;
 	for (It it(res, col); it; ++it) {
-	    it.valueRef() *= lhs.diagonal()(it.row());
+	    it.valueRef() *= lhs[it.row()]; // lhs.diagonal()(it.row());
 	}
     }
 }
@@ -162,7 +163,8 @@ inline void fastDiagSparseProduct(const Eigen::DiagonalMatrix<double, Eigen::Dyn
 
 
 inline void fastSparseDiagProduct(const Eigen::SparseMatrix<double>& lhs,
-				  const Eigen::DiagonalMatrix<double, Eigen::Dynamic>& rhs,
+				  // const Eigen::DiagonalMatrix<double, Eigen::Dynamic>& rhs,
+                                  const std::vector<double>& rhs,
 				  Eigen::SparseMatrix<double>& res)
 {
     res = lhs;
@@ -172,7 +174,7 @@ inline void fastSparseDiagProduct(const Eigen::SparseMatrix<double>& lhs,
     for (int col = 0; col < n; ++col) {
 	typedef Eigen::SparseMatrix<double>::InnerIterator It;
 	for (It it(res, col); it; ++it) {
-	    it.valueRef() *= rhs.diagonal()(col);
+	    it.valueRef() *= rhs[col]; // rhs.diagonal()(col);
 	}
     }
 }

--- a/opm/autodiff/fastSparseProduct.hpp
+++ b/opm/autodiff/fastSparseProduct.hpp
@@ -144,18 +144,18 @@ void fastSparseProduct(const Lhs& lhs, const Rhs& rhs, ResultType& res)
 
 inline void fastDiagSparseProduct(// const Eigen::DiagonalMatrix<double, Eigen::Dynamic>& lhs,
                                   const std::vector<double>& lhs,
-				  const Eigen::SparseMatrix<double>& rhs,
-				  Eigen::SparseMatrix<double>& res)
+                                  const Eigen::SparseMatrix<double>& rhs,
+                                  Eigen::SparseMatrix<double>& res)
 {
     res = rhs;
 
     // Multiply rows by diagonal lhs.
     int n = res.cols();
     for (int col = 0; col < n; ++col) {
-	typedef Eigen::SparseMatrix<double>::InnerIterator It;
-	for (It it(res, col); it; ++it) {
-	    it.valueRef() *= lhs[it.row()]; // lhs.diagonal()(it.row());
-	}
+        typedef Eigen::SparseMatrix<double>::InnerIterator It;
+        for (It it(res, col); it; ++it) {
+            it.valueRef() *= lhs[it.row()]; // lhs.diagonal()(it.row());
+        }
     }
 }
 
@@ -163,19 +163,19 @@ inline void fastDiagSparseProduct(// const Eigen::DiagonalMatrix<double, Eigen::
 
 
 inline void fastSparseDiagProduct(const Eigen::SparseMatrix<double>& lhs,
-				  // const Eigen::DiagonalMatrix<double, Eigen::Dynamic>& rhs,
+                                  // const Eigen::DiagonalMatrix<double, Eigen::Dynamic>& rhs,
                                   const std::vector<double>& rhs,
-				  Eigen::SparseMatrix<double>& res)
+                                  Eigen::SparseMatrix<double>& res)
 {
     res = lhs;
 
     // Multiply columns by diagonal rhs.
     int n = res.cols();
     for (int col = 0; col < n; ++col) {
-	typedef Eigen::SparseMatrix<double>::InnerIterator It;
-	for (It it(res, col); it; ++it) {
-	    it.valueRef() *= rhs[col]; // rhs.diagonal()(col);
-	}
+        typedef Eigen::SparseMatrix<double>::InnerIterator It;
+        for (It it(res, col); it; ++it) {
+            it.valueRef() *= rhs[col]; // rhs.diagonal()(col);
+        }
     }
 }
 

--- a/opm/autodiff/fastSparseProduct.hpp
+++ b/opm/autodiff/fastSparseProduct.hpp
@@ -56,16 +56,16 @@ struct QuickSort< 0 >
 };
 
 
-template<typename Lhs, typename Rhs, typename ResultType>
-void fastSparseProduct(const Lhs& lhs, const Rhs& rhs, ResultType& res)
+template<typename ResultType, typename Lhs, typename Rhs>
+ResultType fastSparseProduct(const Lhs& lhs, const Rhs& rhs)
 {
   // initialize result
-  res = ResultType(lhs.rows(), rhs.cols());
+  ResultType res(lhs.rows(), rhs.cols());
 
   // if one of the matrices does not contain non zero elements
   // the result will only contain an empty matrix
   if( lhs.nonZeros() == 0 || rhs.nonZeros() == 0 )
-    return;
+    return res;
 
   typedef typename Eigen::internal::remove_all<Lhs>::type::Scalar Scalar;
   typedef typename Eigen::internal::remove_all<Lhs>::type::Index Index;
@@ -137,17 +137,19 @@ void fastSparseProduct(const Lhs& lhs, const Rhs& rhs, ResultType& res)
 
   }
   res.finalize();
+
+  return res;
 }
 
 
 
 
-inline void fastDiagSparseProduct(// const Eigen::DiagonalMatrix<double, Eigen::Dynamic>& lhs,
-                                  const std::vector<double>& lhs,
-                                  const Eigen::SparseMatrix<double>& rhs,
-                                  Eigen::SparseMatrix<double>& res)
+inline
+Eigen::SparseMatrix<double>
+fastDiagSparseProduct(const std::vector<double>& lhs,
+                      const Eigen::SparseMatrix<double>& rhs)
 {
-    res = rhs;
+    Eigen::SparseMatrix<double> res = rhs;
 
     // Multiply rows by diagonal lhs.
     int n = res.cols();
@@ -157,17 +159,19 @@ inline void fastDiagSparseProduct(// const Eigen::DiagonalMatrix<double, Eigen::
             it.valueRef() *= lhs[it.row()]; // lhs.diagonal()(it.row());
         }
     }
+
+    return res;
 }
 
 
 
 
-inline void fastSparseDiagProduct(const Eigen::SparseMatrix<double>& lhs,
-                                  // const Eigen::DiagonalMatrix<double, Eigen::Dynamic>& rhs,
-                                  const std::vector<double>& rhs,
-                                  Eigen::SparseMatrix<double>& res)
+inline
+Eigen::SparseMatrix<double>
+fastSparseDiagProduct(const Eigen::SparseMatrix<double>& lhs,
+                      const std::vector<double>& rhs)
 {
-    res = lhs;
+    Eigen::SparseMatrix<double> res = lhs;
 
     // Multiply columns by diagonal rhs.
     int n = res.cols();
@@ -177,6 +181,8 @@ inline void fastSparseDiagProduct(const Eigen::SparseMatrix<double>& lhs,
             it.valueRef() *= rhs[col]; // rhs.diagonal()(col);
         }
     }
+
+    return res;
 }
 
 

--- a/opm/autodiff/fastSparseProduct.hpp
+++ b/opm/autodiff/fastSparseProduct.hpp
@@ -142,8 +142,7 @@ void fastSparseProduct(const Lhs& lhs, const Rhs& rhs, ResultType& res)
 
 
 
-inline void fastDiagSparseProduct(// const Eigen::DiagonalMatrix<double, Eigen::Dynamic>& lhs,
-                                  const std::vector<double>& lhs,
+inline void fastDiagSparseProduct(const std::vector<double>& lhs,
                                   const Eigen::SparseMatrix<double>& rhs,
                                   Eigen::SparseMatrix<double>& res)
 {
@@ -154,7 +153,7 @@ inline void fastDiagSparseProduct(// const Eigen::DiagonalMatrix<double, Eigen::
     for (int col = 0; col < n; ++col) {
         typedef Eigen::SparseMatrix<double>::InnerIterator It;
         for (It it(res, col); it; ++it) {
-            it.valueRef() *= lhs[it.row()]; // lhs.diagonal()(it.row());
+            it.valueRef() *= lhs[it.row()];
         }
     }
 }
@@ -163,7 +162,6 @@ inline void fastDiagSparseProduct(// const Eigen::DiagonalMatrix<double, Eigen::
 
 
 inline void fastSparseDiagProduct(const Eigen::SparseMatrix<double>& lhs,
-                                  // const Eigen::DiagonalMatrix<double, Eigen::Dynamic>& rhs,
                                   const std::vector<double>& rhs,
                                   Eigen::SparseMatrix<double>& res)
 {
@@ -174,7 +172,7 @@ inline void fastSparseDiagProduct(const Eigen::SparseMatrix<double>& lhs,
     for (int col = 0; col < n; ++col) {
         typedef Eigen::SparseMatrix<double>::InnerIterator It;
         for (It it(res, col); it; ++it) {
-            it.valueRef() *= rhs[col]; // rhs.diagonal()(col);
+            it.valueRef() *= rhs[col];
         }
     }
 }

--- a/tests/test_autodiffmatrix.cpp
+++ b/tests/test_autodiffmatrix.cpp
@@ -173,3 +173,51 @@ BOOST_AUTO_TEST_CASE(AdditionOps)
     BOOST_CHECK(x == ss);
 }
 
+BOOST_AUTO_TEST_CASE(MultOps)
+{
+    // Setup.
+    Mat z = Mat(AutoDiffMatrix::ZeroMatrix, 3);
+    Sp zs(3,3);
+
+    Mat i = Mat(AutoDiffMatrix::IdentityMatrix, 3);
+    Sp is(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>::Identity(3,3).sparseView());
+
+    Eigen::Array<double, Eigen::Dynamic, 1> d1(3);
+    d1 << 0.2, 1.2, 13.4;
+    Mat d = Mat(d1.matrix().asDiagonal());
+    Sp ds = spdiag(d1);
+
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> s1(3,3);
+    s1 <<
+        1.0, 0.0, 2.0,
+        0.0, 1.0, 0.0,
+	0.0, 0.0, 2.0;
+    Sp ss(s1.sparseView());
+    Mat s = Mat(ss);
+
+    // Convert to Eigen::SparseMatrix
+    Sp x;
+    z.toSparse(x);
+    BOOST_CHECK(x == zs);
+    i.toSparse(x);
+    BOOST_CHECK(x == is);
+    d.toSparse(x);
+    BOOST_CHECK(x == ds);
+    s.toSparse(x);
+    BOOST_CHECK(x == ss);
+
+    // Multiply by diagonal matrix.
+    auto ztd = z * d;
+    ztd.toSparse(x);
+    BOOST_CHECK(x == zs*ds);
+    auto itd = i * d;
+    itd.toSparse(x);
+    BOOST_CHECK(x == is*ds);
+    auto dtd = d * d;
+    dtd.toSparse(x);
+    BOOST_CHECK(x == ds*ds);
+    auto std = s * d;
+    std.toSparse(x);
+    BOOST_CHECK(x == ss*ds);
+}
+

--- a/tests/test_autodiffmatrix.cpp
+++ b/tests/test_autodiffmatrix.cpp
@@ -1,0 +1,125 @@
+/*
+  Copyright 2014 SINTEF ICT, Applied Mathematics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#define BOOST_TEST_MODULE AutoDiffMatrixTest
+
+#include <opm/autodiff/AutoDiffMatrix.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace Opm::AutoDiffMatrix;
+using std::make_shared;
+typedef Eigen::SparseMatrix<double> Sp;
+
+namespace {
+    template <typename Scalar>
+    bool
+    operator ==(const Eigen::SparseMatrix<Scalar>& A,
+                const Eigen::SparseMatrix<Scalar>& B)
+    {
+        // Two SparseMatrices are equal if
+        //   0) They have the same ordering (enforced by equal types)
+        //   1) They have the same outer and inner dimensions
+        //   2) They have the same number of non-zero elements
+        //   3) They have the same sparsity structure
+        //   4) The non-zero elements are equal
+
+        // 1) Outer and inner dimensions
+        bool eq =       (A.outerSize() == B.outerSize());
+        eq      = eq && (A.innerSize() == B.innerSize());
+
+        // 2) Equal number of non-zero elements
+        eq      = eq && (A.nonZeros() == B.nonZeros());
+
+        for (typename Eigen::SparseMatrix<Scalar>::Index
+                 k0 = 0, kend = A.outerSize(); eq && (k0 < kend); ++k0) {
+            for (typename Eigen::SparseMatrix<Scalar>::InnerIterator
+                     iA(A, k0), iB(B, k0); eq && (iA && iB); ++iA, ++iB) {
+                // 3) Sparsity structure
+                eq = (iA.row() == iB.row()) && (iA.col() == iB.col());
+
+                // 4) Equal non-zero elements
+                eq = eq && (iA.value() == iB.value());
+            }
+        }
+
+        return eq;
+
+        // Note: Investigate implementing this operator as
+        // return A.cwiseNotEqual(B).count() == 0;
+    }
+}
+
+
+
+BOOST_AUTO_TEST_CASE(Initialization)
+{
+    // Setup.
+    Mat z = make_shared<Zero>(3,3);
+
+    Mat i = make_shared<Identity>(3);
+
+    Eigen::Array<double, Eigen::Dynamic> d1(3);
+    d1 << 0.2, 1.2, 13.4;
+    Mat d = make_shared<Diagonal>(d1);
+
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> s1(3,2);
+    s1 <<
+        1.0, 0.0, 2.0,
+        0.0, 1.0, 0.0;
+    Sp s2(s1);
+    Mat s = make_shared<Sparse>(s2);
+}
+
+BOOST_AUTO_TEST_CASE(EigenConversion)
+{
+    // Setup
+    Mat z = make_shared<Zero>(3,3);
+
+    Mat i = make_shared<Identity>(3);
+
+    Eigen::Array<double, Eigen::Dynamic> d1(3);
+    d1 << 0.2, 1.2, 13.4;
+    Mat d = make_shared<Diagonal>(d1);
+
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> s1(3,2);
+    s1 <<
+        1.0, 0.0, 2.0,
+        0.0, 1.0, 0.0;
+    Mat s = make_shared<Sparse>(Sp(s1));
+
+    // Convert to Eigen::SparseMatrix
+    Sp x;
+    z->toSparse(x);
+    BOOST_CHECK_EQUAL(x, Sp(3,3));
+    i->toSparse(x);
+    Sp i1(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>::Identity(3,3));
+    BOOST_CHECK_EQUAL(x, i1);
+    d->toSparse(x);
+    BOOST_CHECK_EQUAL(x, Sp(d1.matrix().asDiagonal()));
+    s->toSparse(x);
+    BOOST_CHECK_EQUAL(x, Sp(s1));
+}
+

--- a/tests/test_autodiffmatrix.cpp
+++ b/tests/test_autodiffmatrix.cpp
@@ -36,7 +36,7 @@ using namespace Opm;
 
 bool
 operator ==(const Eigen::SparseMatrix<double>& A,
-	    const Eigen::SparseMatrix<double>& B)
+            const Eigen::SparseMatrix<double>& B)
 {
     // Two SparseMatrices are equal if
     //   0) They have the same ordering (enforced by equal types)
@@ -53,15 +53,15 @@ operator ==(const Eigen::SparseMatrix<double>& A,
     eq      = eq && (A.nonZeros() == B.nonZeros());
 
     for (typename Eigen::SparseMatrix<double>::Index
-	     k0 = 0, kend = A.outerSize(); eq && (k0 < kend); ++k0) {
-	for (typename Eigen::SparseMatrix<double>::InnerIterator
-		 iA(A, k0), iB(B, k0); eq && (iA && iB); ++iA, ++iB) {
-	    // 3) Sparsity structure
-	    eq = (iA.row() == iB.row()) && (iA.col() == iB.col());
+             k0 = 0, kend = A.outerSize(); eq && (k0 < kend); ++k0) {
+        for (typename Eigen::SparseMatrix<double>::InnerIterator
+                 iA(A, k0), iB(B, k0); eq && (iA && iB); ++iA, ++iB) {
+            // 3) Sparsity structure
+            eq = (iA.row() == iB.row()) && (iA.col() == iB.col());
 
-	    // 4) Equal non-zero elements
-	    eq = eq && (iA.value() == iB.value());
-	}
+            // 4) Equal non-zero elements
+            eq = eq && (iA.value() == iB.value());
+        }
     }
 
     return eq;
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE(AdditionOps)
     s1 <<
         1.0, 0.0, 2.0,
         0.0, 1.0, 0.0,
-	0.0, 0.0, 2.0;
+        0.0, 0.0, 2.0;
     Sp ss(s1.sparseView());
     Mat s = Mat(ss);
 
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(MultOps)
     s1 <<
         1.0, 0.0, 2.0,
         0.0, 1.0, 0.0,
-	0.0, 0.0, 2.0;
+        0.0, 0.0, 2.0;
     Sp ss(s1.sparseView());
     Mat s = Mat(ss);
 

--- a/tests/test_autodiffmatrix.cpp
+++ b/tests/test_autodiffmatrix.cpp
@@ -206,6 +206,34 @@ BOOST_AUTO_TEST_CASE(MultOps)
     s.toSparse(x);
     BOOST_CHECK(x == ss);
 
+    //Multiply by zero matrix
+    auto ztz = z * z;
+    ztz.toSparse(x);
+    BOOST_CHECK(x == zs*zs);
+    auto itz = i * z;
+    itz.toSparse(x);
+    BOOST_CHECK(x == is*zs);
+    auto dtz = d * z;
+    dtz.toSparse(x);
+    BOOST_CHECK(x == ds*zs);
+    auto stz = s * z;
+    stz.toSparse(x);
+    BOOST_CHECK(x == ss*zs);
+
+    //Multiply by identity matrix
+    auto zti = z * i;
+    zti.toSparse(x);
+    BOOST_CHECK(x == zs*is);
+    auto iti = i * i;
+    iti.toSparse(x);
+    BOOST_CHECK(x == is*is);
+    auto dti = d * i;
+    dti.toSparse(x);
+    BOOST_CHECK(x == ds*is);
+    auto sti = s * i;
+    sti.toSparse(x);
+    BOOST_CHECK(x == ss*is);
+
     // Multiply by diagonal matrix.
     auto ztd = z * d;
     ztd.toSparse(x);
@@ -219,5 +247,177 @@ BOOST_AUTO_TEST_CASE(MultOps)
     auto std = s * d;
     std.toSparse(x);
     BOOST_CHECK(x == ss*ds);
+
+    // Multiply by sparse matrix.
+    auto zts = z * s;
+    zts.toSparse(x);
+    BOOST_CHECK(x == zs*ss);
+    auto its = i * s;
+    its.toSparse(x);
+    BOOST_CHECK(x == is*ss);
+    auto dts = d * s;
+    dts.toSparse(x);
+    BOOST_CHECK(x == ds*ss);
+    auto sts = s * s;
+    sts.toSparse(x);
+    BOOST_CHECK(x == ss*ss);
+}
+
+
+BOOST_AUTO_TEST_CASE(MultOpsDouble)
+{
+    // Setup.
+    Mat z = Mat(AutoDiffMatrix::ZeroMatrix, 3);
+    Sp zs(3,3);
+
+    Mat i = Mat(AutoDiffMatrix::IdentityMatrix, 3);
+    Sp is(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>::Identity(3,3).sparseView());
+
+    Eigen::Array<double, Eigen::Dynamic, 1> d1(3);
+    d1 << 0.2, 1.2, 13.4;
+    Mat d = Mat(d1.matrix().asDiagonal());
+    Sp ds = spdiag(d1);
+
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> s1(3,3);
+    s1 <<
+        1.0, 0.0, 2.0,
+        0.0, 1.0, 0.0,
+        0.0, 0.0, 2.0;
+    Sp ss(s1.sparseView());
+    Mat s = Mat(ss);
+
+    static double factor = 5.3;
+
+    Sp x;
+    auto zd = z*factor;
+    zd.toSparse(x);
+    BOOST_CHECK(x == zs*factor);
+    auto id = i*factor;
+    id.toSparse(x);
+    BOOST_CHECK(x == is*factor);
+    auto dd = d*factor;
+    dd.toSparse(x);
+    BOOST_CHECK(x == ds*factor);
+    auto sd = s*factor;
+    sd.toSparse(x);
+    BOOST_CHECK(x == ss*factor);
+}
+
+
+BOOST_AUTO_TEST_CASE(DivOpsDouble)
+{
+    // Setup.
+    Mat z = Mat(AutoDiffMatrix::ZeroMatrix, 3);
+    Sp zs(3,3);
+
+    Mat i = Mat(AutoDiffMatrix::IdentityMatrix, 3);
+    Sp is(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>::Identity(3,3).sparseView());
+
+    Eigen::Array<double, Eigen::Dynamic, 1> d1(3);
+    d1 << 0.2, 1.2, 13.4;
+    Mat d = Mat(d1.matrix().asDiagonal());
+    Sp ds = spdiag(d1);
+
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> s1(3,3);
+    s1 <<
+        1.0, 0.0, 2.0,
+        0.0, 1.0, 0.0,
+        0.0, 0.0, 2.0;
+    Sp ss(s1.sparseView());
+    Mat s = Mat(ss);
+
+    static double factor = 5.3;
+
+    Sp x;
+    auto zd = z/factor;
+    zd.toSparse(x);
+    BOOST_CHECK(x == zs/factor);
+    auto id = i/factor;
+    id.toSparse(x);
+    BOOST_CHECK(x == is/factor);
+    auto dd = d/factor;
+    dd.toSparse(x);
+    BOOST_CHECK(x == ds/factor);
+    auto sd = s/factor;
+    sd.toSparse(x);
+    BOOST_CHECK(x == ss/factor);
+}
+
+BOOST_AUTO_TEST_CASE(MultVectorXd)
+{
+    Mat z = Mat(AutoDiffMatrix::ZeroMatrix, 3);
+    Sp zs(3,3);
+
+    Mat i = Mat(AutoDiffMatrix::IdentityMatrix, 3);
+    Sp is(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>::Identity(3,3).sparseView());
+
+    Eigen::Array<double, Eigen::Dynamic, 1> d1(3);
+    d1 << 0.2, 1.2, 13.4;
+    Mat d = Mat(d1.matrix().asDiagonal());
+    Sp ds = spdiag(d1);
+
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> s1(3,3);
+    s1 <<
+        1.0, 0.0, 2.0,
+        0.0, 1.0, 0.0,
+        0.0, 0.0, 2.0;
+    Sp ss(s1.sparseView());
+    Mat s = Mat(ss);
+
+    Eigen::VectorXd vec(3);
+    vec << 1.0, 2.0, 3.0;
+
+    Sp x;
+    Eigen::VectorXd zd = z*vec;
+    BOOST_CHECK(zd == zs*vec);
+    Eigen::VectorXd id = i*vec;
+    BOOST_CHECK(id == is*vec);
+    Eigen::VectorXd dd = d*vec;
+    BOOST_CHECK(dd == ds*vec);
+    Eigen::VectorXd sd = s*vec;
+    BOOST_CHECK(sd == ss*vec);
+}
+
+BOOST_AUTO_TEST_CASE(Coeff)
+{
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> s1(3,2);
+    s1 <<
+        1.0, 0.0, 2.0,
+        0.0, 1.0, 0.0;
+    Sp s2(s1.sparseView());
+    Mat s = Mat(s2);
+
+    for (int row=0; row<s1.rows(); ++row) {
+        for (int col=0; col<s1.cols(); ++col) {
+            double a = s.coeff(row, col);
+            double b = s1(row, col);
+            BOOST_CHECK_EQUAL(a, b);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(nonZeros)
+{
+    Mat z = Mat(AutoDiffMatrix::ZeroMatrix, 3);
+
+    Mat i = Mat(AutoDiffMatrix::IdentityMatrix, 3);
+
+    Eigen::Array<double, Eigen::Dynamic, 1> d1(3);
+    d1 << 0.2, 1.2, 13.4;
+    Mat d = Mat(d1.matrix().asDiagonal());
+    Sp ds = spdiag(d1);
+
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> s1(3,3);
+    s1 <<
+        1.0, 0.0, 2.0,
+        0.0, 1.0, 0.0,
+        0.0, 0.0, 2.0;
+    Sp ss(s1.sparseView());
+    Mat s = Mat(ss);
+
+    BOOST_CHECK_EQUAL(z.nonZeros(), 0);
+    BOOST_CHECK_EQUAL(i.nonZeros(), 3);
+    BOOST_CHECK_EQUAL(d.nonZeros(), 3);
+    BOOST_CHECK_EQUAL(s.nonZeros(), 4);
 }
 


### PR DESCRIPTION
This significantly improves performance of flow by keeping track of matrix types. The gist of it is that if a is zero, identity or a purely diagonal matrix, we can use specialized multiplication/addition/etc. methods that are faster than a general sparse (op) sparse method.

Tested that it gives same result as master.