### PR TITLE
Change defaults

### DIFF
--- a/examples/flow.cpp
+++ b/examples/flow.cpp
@@ -358,7 +358,7 @@ try
     std::unique_ptr<NewtonIterationBlackoilInterface> fis_solver;
     if (param.getDefault("use_interleaved", true)) {
         fis_solver.reset(new NewtonIterationBlackoilInterleaved(param, parallel_information));
-    } else if (param.getDefault("use_cpr", false)) {
+    } else if (param.getDefault("use_cpr", true)) {
         fis_solver.reset(new NewtonIterationBlackoilCPR(param, parallel_information));
     } else {
         fis_solver.reset(new NewtonIterationBlackoilSimple(param, parallel_information));

--- a/examples/flow.cpp
+++ b/examples/flow.cpp
@@ -356,9 +356,9 @@ try
 
     // Solver for Newton iterations.
     std::unique_ptr<NewtonIterationBlackoilInterface> fis_solver;
-    if (param.getDefault("use_interleaved", false)) {
+    if (param.getDefault("use_interleaved", true)) {
         fis_solver.reset(new NewtonIterationBlackoilInterleaved(param, parallel_information));
-    } else if (param.getDefault("use_cpr", true)) {
+    } else if (param.getDefault("use_cpr", false)) {
         fis_solver.reset(new NewtonIterationBlackoilCPR(param, parallel_information));
     } else {
         fis_solver.reset(new NewtonIterationBlackoilSimple(param, parallel_information));

--- a/examples/flow_solvent.cpp
+++ b/examples/flow_solvent.cpp
@@ -368,7 +368,7 @@ try
     std::unique_ptr<NewtonIterationBlackoilInterface> fis_solver;
     if (param.getDefault("use_interleaved", true)) {
         fis_solver.reset(new NewtonIterationBlackoilInterleaved(param));
-    } else if (param.getDefault("use_cpr", false)) {
+    } else if (param.getDefault("use_cpr", true)) {
         fis_solver.reset(new NewtonIterationBlackoilCPR(param));
     } else {
         fis_solver.reset(new NewtonIterationBlackoilSimple(param, parallel_information));

--- a/examples/flow_solvent.cpp
+++ b/examples/flow_solvent.cpp
@@ -366,9 +366,9 @@ try
 
     // Solver for Newton iterations.
     std::unique_ptr<NewtonIterationBlackoilInterface> fis_solver;
-    if (param.getDefault("use_interleaved", false)) {
+    if (param.getDefault("use_interleaved", true)) {
         fis_solver.reset(new NewtonIterationBlackoilInterleaved(param));
-    } else if (param.getDefault("use_cpr", true)) {
+    } else if (param.getDefault("use_cpr", false)) {
         fis_solver.reset(new NewtonIterationBlackoilCPR(param));
     } else {
         fis_solver.reset(new NewtonIterationBlackoilSimple(param, parallel_information));

--- a/opm/autodiff/BlackoilModelParameters.cpp
+++ b/opm/autodiff/BlackoilModelParameters.cpp
@@ -62,7 +62,7 @@ namespace Opm
         tolerance_mb_    = 1.0e-5;
         tolerance_cnv_   = 1.0e-2;
         tolerance_wells_ = 1.0e-3;
-        solve_welleq_initially_ = false;
+        solve_welleq_initially_ = true;
     }
 
 


### PR DESCRIPTION
Use the more stable interleaved solver instead of CPR as default
Solve well equation initially as default

Most of the testing lately has been done with the interleaved solver and solve_welleq_initially_  =true. It gives significant speed up for norne and some for the SPEs

