### PR TITLE
Use well information during load balancing.

### DIFF
--- a/opm/autodiff/RedistributeDataHandles.hpp
+++ b/opm/autodiff/RedistributeDataHandles.hpp
@@ -324,7 +324,7 @@ void distributeGridAndData( Dune::CpGrid& grid,
     global_grid.switchToGlobalView();
 
     // distribute the grid and switch to the distributed view
-    grid.loadBalance();
+    grid.loadBalance(eclipseState);
     grid.switchToDistributedView();
 
     distributed_props = std::make_shared<BlackoilPropsAdFromDeck>(properties, grid.numCells());


### PR DESCRIPTION
With this commit we pass the well information to
the loadbalance method of CpGrid to ensure that
each well is stored completely on one process.

This is a follow up to PR OPM/dune-cornerpoint#163 that is used now for flow_cp