### PR TITLE
Fixes parallel runs with solve_welleq_initially

### DIFF
--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -253,6 +253,7 @@ namespace Opm {
 
         ModelParameters                 param_;
         bool use_threshold_pressure_;
+        bool wells_active_;
         V threshold_pressures_by_interior_face_;
 
         std::vector<ReservoirResidualQuant> rq_;
@@ -287,8 +288,10 @@ namespace Opm {
             return static_cast<const Implementation&>(*this);
         }
 
-        // return true if wells are available
-        bool wellsActive() const { return wells_ ? wells_->number_of_wells > 0 : false ; }
+        // return true if wells are available in the reservoir
+        bool wellsActive() const { return wells_active_; }
+        // return true if wells are available on this process
+        bool localWellsActive() const { return wells_ ? (wells_->number_of_wells > 0 ) : false; }
         // return wells object
         const Wells& wells () const { assert( bool(wells_ != 0) ); return *wells_; }
 

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -188,8 +188,8 @@ namespace detail {
                 // Only rank 0 does print to std::cout if terminal_output is enabled
                 terminal_output_ = (info.communicator().rank()==0);
             }
-            int global_number_of_wells = wells_->number_of_wells;
-            global_number_of_wells = info.communicator().sum(global_number_of_wells);
+            int local_number_of_wells = wells_->number_of_wells;
+            int global_number_of_wells = info.communicator().sum(local_number_of_wells);
             wells_active_ = ( global_number_of_wells > 0 );
         }else
         {


### PR DESCRIPTION
If this option was set there were some branches in
the code that did depend on the local number of wells
but should depend on the number of wells in the reservoir
no matter on which process they are stored.

With this commit we introduce BlackOilModelBase::localWellsActive()
which only takes local wells into account. The function now
BlackOilModelBase::wellsActive() considers all active wells in the
reservoir.