### PR TITLE
Removes unused experimental header include to fix build.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -101,6 +101,7 @@ list (APPEND PROGRAM_SOURCE_FILES
 # originally generated with the command:
 # find opm -name '*.h*' -a ! -name '*-pch.hpp' -printf '\t%p\n' | sort
 list (APPEND PUBLIC_HEADER_FILES
+	opm/autodiff/AdditionalObjectDeleter.hpp
 	opm/autodiff/AutoDiffBlock.hpp
 	opm/autodiff/AutoDiffHelpers.hpp
 	opm/autodiff/AutoDiff.hpp

--- a/opm/autodiff/CPRPreconditioner.hpp
+++ b/opm/autodiff/CPRPreconditioner.hpp
@@ -48,7 +48,6 @@
 #include <opm/core/utility/Exceptions.hpp>
 
 #include <opm/autodiff/AdditionalObjectDeleter.hpp>
-#include <opm/autodiff/ParallelRestrictedAdditiveSchwarz.hh>
 namespace Opm
 {
 namespace


### PR DESCRIPTION
The include of ParallelRestrictedAdditiveSchwarz.hh was a left over
from some experiments and should not be here yet.