### PR TITLE
Introduces parallel exception handling for ILU0 preconditioner.

### DIFF
--- a/opm/autodiff/CPRPreconditioner.hpp
+++ b/opm/autodiff/CPRPreconditioner.hpp
@@ -196,6 +196,11 @@ createILU0Ptr(const M& A, double relax,
     // Check whether there was a problem on some process
     if ( comm.communicator().min(ilu_setup_successful) == 0 )
     {
+        if ( ilu ) // not null if constructor succeeded
+        {
+            // prevent memory leak
+            delete ilu;
+        }
         throw Dune::MatrixBlockError();
     }
     return typename SelectParallelILUSharedPtr<Dune::SeqILU0<M,X,X>, I1, I2>

--- a/opm/autodiff/CPRPreconditioner.hpp
+++ b/opm/autodiff/CPRPreconditioner.hpp
@@ -178,7 +178,26 @@ createILU0Ptr(const M& A, double relax,
         Dune::OwnerOverlapCopyCommunication<I1,I2>,
         Dune::SeqILU0<M,X,X>
         > PointerType;
-    Dune::SeqILU0<M,X,X>* ilu = new Dune::SeqILU0<M,X,X>(A, relax);
+    Dune::SeqILU0<M,X,X>* ilu = nullptr;
+    int ilu_setup_successful = 1;
+    std::string message;
+    try {
+        ilu = new Dune::SeqILU0<M,X,X>(A, relax);
+    }
+    catch ( Dune::MatrixBlockError error )
+    {
+                message = error.what();
+                std::cerr<<"Exception occured on process " <<
+                    comm.communicator().rank() << " during " <<
+                    "setup of ILU0 preconditioner with message: " <<
+                    message<<std::endl;
+                ilu_setup_successful = 0;
+    }
+    // Check whether there was a problem on some process
+    if ( comm.communicator().min(ilu_setup_successful) == 0 )
+    {
+        throw Dune::MatrixBlockError();
+    }
     return typename SelectParallelILUSharedPtr<Dune::SeqILU0<M,X,X>, I1, I2>
         ::type ( new PointerType(*ilu, comm), createParallelDeleter(*ilu, comm));
 }

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -147,7 +147,10 @@ namespace Opm
             catch ( Dune::MatrixBlockError error )
             {
                 message = error.what();
-                std::cerr<<message<<std::endl;
+                std::cerr<<"Exception occured on process " <<
+                    comm.communicator().rank() << " during " <<
+                    "setup of ILU0 preconditioner with message: " <<
+                    message<<std::endl;
                 ilu_setup_successful = 0;
             }
             // Check whether there was a problem on some process

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -134,15 +134,13 @@ namespace Opm
         {
             typedef AdditionalObjectDeleter<SeqPreconditioner> Deleter;
             typedef std::unique_ptr<ParPreconditioner, Deleter> Pointer;
-            Pointer precond;
             int ilu_setup_successful = 1;
             std::string message;
             const double relax = 1.0;
+            SeqPreconditioner* seq_precond = nullptr;
             try {
-                SeqPreconditioner* seq_precond= new SeqPreconditioner(opA.getmat(),
-                                                                  relax);
-                precond = Pointer(new ParPreconditioner(*seq_precond, comm),
-                                  Deleter(*seq_precond));
+                seq_precond= new SeqPreconditioner(opA.getmat(),
+                                                   relax);
             }
             catch ( Dune::MatrixBlockError error )
             {
@@ -158,7 +156,8 @@ namespace Opm
             {
                 throw Dune::MatrixBlockError();
             }
-            return precond;
+            return Pointer(new ParPreconditioner(*seq_precond, comm),
+                                  Deleter(*seq_precond));
         }
 #endif
 

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -150,7 +150,7 @@ namespace Opm
                 std::cerr<<message<<std::endl;
                 ilu_setup_successful = 0;
             }
-            // Check wether there was a problem on some process
+            // Check whether there was a problem on some process
             if ( comm.communicator().min(ilu_setup_successful) == 0 )
             {
                 throw Dune::MatrixBlockError();

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -139,7 +139,7 @@ namespace Opm
             const double relax = 1.0;
             SeqPreconditioner* seq_precond = nullptr;
             try {
-                seq_precond= new SeqPreconditioner(opA.getmat(),
+                seq_precond = new SeqPreconditioner(opA.getmat(),
                                                    relax);
             }
             catch ( Dune::MatrixBlockError error )
@@ -154,6 +154,11 @@ namespace Opm
             // Check whether there was a problem on some process
             if ( comm.communicator().min(ilu_setup_successful) == 0 )
             {
+                if ( seq_precond ) // not null if constructor succeeded
+                {
+                    // prevent memory leak
+                    delete seq_precond;
+                }
                 throw Dune::MatrixBlockError();
             }
             return Pointer(new ParPreconditioner(*seq_precond, comm),

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -138,19 +138,20 @@ namespace Opm
             int ilu_setup_successful = 1;
             std::string message;
             const double relax = 1.0;
-            try{
+            try {
                 SeqPreconditioner* seq_precond= new SeqPreconditioner(opA.getmat(),
                                                                   relax);
                 precond = Pointer(new ParPreconditioner(*seq_precond, comm),
                                   Deleter(*seq_precond));
-            }catch(Dune::MatrixBlockError error)
+            }
+            catch ( Dune::MatrixBlockError error )
             {
                 message = error.what();
                 std::cerr<<message<<std::endl;
                 ilu_setup_successful = 0;
             }
             // Check wether there was a problem on some process
-            if(comm.communicator().min(ilu_setup_successful) == 0)
+            if ( comm.communicator().min(ilu_setup_successful) == 0 )
             {
                 throw Dune::MatrixBlockError();
             }


### PR DESCRIPTION
When running Norne with the interleaved solver sometimes exceptions
(diagonal matrix block is not invertible) occur for some rows in the
ILU decomposition. In a parallel run this means that some, but not all
processes will see the exceptions. This leads to a classic deadlock.

With this commit we catch the exception during the setup of the preconditioner,
determine with the other processes whether there were any exceptions, and
in this case all the processes will throw an exception.

Currently this limited to Dune::MatrixBlockError, but we could extend this.