### PR TITLE
Silence some more warnings.

### DIFF
--- a/opm/autodiff/AutoDiffMatrix.hpp
+++ b/opm/autodiff/AutoDiffMatrix.hpp
@@ -388,6 +388,7 @@ namespace Opm
 
         static AutoDiffMatrix addSI(const AutoDiffMatrix& lhs, const AutoDiffMatrix& rhs)
         {
+            static_cast<void>(rhs); // Silence release-mode warning.
             assert(lhs.type_ == S);
             assert(rhs.type_ == I);
             AutoDiffMatrix retval = lhs;

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -57,8 +57,8 @@ namespace Opm
                                                      const UnstructuredGrid& grid,
                                                      const bool init_rock)
     {
-        init(deck, eclState, materialLawManager, grid.number_of_cells, grid.global_cell, grid.cartdims, 
-             grid.cell_centroids, grid.dimensions, init_rock);
+        init(deck, eclState, materialLawManager, grid.number_of_cells, grid.global_cell, grid.cartdims,
+             init_rock);
     }
 
 #ifdef HAVE_DUNE_CORNERPOINT
@@ -77,7 +77,7 @@ namespace Opm
         materialLawManager->initFromDeck(deck, eclState, compressedToCartesianIdx);
         init(deck, eclState, materialLawManager, grid.numCells(), static_cast<const int*>(&grid.globalCell()[0]),
              static_cast<const int*>(&grid.logicalCartesianSize()[0]),
-             grid.beginCellCentroids(), Dune::CpGrid::dimension, init_rock);
+             init_rock);
     }
 #endif
 
@@ -89,7 +89,7 @@ namespace Opm
     {
         auto materialLawManager = std::make_shared<MaterialLawManager>();
         std::vector<int> compressedToCartesianIdx(grid.number_of_cells);
-        for (unsigned cellIdx = 0; cellIdx < grid.number_of_cells; ++cellIdx) {
+        for (int cellIdx = 0; cellIdx < grid.number_of_cells; ++cellIdx) {
             if (grid.global_cell) {
                 compressedToCartesianIdx[cellIdx] = grid.global_cell[cellIdx];
             }
@@ -99,7 +99,7 @@ namespace Opm
         }
         materialLawManager->initFromDeck(deck, eclState, compressedToCartesianIdx);
         init(deck, eclState, materialLawManager, grid.number_of_cells, grid.global_cell, grid.cartdims, 
-             grid.cell_centroids, grid.dimensions, init_rock);
+             init_rock);
     }
 
 #ifdef HAVE_DUNE_CORNERPOINT
@@ -112,7 +112,7 @@ namespace Opm
     {
         init(deck, eclState, materialLawManager, grid.numCells(), static_cast<const int*>(&grid.globalCell()[0]),
              static_cast<const int*>(&grid.logicalCartesianSize()[0]),
-             grid.beginCellCentroids(), Dune::CpGrid::dimension, init_rock);
+             init_rock);
     }
 #endif
 
@@ -145,15 +145,12 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
 }
 
     /// Initializes the properties.
-    template <class CentroidIterator>
     void BlackoilPropsAdFromDeck::init(Opm::DeckConstPtr deck,
                                        Opm::EclipseStateConstPtr eclState,
                                        std::shared_ptr<MaterialLawManager> materialLawManager,
                                        int number_of_cells,
                                        const int* global_cell,
                                        const int* cart_dims,
-                                       const CentroidIterator& begin_cell_centroids,
-                                       int dimension,
                                        const bool init_rock)
     {
         materialLawManager_ = materialLawManager;

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -358,15 +358,12 @@ namespace Opm
 
     private:
         /// Initializes the properties.
-        template <class CentroidIterator>
         void init(Opm::DeckConstPtr deck,
                   Opm::EclipseStateConstPtr eclState,
                   std::shared_ptr<MaterialLawManager> materialLawManager,
                   int number_of_cells,
                   const int* global_cell,
                   const int* cart_dims,
-                  const CentroidIterator& begin_cell_centroids,
-                  int dimension,
                   const bool init_rock);
 
         /// Correction to rs/rv according to kw VAPPARS

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -482,7 +482,9 @@ namespace Opm
                                 well_controls_add_new(BHP, bhp_limit,
                                                       invalid_alq, invalid_vfp,
                                                       NULL, ctrl);
-                        assert(ok_bhp != 0);
+                        if (!ok_bhp) {
+                            OPM_THROW(std::runtime_error, "Failed to add well control.");
+                        }
                     }
                 }
             }

--- a/opm/autodiff/createGlobalCellArray.hpp
+++ b/opm/autodiff/createGlobalCellArray.hpp
@@ -34,7 +34,7 @@ void createGlobalCellArray(const Grid &grid, std::vector<int>& dest)
     dest.resize(numCells);
     const auto& globalCell = Opm::UgGridHelpers::globalCell(grid);
     std::vector<int> compressedToCartesianIdx(numCells);
-    for (unsigned cellIdx = 0; cellIdx < numCells; ++cellIdx) {
+    for (int cellIdx = 0; cellIdx < numCells; ++cellIdx) {
         if (globalCell) {
             dest[cellIdx] = globalCell[cellIdx];
         }


### PR DESCRIPTION
This also simplifies the `init()` method of `BlackoilPropsAdFromDeck`, since it no longer requires 2 of its old arguments.