### PR TITLE
Faster form interleaved

### DIFF
--- a/opm/autodiff/AutoDiffMatrix.hpp
+++ b/opm/autodiff/AutoDiffMatrix.hpp
@@ -529,6 +529,14 @@ namespace Opm
             }
         }
 
+
+        const Sparse& getSparse() const {
+            if (type_ != S) {
+                OPM_THROW(std::logic_error, "Must not call getSparse() for non-sparse type.");
+            }
+            return sparse_;
+        }
+
     private:
         enum MatrixType { Z, I, D, S };
         MatrixType type_;

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
@@ -214,7 +214,7 @@ namespace Opm
 
     void NewtonIterationBlackoilInterleaved::formInterleavedSystem(const std::vector<ADB>& eqs,
                                                                    Mat& istlA) const
-   {
+    {
         const int np = eqs.size();
         // Find sparsity structure as union of basic block sparsity structures,
         // corresponding to the jacobians with respect to pressure.


### PR DESCRIPTION
This PR improves the performance of `formInterleavedSystem(...)` by assembling the system in a different order. 

It also makes changes the enums for matrix types in `AutoDiffMatrix` to more descriptive names. 