### PR TITLE
NewtonIterationInterleaved: allow np to be different than 3.

### DIFF
--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
@@ -241,7 +241,8 @@ namespace Opm
         istlA.setBuildMode(Mat::row_wise);
         const int* ia = row_major.outerIndexPtr();
         const int* ja = row_major.innerIndexPtr();
-        for (Mat::CreateIterator row = istlA.createbegin(); row != istlA.createend(); ++row) {
+        const Mat::CreateIterator istlEnd = istlA.createend();
+        for (Mat::CreateIterator row = istlA.createbegin(); row != istlEnd; ++row) {
             const int ri = row.index();
             for (int i = ia[ri]; i < ia[ri + 1]; ++i) {
                 row.insert(ja[i]);
@@ -249,10 +250,11 @@ namespace Opm
         }
 
         // Set all blocks to zero.
-        for (int row = 0; row < size; ++row) {
-            for (int col_ix = ia[row]; col_ix < ia[row + 1]; ++col_ix) {
-                const int col = ja[col_ix];
-                istlA[row][col] = 0.0;
+        for (auto rowit = istlA.begin(), rowend = istlA.end(); rowit != rowend; ++ rowit )
+        {
+            for ( auto colit = rowit->begin(), colend = rowit->end(); colit != colend; ++colit )
+            {
+                *colit = 0.0;
             }
         }
 

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -51,8 +51,9 @@ namespace Opm
     /// as a block-structured matrix (one block for all cell variables).
     class NewtonIterationBlackoilInterleaved : public NewtonIterationBlackoilInterface
     {
-        typedef Dune::FieldVector<double, 3   > VectorBlockType;
-        typedef Dune::FieldMatrix<double, 3, 3> MatrixBlockType;
+        static const int np = 3;
+        typedef Dune::FieldVector<double, np    > VectorBlockType;
+        typedef Dune::FieldMatrix<double, np, np> MatrixBlockType;
         typedef Dune::BCRSMatrix <MatrixBlockType>        Mat;
         typedef Dune::BlockVector<VectorBlockType>        Vector;
 


### PR DESCRIPTION
This PR changes all places in the NewtonIterationInterleaved such that np could be different than 3, as for example needed for flow_solvent. For now, np is set to 3 and the code works as before.

However, np should then be a template parameter and I leave this change for @atgeirr because it involves some redesign of the BlackoilModel.