### PR TITLE
Refactor convergence reduction and report

### DIFF
--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -205,11 +205,17 @@ namespace Opm {
         /// \param[in]   iteration   current iteration number
         bool getConvergence(const double dt, const int iteration);
 
-        /// The number of active phases in the model.
+        /// The number of active fluid phases in the model.
         int numPhases() const;
 
-        /// The name of an active phase in the model.
-        const std::string& phaseName(int phase_index) const;
+        /// The number of active materials in the model.
+        /// This should be equal to the number of material balance
+        /// equations.
+        int numMaterials() const;
+
+        /// The name of an active material in the model.
+        /// It is required that material_index < numMaterials().
+        const std::string& materialName(int material_index) const;
 
         /// Update the scaling factors for mass balance equations
         void updateEquationsScaling();
@@ -277,7 +283,7 @@ namespace Opm {
 
         std::vector<int>         primalVariable_;
         V pvdt_;
-        std::vector<std::string> phase_name_;
+        std::vector<std::string> material_name_;
 
         // ---------  Protected methods  ---------
 

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -493,12 +493,12 @@ namespace Opm {
         /// \param[in]  nw    The number of wells on the local grid.
         /// \return The total pore volume over all cells.
         double
-        convergenceReduction(const Eigen::Array<double, Eigen::Dynamic, MaxNumPhases>& B,
-                             const Eigen::Array<double, Eigen::Dynamic, MaxNumPhases>& tempV,
-                             const Eigen::Array<double, Eigen::Dynamic, MaxNumPhases>& R,
-                             std::array<double,MaxNumPhases>& R_sum,
-                             std::array<double,MaxNumPhases>& maxCoeff,
-                             std::array<double,MaxNumPhases>& B_avg,
+        convergenceReduction(const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic>& B,
+                             const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic>& tempV,
+                             const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic>& R,
+                             std::vector<double>& R_sum,
+                             std::vector<double>& maxCoeff,
+                             std::vector<double>& B_avg,
                              std::vector<double>& maxNormWell,
                              int nc,
                              int nw) const;

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -208,6 +208,9 @@ namespace Opm {
         /// The number of active phases in the model.
         int numPhases() const;
 
+        /// The name of an active phase in the model.
+        const std::string& phaseName(int phase_index) const;
+
         /// Update the scaling factors for mass balance equations
         void updateEquationsScaling();
 
@@ -274,6 +277,7 @@ namespace Opm {
 
         std::vector<int>         primalVariable_;
         V pvdt_;
+        std::vector<std::string> phase_name_;
 
         // ---------  Protected methods  ---------
 

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -2384,7 +2384,7 @@ namespace detail {
 
         const int nc = Opm::AutoDiffGrid::numCells(grid_);
         const int nw = localWellsActive() ? wells().number_of_wells : 0;
-        const int np = numPhases();
+        const int np = asImpl().numPhases();
         assert(int(rq_.size()) == np);
 
         const V pv = geo_.poreVolume();
@@ -2501,7 +2501,7 @@ namespace detail {
 
         const int nc = Opm::AutoDiffGrid::numCells(grid_);
         const int nw = localWellsActive() ? wells().number_of_wells : 0;
-        const int np = numPhases();
+        const int np = asImpl().numPhases();
 
         const V pv = geo_.poreVolume();
         std::vector<double> R_sum(np);

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -179,7 +179,9 @@ namespace detail {
                         ADB::null(),
                         { 1.1169, 1.0031, 0.0031 }} ) // the default magic numbers
         , terminal_output_ (terminal_output)
+        , phase_name_{ "Water", "Oil", "Gas" }
     {
+        assert(numPhases() == 3); // Due to the phase_name_ init above.
 #if HAVE_MPI
         if ( linsolver_.parallelInformation().type() == typeid(ParallelISTLInformation) )
         {
@@ -278,6 +280,19 @@ namespace detail {
     numPhases() const
     {
         return fluid_.numPhases();
+    }
+
+
+
+
+
+    template <class Grid, class Implementation>
+    const std::string&
+    BlackoilModelBase<Grid, Implementation>::
+    phaseName(int phase_index) const
+    {
+        assert(phase_index < numPhases());
+        return phase_name_[phase_index];
     }
 
 

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -2312,7 +2312,8 @@ namespace detail {
                                                                   int nc,
                                                                   int nw) const
     {
-        const int num_elems = B.cols();
+        const int np = asImpl().numPhases();
+        const int nm = asImpl().numMaterials();
 
         // Do the global reductions
 #if HAVE_MPI
@@ -2361,20 +2362,22 @@ namespace detail {
         else
 #endif
         {
-            B_avg.resize(num_elems);
-            maxCoeff.resize(num_elems);
-            R_sum.resize(num_elems);
-            maxNormWell.resize(num_elems);
-            for ( int idx = 0; idx < num_elems; ++idx )
+            B_avg.resize(nm);
+            maxCoeff.resize(nm);
+            R_sum.resize(nm);
+            maxNormWell.resize(np);
+            for ( int idx = 0; idx < nm; ++idx )
             {
                 B_avg[idx] = B.col(idx).sum()/nc;
                 maxCoeff[idx] = tempV.col(idx).maxCoeff();
                 R_sum[idx] = R.col(idx).sum();
 
-                maxNormWell[idx] = 0.0;
-                for ( int w = 0; w < nw; ++w )
-                {
-                    maxNormWell[idx] = std::max(maxNormWell[idx], std::abs(residual_.well_flux_eq.value()[nw*idx + w]));
+                assert(nm >= np);
+                if (idx < np) {
+                    maxNormWell[idx] = 0.0;
+                    for ( int w = 0; w < nw; ++w ) {
+                        maxNormWell[idx] = std::max(maxNormWell[idx], std::abs(residual_.well_flux_eq.value()[nw*idx + w]));
+                    }
                 }
             }
             // Compute total pore volume

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -279,7 +279,7 @@ namespace detail {
     BlackoilModelBase<Grid, Implementation>::
     numPhases() const
     {
-        return fluid_.numPhases();
+        return phase_name_.size();
     }
 
 


### PR DESCRIPTION
This refactoring has the following aims:
 - use active phases (not "canonical phases") in the convergence logic,
 - move towards making it possible to run flow with just two phases,
 - make it easier for other models to reuse this implementation (removes more than 200 lines from opm-polymer).

It does not:
 - eliminate the duplication between the `getConvergence()` and `getWellConvergence()` methods.

To do this some concepts have been reconsidered. We already had a model method `numPhases()`, that is now (as before) intended to give the number of active physical fluid phases. A new method `numMaterials()` has been added, this is intended to be the number of materials that are conserved (i.e., should be equal to `residual_.material_balance_eq.size()`). I think it might be misleading to call this `numComponents()`, which is why I went with the term "material". The materials have names used for the reporting, defaulting to "Water", "Oil" and "Gas", the polymer model adds "Polymer" to this.

I have some questions about both the old implementation and this one: it seems to me that in the parallel case `maxNormWell` is computed in `convergenceReduction()` only locally. Is this proper, @blattms?

The current PR has been tested with SPE9 (both serial and with two parallels) and with the first few steps of Norne, and gives identical output except for the iteration headers that are slightly changed.