### PR TITLE
Silence warnings (shadowing and unused argument).

### DIFF
--- a/opm/autodiff/BlackoilSolventModel_impl.hpp
+++ b/opm/autodiff/BlackoilSolventModel_impl.hpp
@@ -370,7 +370,6 @@ namespace Opm {
                 // A weighted sum of the b-factors of gas and solvent are used.
                 const int nc = Opm::AutoDiffGrid::numCells(grid_);
 
-                const Opm::PhaseUsage& pu = fluid_.phaseUsage();
                 const ADB zero = ADB::constant(V::Zero(nc));
                 const ADB& ss = state.solvent_saturation;
                 const ADB& sg = (active_[ Gas ]
@@ -380,7 +379,6 @@ namespace Opm {
                 Selector<double> zero_selector(ss.value() + sg.value(), Selector<double>::Zero);
                 V F_solvent = subset(zero_selector.select(ss, ss / (ss + sg)),well_cells).value();
 
-                const int nw = wells().number_of_wells;
                 V injectedSolventFraction = Eigen::Map<const V>(&xw.solventFraction()[0], nperf);
 
                 V isProducer = V::Zero(nperf);
@@ -637,7 +635,6 @@ namespace Opm {
             mob_perfcells[gas_pos] += subset(rq_[solvent_pos_].mob, well_cells);
 
             // A weighted sum of the b-factors of gas and solvent are used.
-            const int nperf = wells().well_connpos[wells().number_of_wells];
             const int nc = Opm::AutoDiffGrid::numCells(grid_);
 
             const Opm::PhaseUsage& pu = fluid_.phaseUsage();
@@ -647,7 +644,6 @@ namespace Opm {
                              ? state.saturation[ pu.phase_pos[ Gas ] ]
                              : zero);
 
-            const std::vector<int> well_cells(wells().well_cells, wells().well_cells + nperf);
             Selector<double> zero_selector(ss.value() + sg.value(), Selector<double>::Zero);
             ADB F_solvent = subset(zero_selector.select(ss, ss / (ss + sg)),well_cells);
             V ones = V::Constant(nperf,1.0);

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
@@ -207,7 +207,7 @@ namespace Opm
          */
         template<typename Scalar> struct PointOneOp {
             EIGEN_EMPTY_STRUCT_CTOR(PointOneOp)
-            Scalar operator()(const Scalar&, const Scalar&) const { return 0.1; }
+            Scalar operator()(const Scalar& a, const Scalar& b) const { return 0.1; }
         };
     }
 
@@ -234,25 +234,23 @@ namespace Opm
         assert(size == row_major.cols());
 
         // Create ISTL matrix with interleaved rows and columns (block structured).
-        {
-            assert(np == 3);
-            istlA.setSize(row_major.rows(), row_major.cols(), row_major.nonZeros());
-            istlA.setBuildMode(Mat::row_wise);
-            const int* ia = row_major.outerIndexPtr();
-            const int* ja = row_major.innerIndexPtr();
-            for (Mat::CreateIterator row = istlA.createbegin(); row != istlA.createend(); ++row) {
-                const int ri = row.index();
-                for (int i = ia[ri]; i < ia[ri + 1]; ++i) {
-                    row.insert(ja[i]);
-                }
+        assert(np == 3);
+        istlA.setSize(row_major.rows(), row_major.cols(), row_major.nonZeros());
+        istlA.setBuildMode(Mat::row_wise);
+        const int* ia = row_major.outerIndexPtr();
+        const int* ja = row_major.innerIndexPtr();
+        for (Mat::CreateIterator row = istlA.createbegin(); row != istlA.createend(); ++row) {
+            const int ri = row.index();
+            for (int i = ia[ri]; i < ia[ri + 1]; ++i) {
+                row.insert(ja[i]);
             }
+        }
 
-            // Set all blocks to zero.
-            for (int row = 0; row < size; ++row) {
-                for (int col_ix = ia[row]; col_ix < ia[row + 1]; ++col_ix) {
-                    const int col = ja[col_ix];
-                    istlA[row][col] = 0.0;
-                }
+        // Set all blocks to zero.
+        for (int row = 0; row < size; ++row) {
+            for (int col_ix = ia[row]; col_ix < ia[row + 1]; ++col_ix) {
+                const int col = ja[col_ix];
+                istlA[row][col] = 0.0;
             }
         }
 

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
@@ -207,7 +207,7 @@ namespace Opm
          */
         template<typename Scalar> struct PointOneOp {
             EIGEN_EMPTY_STRUCT_CTOR(PointOneOp)
-            Scalar operator()(const Scalar& a, const Scalar& b) const { return 0.1; }
+            Scalar operator()(const Scalar&, const Scalar&) const { return 0.1; }
         };
     }
 
@@ -234,23 +234,25 @@ namespace Opm
         assert(size == row_major.cols());
 
         // Create ISTL matrix with interleaved rows and columns (block structured).
-        assert(np == 3);
-        istlA.setSize(row_major.rows(), row_major.cols(), row_major.nonZeros());
-        istlA.setBuildMode(Mat::row_wise);
-        const int* ia = row_major.outerIndexPtr();
-        const int* ja = row_major.innerIndexPtr();
-        for (Mat::CreateIterator row = istlA.createbegin(); row != istlA.createend(); ++row) {
-            const int ri = row.index();
-            for (int i = ia[ri]; i < ia[ri + 1]; ++i) {
-                row.insert(ja[i]);
+        {
+            assert(np == 3);
+            istlA.setSize(row_major.rows(), row_major.cols(), row_major.nonZeros());
+            istlA.setBuildMode(Mat::row_wise);
+            const int* ia = row_major.outerIndexPtr();
+            const int* ja = row_major.innerIndexPtr();
+            for (Mat::CreateIterator row = istlA.createbegin(); row != istlA.createend(); ++row) {
+                const int ri = row.index();
+                for (int i = ia[ri]; i < ia[ri + 1]; ++i) {
+                    row.insert(ja[i]);
+                }
             }
-        }
 
-        // Set all blocks to zero.
-        for (int row = 0; row < size; ++row) {
-            for (int col_ix = ia[row]; col_ix < ia[row + 1]; ++col_ix) {
-                const int col = ja[col_ix];
-                istlA[row][col] = 0.0;
+            // Set all blocks to zero.
+            for (int row = 0; row < size; ++row) {
+                for (int col_ix = ia[row]; col_ix < ia[row + 1]; ++col_ix) {
+                    const int col = ja[col_ix];
+                    istlA[row][col] = 0.0;
+                }
             }
         }
 


### PR DESCRIPTION
I would recommend that developers turn on `-Wshadow` to catch these potentially confusing situations.