### PR TITLE
Add "allow crossflow" argument to add_well() calls.

### DIFF
--- a/tests/test_vfpproperties.cpp
+++ b/tests/test_vfpproperties.cpp
@@ -446,7 +446,7 @@ BOOST_AUTO_TEST_CASE(GetTable)
     std::shared_ptr<Wells> wells(create_wells(nphases, nwells, nperfs),
                                 destroy_wells);
     const int cells[] = {5};
-    add_well(INJECTOR, 100, 1, NULL, cells, NULL, NULL, wells.get());
+    add_well(INJECTOR, 100, 1, NULL, cells, NULL, NULL, true, wells.get());
 
     //Create interpolation points
     double aqua_d   = -0.15;
@@ -783,7 +783,7 @@ BOOST_AUTO_TEST_CASE(InterpolateADBAndQs)
         std::stringstream ss;
         ss << "WELL_" << i;
         const bool ok = add_well(INJECTOR, 0.0, 1, NULL, &cells,
-                              NULL, ss.str().c_str(), wells.get());
+                                 NULL, ss.str().c_str(), true, wells.get());
         BOOST_REQUIRE(ok);
     }
 

--- a/tests/test_welldensitysegmented.cpp
+++ b/tests/test_welldensitysegmented.cpp
@@ -49,11 +49,12 @@ BOOST_AUTO_TEST_CASE(TestPressureDeltas)
     const double comp_frac_o[np] = { 0.0, 1.0, 0.0 };
     const int cells[nperf/2] = { 0, 1, 2, 3, 4 };
     const double WI[nperf/2] = { 1.0, 1.0, 1.0, 1.0, 1.0 };
+    const bool allow_crossflow = true;
     std::shared_ptr<Wells> wells(create_wells(np, 2, nperf), destroy_wells);
     BOOST_REQUIRE(wells);
-    int ok = add_well(INJECTOR, ref_depth, nperf/2, comp_frac_w, cells, WI, "INJ", wells.get());
+    int ok = add_well(INJECTOR, ref_depth, nperf/2, comp_frac_w, cells, WI, "INJ", allow_crossflow, wells.get());
     BOOST_REQUIRE(ok);
-    ok = add_well(PRODUCER, ref_depth, nperf/2, comp_frac_o, cells, WI, "PROD", wells.get());
+    ok = add_well(PRODUCER, ref_depth, nperf/2, comp_frac_o, cells, WI, "PROD", allow_crossflow, wells.get());
     BOOST_REQUIRE(ok);
     std::vector<double> rates = { 1.0, 0.0, 0.0,
                                   1.0, 0.0, 0.0,


### PR DESCRIPTION
Required for building, self-merging.