### PR TITLE
adapt to the threshold pressure related API changes

### DIFF
--- a/examples/flow.cpp
+++ b/examples/flow.cpp
@@ -367,7 +367,9 @@ try
     // initialize variables
     simtimer.init(timeMap);
 
-    std::vector<double> threshold_pressures = thresholdPressures(parseMode, eclipseState, grid);
+    std::map<std::pair<int, int>, double> maxDp;
+    computeMaxDp(maxDp, deck, eclipseState, grid, state, props, gravity[2]);
+    std::vector<double> threshold_pressures = thresholdPressures(deck, eclipseState, grid, maxDp);
 
     SimulatorFullyImplicitBlackoil< Grid >  simulator(param,
                                                       grid,

--- a/examples/flow_solvent.cpp
+++ b/examples/flow_solvent.cpp
@@ -377,7 +377,9 @@ try
     // initialize variables
     simtimer.init(timeMap);
 
-    std::vector<double> threshold_pressures = thresholdPressures(parseMode, eclipseState, grid);
+    std::map<std::pair<int, int>, double> maxDp;
+    computeMaxDp(maxDp, deck, eclipseState, grid, state, props, gravity[2]);
+    std::vector<double> threshold_pressures = thresholdPressures(deck, eclipseState, grid, maxDp);
 
     SimulatorFullyImplicitBlackoilSolvent< Grid >  simulator(param,
                                                       grid,


### PR DESCRIPTION
to be able to determine the threshold pressure from the initial
condition it needs to be able to access the initial condition, i.e.,
the initial simulator state, material properties object and gravity
constant need to be passed to the thresholdPressure() function.

this is a follow-up of OPM/opm-core#907.