### PR TITLE
Use opm data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ else()
 
 endif()
 
+
 # not the same location as most of the other projects? this hook overrides
 macro (dir_hook)
 endmacro (dir_hook)
@@ -63,6 +64,10 @@ endmacro (dir_hook)
 # we cannot generate dune.module since it is read by dunecontrol before
 # the build starts, so it makes sense to keep the data there then.
 include (OpmInit)
+
+# Look for the opm-data repository; if found the variable
+# HAVE_OPM_DATA will be set to true.
+include( Findopm-data )
 
 # list of prerequisites for this particular project; this is in a
 # separate file (in cmake/Modules sub-directory) because it is shared
@@ -114,3 +119,9 @@ if (NOT EIGEN3_FOUND)
 	include_directories (${CMAKE_BINARY_DIR}/eigen3-installed/include/eigen3)
 	add_dependencies (opmautodiff Eigen3)
 endif (NOT EIGEN3_FOUND)
+
+
+
+if (HAVE_OPM_DATA)
+   add_test( NAME flow_SPE1 COMMAND flow ${OPM_DATA_ROOT}/spe1/SPE1CASE1.DATA )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,8 +55,6 @@ else()
 
 endif()
 
-option( INCLUDE_NON_PUBLIC_TESTS  "Include the tests which need non-public data" OFF)
-
 # not the same location as most of the other projects? this hook overrides
 macro (dir_hook)
 endmacro (dir_hook)

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -47,6 +47,7 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/autodiff/VFPInjProperties.cpp
 	)
 
+
 # originally generated with the command:
 # find tests -name '*.cpp' -a ! -wholename '*/not-unit/*' -printf '\t%p\n' | sort
 list (APPEND TEST_SOURCE_FILES

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -69,16 +69,6 @@ list (APPEND TEST_DATA_FILES
 	tests/VFPPROD2
 	)
 
-# Note, these two files are not included in the repo.
-# If enabling INCLUDE_NON_PUBLIC_TESTS, please add add symlink to the folder
-# "non_public" containing these two files.
-if (INCLUDE_NON_PUBLIC_TESTS)
-	list (APPEND TEST_DATA_FILES
-		tests/non_public/SPE1_opm.DATA
-		tests/non_public/spe1.xml
-		)
-endif()
-
 
 # originally generated with the command:
 # find tutorials examples -name '*.c*' -printf '\t%p\n' | sort


### PR DESCRIPTION
1. Have removed old - completely stale cmake switch `INCLUDE_NON_PUBLIC_TESTS`
2. Will look for `opm-data` and run `flow` on SPE1 case as a test.

Observe that the integration test is currently just a `it runs through with exit(0)` test.
