### PR TITLE
Cater for wells null pointer

### DIFF
--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -191,15 +191,15 @@ namespace detail {
                 // Only rank 0 does print to std::cout if terminal_output is enabled
                 terminal_output_ = (info.communicator().rank()==0);
             }
-            int local_number_of_wells = wells_->number_of_wells;
+            int local_number_of_wells = wells_ ? wells_->number_of_wells : 0;
             int global_number_of_wells = info.communicator().sum(local_number_of_wells);
-            wells_active_ = ( global_number_of_wells > 0 );
+            wells_active_ = ( wells_ && global_number_of_wells > 0 );
         }else
         {
-            wells_active_ = (wells_->number_of_wells > 0 );
+            wells_active_ = ( wells_ && wells_->number_of_wells > 0 );
         }
 #else
-        wells_active_ = (wells_->number_of_wells > 0 );
+        wells_active_ = ( wells_ && wells_->number_of_wells > 0 );
 #endif
     }
 

--- a/opm/autodiff/RedistributeDataHandles.hpp
+++ b/opm/autodiff/RedistributeDataHandles.hpp
@@ -324,7 +324,7 @@ void distributeGridAndData( Dune::CpGrid& grid,
     global_grid.switchToGlobalView();
 
     // distribute the grid and switch to the distributed view
-    grid.loadBalance(eclipseState);
+    grid.loadBalance(eclipseState, 1);
     grid.switchToDistributedView();
 
     distributed_props = std::make_shared<BlackoilPropsAdFromDeck>(properties, grid.numCells());

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -463,32 +463,34 @@ namespace Opm
             }
         }
 
-        for (int w = 0, nw = wells->number_of_wells; w < nw; ++w) {
-            WellControls* ctrl = wells->ctrls[w];
-            const bool is_producer = wells->type[w] == PRODUCER;
-            if (!is_producer && wells->name[w] != 0) {
-                WellMap::const_iterator i = wmap.find(wells->name[w]);
-                if (i != wmap.end()) {
-                    WellConstPtr wp = i->second;
-                    const WellInjectionProperties& injector = wp->getInjectionProperties(step);
-                    if (!injector.predictionMode) {
-                        //History matching WCONINJEH
-                        static const double invalid_alq = -std::numeric_limits<double>::max();
-                        static const int invalid_vfp = -std::numeric_limits<int>::max();
-                        // For WCONINJEH the BHP limit is set to a large number
-                        // or a value specified using WELTARG
-                        double bhp_limit = (injector.BHPLimit > 0) ? injector.BHPLimit : std::numeric_limits<double>::max();
-                        const int ok_bhp =
+        if( wells )
+        {
+            for (int w = 0, nw = wells->number_of_wells; w < nw; ++w) {
+                WellControls* ctrl = wells->ctrls[w];
+                const bool is_producer = wells->type[w] == PRODUCER;
+                if (!is_producer && wells->name[w] != 0) {
+                    WellMap::const_iterator i = wmap.find(wells->name[w]);
+                    if (i != wmap.end()) {
+                        WellConstPtr wp = i->second;
+                        const WellInjectionProperties& injector = wp->getInjectionProperties(step);
+                        if (!injector.predictionMode) {
+                            //History matching WCONINJEH
+                            static const double invalid_alq = -std::numeric_limits<double>::max();
+                            static const int invalid_vfp = -std::numeric_limits<int>::max();
+                            // For WCONINJEH the BHP limit is set to a large number
+                            // or a value specified using WELTARG
+                            double bhp_limit = (injector.BHPLimit > 0) ? injector.BHPLimit : std::numeric_limits<double>::max();
+                            const int ok_bhp =
                                 well_controls_add_new(BHP, bhp_limit,
                                                       invalid_alq, invalid_vfp,
                                                       NULL, ctrl);
-                        if (!ok_bhp) {
-                            OPM_THROW(std::runtime_error, "Failed to add well control.");
+                            if (!ok_bhp) {
+                                OPM_THROW(std::runtime_error, "Failed to add well control.");
+                            }
                         }
                     }
                 }
             }
         }
-
     }
 } // namespace Opm


### PR DESCRIPTION
In the rare occasion that there are not wells the wells_ point in
BlackoilModelBase is a null. Therefore we need to test whether it it
null and only process well information if it is not.

This problem was reintroduced with PR #460 and gets fixed by this
one. No we can run the equilibrium examples without wells again.
Sorry for the inconvenience.