### PR TITLE
Removes superfluous wellMap_ member from WellStateFullyImplicitBlackoil

### DIFF
--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -180,7 +180,6 @@ namespace Opm
     private:
         std::vector<double> perfphaserates_;
         std::vector<int> current_controls_;
-        WellMapType wellMap_;
     };
 
 } // namespace Opm


### PR DESCRIPTION
There is a using `BaseType::wellMap` directive that redirects all the
well map accesses to the base class. In consequence the local wellMap_
is alway empty and just makes debugging harder. Therefore it is
removed in this commit.