### PR TITLE
Bump version and unify format of dune.module.

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -1,7 +1,13 @@
+####################################################################
+# Dune module information file: This file gets parsed by dunecontrol
+# and by the CMake build scripts.
+####################################################################
+
 Module: opm-autodiff
 Description: Utilities for automatic differentiation and simulators based on AD
 Version: 2016.04-pre
 Label: 2016.04-pre
 Maintainer: atgeirr@sintef.no
-Depends: opm-common opm-material opm-core dune-cornerpoint dune-istl (>=2.2)
-Suggests:
+MaintainerName: Atgeirr F. Rasmussen
+Url: http://opm-project.org
+Depends: opm-common opm-core dune-cornerpoint dune-istl (>=2.2)


### PR DESCRIPTION
After this, all code modules have the same formatting in dune.module, and the correct version name (for the master branch): "2016.04-pre".