### PR TITLE
Wells: fix seg fault when deck with no wells is loaded.

### DIFF
--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -196,10 +196,10 @@ namespace detail {
             wells_active_ = ( global_number_of_wells > 0 );
         }else
         {
-            wells_active_ = (wells_->number_of_wells > 0 );
+            wells_active_ = wells_ && (wells_->number_of_wells > 0 );
         }
 #else
-        wells_active_ = (wells_->number_of_wells > 0 );
+        wells_active_ = wells_ && (wells_->number_of_wells > 0 );
 #endif
     }
 

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -463,7 +463,7 @@ namespace Opm
             }
         }
 
-        for (int w = 0, nw = wells->number_of_wells; w < nw; ++w) {
+        for (int w = 0, nw = wells ? wells->number_of_wells : 0; w < nw; ++w) {
             WellControls* ctrl = wells->ctrls[w];
             const bool is_producer = wells->type[w] == PRODUCER;
             if (!is_producer && wells->name[w] != 0) {


### PR DESCRIPTION
This PR fixes a seg fault received, when a test case deck containing no wells is loaded.