### PR TITLE
Communicate rock properties, too.

### DIFF
--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -119,6 +119,7 @@ namespace Opm
 /// Constructor for properties on a subgrid
 BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& props,
                                                  const int number_of_cells)
+    : rock_(number_of_cells)
 {
     const int original_size = props.cellPvtRegionIdx_.size();
     if (number_of_cells > original_size) {
@@ -131,7 +132,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
     materialLawManager_ = props.materialLawManager_;
 
     // Copy properties that do not depend on the postion within the grid.
-    rock_             = props.rock_;
     satprops_         = props.satprops_;
     phase_usage_      = props.phase_usage_;
     props_            = props.props_;

--- a/opm/autodiff/RedistributeDataHandles.hpp
+++ b/opm/autodiff/RedistributeDataHandles.hpp
@@ -242,7 +242,7 @@ public:
     BlackoilPropsDataHandle(const BlackoilPropsAdFromDeck& sendProps,
                             BlackoilPropsAdFromDeck& recvProps)
         : sendProps_(sendProps), recvProps_(recvProps),
-          size_(1)
+          size_(11)
     {
         // satOilMax might be non empty. In this case we will need to send it, too.
         // It has to have the same size as the cellPvtRegionIdx_
@@ -278,7 +278,12 @@ public:
         assert( T::codimension == 0);
 
         buffer.write(sendProps_.cellPvtRegionIndex()[e.index()]);
-        if ( size_ > 1 ) {
+        for( std::size_t i = 0; i < 9; ++i )
+        {
+            buffer.write(sendProps_.rock_.permeability_[e.index()*9+i]);
+        }
+        buffer.write(sendProps_.rock_.porosity_[e.index()]);
+        if ( size_ > 11 ) {
             buffer.write(sendProps_.satOilMax_[e.index()]);
         }
     }
@@ -290,7 +295,15 @@ public:
         double val;
         buffer.read(val);
         recvProps_.cellPvtRegionIdx_[e.index()]=val;
-        if ( size_ > 1 ) {
+        for( std::size_t i = 0; i < 9; ++i )
+        {
+            buffer.read(val);
+            recvProps_.rock_.permeability_[e.index()*9+i]
+                = val;
+        }
+        buffer.read(val);
+        recvProps_.rock_.porosity_[e.index()]=val;
+        if ( size_ > 11 ) {
             buffer.read(val);
             recvProps_.satOilMax_[e.index()]=val;
         }

--- a/opm/autodiff/RedistributeDataHandles.hpp
+++ b/opm/autodiff/RedistributeDataHandles.hpp
@@ -231,6 +231,7 @@ private:
     BlackoilState& recvState_;
 };
 
+/// \brief A DUNE data handle for sending the blackoil properties
 class BlackoilPropsDataHandle
 {
 public:
@@ -242,12 +243,13 @@ public:
     BlackoilPropsDataHandle(const BlackoilPropsAdFromDeck& sendProps,
                             BlackoilPropsAdFromDeck& recvProps)
         : sendProps_(sendProps), recvProps_(recvProps),
-          size_(11)
+          size_(11) // full permeability tensor 9 + porosity 1 + pvt region index
     {
         // satOilMax might be non empty. In this case we will need to send it, too.
-        // It has to have the same size as the cellPvtRegionIdx_
         if ( sendProps.satOilMax_.size()>0 )
         {
+            
+            // satOilMax has to have the same size as the cellPvtRegionIdx_
             recvProps_.satOilMax_.resize(recvProps_.cellPvtRegionIdx_.size(),
                                          -std::numeric_limits<double>::max());
             ++size_;
@@ -264,7 +266,6 @@ public:
     {
         if ( T::codimension == 0)
         {
-            // We only send cellPvtRegionIdx_, and maybe satOilMax_
             return size_;
         }
         else
@@ -315,8 +316,12 @@ public:
 private:
     /// \brief The properties where we will retieve the values to be sent.
     const BlackoilPropsAdFromDeck& sendProps_;
-    // \brief The properties where we will store the received values.
+    /// \brief The properties where we will store the received values.
     BlackoilPropsAdFromDeck& recvProps_;
+    /// \brief The number of entries to send.
+    ///
+    /// full permeability tensor 9 + porosity 1 + pvt region index and
+    /// in some case satOilMax
     std::size_t size_;
 };
 


### PR DESCRIPTION
Somehow I was mislead by the name rock properties that the data stored in
them is not associated to grid cells, but to rock regions. With this commit
we determine the porosity and permeability by communication.

This needs PR OPM/opm-core#918