### PR TITLE
Correctly compute the scaling factor for the equations in parallel.

### DIFF
--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -280,6 +280,8 @@ namespace Opm {
 
         /// \brief Whether we print something to std::cout
         bool terminal_output_;
+        /// \brief The number of cells of the global grid.
+        int global_nc_;
 
         std::vector<int>         primalVariable_;
         V pvdt_;

--- a/opm/autodiff/BlackoilSolventModel_impl.hpp
+++ b/opm/autodiff/BlackoilSolventModel_impl.hpp
@@ -237,7 +237,7 @@ namespace Opm {
         if (has_solvent_) {
             const ADB& temp_b = rq_[solvent_pos_].b;
             ADB::V B = 1. / temp_b.value();
-            #if HAVE_MPI
+#if HAVE_MPI
             if ( linsolver_.parallelInformation().type() == typeid(ParallelISTLInformation) )
             {
                 const ParallelISTLInformation& real_info =

--- a/opm/autodiff/BlackoilSolventModel_impl.hpp
+++ b/opm/autodiff/BlackoilSolventModel_impl.hpp
@@ -244,12 +244,12 @@ namespace Opm {
                     boost::any_cast<const ParallelISTLInformation&>(linsolver_.parallelInformation());
                 double B_global_sum = 0;
                 real_info.computeReduction(B, Reduction::makeGlobalSumFunctor<double>(), B_global_sum);
-                residual_.matbalscale[idx] = B_global_sum / global_nc_;
+                residual_.matbalscale[solvent_pos_] = B_global_sum / Base::global_nc_;
             }
             else
 #endif
             {
-                residual_.matbalscale[idx] = B.mean();
+                residual_.matbalscale[solvent_pos_] = B.mean();
             }
         }
     }


### PR DESCRIPTION
When running parallel one cannot use Eigen::Array::mean() for this
as the it is just a local part of the complete array. With this commit
we correctly compute the number of global cells in the grid and use this
together with a parallel reduction to compute a global mean value.