### PR TITLE
Support for non-constant surface densities

### DIFF
--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -782,12 +782,11 @@ namespace detail {
         std::vector<double> perf_depth(pdepth.data(), pdepth.data() + nperf);
 
         // Surface density.
-        const std::vector<V> rhos = fluid_.surfaceDensity(well_cells);
         // The compute density segment wants the surface densities as
         // an np * number of wells cells array
-        V rho = superset(rhos[0], Span(nperf, pu.num_phases, 0), nperf*pu.num_phases);
+        V rho = superset(fluid_.surfaceDensity(0 , well_cells), Span(nperf, pu.num_phases, 0), nperf*pu.num_phases);
         for (int phase = 1; phase < pu.num_phases; ++phase) {
-            rho += superset(rhos[phase], Span(nperf, pu.num_phases, phase), nperf*pu.num_phases);
+            rho += superset(fluid_.surfaceDensity(phase , well_cells), Span(nperf, pu.num_phases, phase), nperf*pu.num_phases);
         }
         std::vector<double> surf_dens_perf(rho.data(), rho.data() + nperf * pu.num_phases);
 
@@ -2692,15 +2691,14 @@ namespace detail {
                                                           const ADB& rs,
                                                           const ADB& rv) const
     {
-        std::vector<V> rhos = fluid_.surfaceDensity(cells_);
-        ADB rho = rhos[phase] * b;
+        const V& rhos = fluid_.surfaceDensity(phase,  cells_);
+        const Opm::PhaseUsage& pu = fluid_.phaseUsage();
+        ADB rho = rhos * b;
         if (phase == Oil && active_[Gas]) {
-            // It is correct to index into rhos with canonical phase indices.
-            rho += rhos[Gas] * rs * b;
+            rho += fluid_.surfaceDensity(pu.phase_pos[ Gas ],  cells_) * rs * b;
         }
         if (phase == Gas && active_[Oil]) {
-            // It is correct to index into rhos with canonical phase indices.
-            rho += rhos[Oil] * rv * b;
+            rho += fluid_.surfaceDensity(pu.phase_pos[ Oil ],  cells_) * rv * b;
         }
         return rho;
     }

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -349,11 +349,25 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
     // ------ Density ------
 
     /// Densities of stock components at surface conditions.
-    /// \return Array of 3 density values.
-    const double* BlackoilPropsAdFromDeck::surfaceDensity(const int cellIdx) const
+    /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+    /// \return Array of number of phases with n density values each.
+    std::vector<V> BlackoilPropsAdFromDeck::surfaceDensity(const Cells& cells) const
     {
-        int pvtRegionIdx = cellPvtRegionIdx_[cellIdx];
-        return &densities_[pvtRegionIdx][0];
+        const int n = cells.size();
+        std::vector<V> rhos(BlackoilPhases::MaxNumPhases);
+        for (size_t phaseIdx = 0; phaseIdx < rhos.size(); ++phaseIdx) {
+            rhos[phaseIdx] = V::Zero(n);
+        }
+
+        for (int cellIdx = 0; cellIdx < n; ++cellIdx) {
+            int pvtRegionIdx = cellPvtRegionIdx_[cellIdx];
+            const double* rho = &densities_[pvtRegionIdx][0];
+            for (size_t phaseIdx = 0; phaseIdx < rhos.size(); ++phaseIdx) {
+                rhos[phaseIdx][cellIdx] = rho[phaseIdx];
+            }
+        }
+        return rhos;
+
     }
 
 

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -349,25 +349,20 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
     // ------ Density ------
 
     /// Densities of stock components at surface conditions.
-    /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-    /// \return Array of number of phases with n density values each.
-    std::vector<V> BlackoilPropsAdFromDeck::surfaceDensity(const Cells& cells) const
+    /// \param[in] phaseIdx
+    /// \param[in] cells  Array of n cell indices to be associated with the pressure values.
+    /// \return Array of n density values for phase given by phaseIdx.
+    V BlackoilPropsAdFromDeck::surfaceDensity(const int phaseIdx, const Cells& cells) const
     {
+        assert( !(phaseIdx > numPhases()));
         const int n = cells.size();
-        std::vector<V> rhos(BlackoilPhases::MaxNumPhases);
-        for (size_t phaseIdx = 0; phaseIdx < rhos.size(); ++phaseIdx) {
-            rhos[phaseIdx] = V::Zero(n);
-        }
-
+        V rhos = V::Zero(n);
         for (int cellIdx = 0; cellIdx < n; ++cellIdx) {
             int pvtRegionIdx = cellPvtRegionIdx_[cellIdx];
-            const double* rho = &densities_[pvtRegionIdx][0];
-            for (size_t phaseIdx = 0; phaseIdx < rhos.size(); ++phaseIdx) {
-                rhos[phaseIdx][cellIdx] = rho[phaseIdx];
-            }
+            const auto* rho = &densities_[pvtRegionIdx][0];
+            rhos[cellIdx] = rho[phaseIdx];
         }
         return rhos;
-
     }
 
 

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -187,8 +187,9 @@ namespace Opm
         // ------ Density ------
 
         /// Densities of stock components at surface conditions.
-        /// \return Array of 3 density values.
-        const double* surfaceDensity(const int cellIdx = 0) const;
+        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+        /// \return    Array of number of phases with n density values each.
+        std::vector<V> surfaceDensity(const Cells& cells) const;
 
 
         // ------ Viscosity ------

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -187,9 +187,10 @@ namespace Opm
         // ------ Density ------
 
         /// Densities of stock components at surface conditions.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return    Array of number of phases with n density values each.
-        std::vector<V> surfaceDensity(const Cells& cells) const;
+        /// \param[in] phaseIdx
+        /// \param[in] cells  Array of n cell indices to be associated with the pressure values.
+        /// \return Array of n density values for phase given by phaseIdx.
+        V surfaceDensity(const int phaseIdx , const Cells& cells) const;
 
 
         // ------ Viscosity ------

--- a/opm/autodiff/BlackoilPropsAdInterface.hpp
+++ b/opm/autodiff/BlackoilPropsAdInterface.hpp
@@ -88,8 +88,9 @@ namespace Opm
         // ------ Density ------
 
         /// Densities of stock components at surface conditions.
-        /// \return Array of 3 density values.
-        virtual const double* surfaceDensity(int regionIdx = 0) const = 0;
+        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
+        /// \return Array of number of phases with n density values each.
+        virtual std::vector<V> surfaceDensity(const Cells& cells) const = 0;
 
 
         // ------ Viscosity ------

--- a/opm/autodiff/BlackoilPropsAdInterface.hpp
+++ b/opm/autodiff/BlackoilPropsAdInterface.hpp
@@ -88,9 +88,10 @@ namespace Opm
         // ------ Density ------
 
         /// Densities of stock components at surface conditions.
-        /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
-        /// \return Array of number of phases with n density values each.
-        virtual std::vector<V> surfaceDensity(const Cells& cells) const = 0;
+        /// \param[in] phaseIdx
+        /// \param[in] cells  Array of n cell indices to be associated with the pressure values.
+        /// \return Array of n density values for phase given by phaseIdx.
+        virtual V surfaceDensity(const int PhaseIdx, const Cells& cells) const = 0;
 
 
         // ------ Viscosity ------

--- a/opm/autodiff/ImpesTPFAAD.cpp
+++ b/opm/autodiff/ImpesTPFAAD.cpp
@@ -623,9 +623,9 @@ namespace {
 
     V ImpesTPFAAD::fluidRho(const int phase, const V& p, const V& T, const std::vector<int>& cells) const
     {
-        std::vector<V> rhos = fluid_.surfaceDensity(cells);
+        V rho = fluid_.surfaceDensity(phase, cells);
         V b = fluidFvf(phase, p, T, cells);
-        V rho = rhos[phase] * b;
+        rho = rho * b;
         return rho;
     }
 
@@ -635,9 +635,9 @@ namespace {
 
     ADB ImpesTPFAAD::fluidRho(const int phase, const ADB& p, const ADB& T, const std::vector<int>& cells) const
     {
-        std::vector<V> rhos = fluid_.surfaceDensity(cells);
+        const V& rhos = fluid_.surfaceDensity(phase, cells);
         ADB b = fluidFvf(phase, p, T, cells);
-        ADB rho = rhos[phase] * b;
+        ADB rho = rhos * b;
         return rho;
     }
 

--- a/opm/autodiff/ImpesTPFAAD.cpp
+++ b/opm/autodiff/ImpesTPFAAD.cpp
@@ -623,9 +623,9 @@ namespace {
 
     V ImpesTPFAAD::fluidRho(const int phase, const V& p, const V& T, const std::vector<int>& cells) const
     {
-        const double* rhos = fluid_.surfaceDensity();
+        std::vector<V> rhos = fluid_.surfaceDensity(cells);
         V b = fluidFvf(phase, p, T, cells);
-        V rho = V::Constant(p.size(), 1, rhos[phase]) * b;
+        V rho = rhos[phase] * b;
         return rho;
     }
 
@@ -635,9 +635,9 @@ namespace {
 
     ADB ImpesTPFAAD::fluidRho(const int phase, const ADB& p, const ADB& T, const std::vector<int>& cells) const
     {
-        const double* rhos = fluid_.surfaceDensity();
+        std::vector<V> rhos = fluid_.surfaceDensity(cells);
         ADB b = fluidFvf(phase, p, T, cells);
-        ADB rho = V::Constant(p.size(), 1, rhos[phase]) * b;
+        ADB rho = rhos[phase] * b;
         return rho;
     }
 

--- a/tests/test_boprops_ad.cpp
+++ b/tests/test_boprops_ad.cpp
@@ -115,16 +115,25 @@ BOOST_FIXTURE_TEST_CASE(SubgridConstruction, TestFixtureAd<SetupSimple>)
 
 BOOST_FIXTURE_TEST_CASE(SurfaceDensity, TestFixture<SetupSimple>)
 {
-    const double* rho0AD = boprops_ad.surfaceDensity();
+    const Opm::BlackoilPropsAdFromDeck::Cells cells(1, 0);
+
+    typedef Opm::BlackoilPropsAdFromDeck::V V;
+
+    std::vector<V> rho0AD = boprops_ad.surfaceDensity(cells);
+
+    BOOST_REQUIRE_EQUAL(rho0AD.size(), 3);
 
     enum { Water = Opm::BlackoilPropsAdFromDeck::Water };
-    BOOST_CHECK_EQUAL(rho0AD[ Water ], 1000.0);
+    BOOST_REQUIRE_EQUAL(rho0AD[Water].size(), cells.size());
+    BOOST_CHECK_EQUAL(rho0AD[ Water ][0], 1000.0);
 
     enum { Oil = Opm::BlackoilPropsAdFromDeck::Oil };
-    BOOST_CHECK_EQUAL(rho0AD[ Oil ], 800.0);
+    BOOST_REQUIRE_EQUAL(rho0AD[Oil].size(), cells.size());
+    BOOST_CHECK_EQUAL(rho0AD[ Oil ][0], 800.0);
 
     enum { Gas = Opm::BlackoilPropsAdFromDeck::Gas };
-    BOOST_CHECK_EQUAL(rho0AD[ Gas ], 1.0);
+    BOOST_REQUIRE_EQUAL(rho0AD[Gas].size(), cells.size());
+    BOOST_CHECK_EQUAL(rho0AD[ Gas ][0], 1.0);
 }
 
 

--- a/tests/test_boprops_ad.cpp
+++ b/tests/test_boprops_ad.cpp
@@ -119,21 +119,20 @@ BOOST_FIXTURE_TEST_CASE(SurfaceDensity, TestFixture<SetupSimple>)
 
     typedef Opm::BlackoilPropsAdFromDeck::V V;
 
-    std::vector<V> rho0AD = boprops_ad.surfaceDensity(cells);
-
-    BOOST_REQUIRE_EQUAL(rho0AD.size(), 3);
-
     enum { Water = Opm::BlackoilPropsAdFromDeck::Water };
-    BOOST_REQUIRE_EQUAL(rho0AD[Water].size(), cells.size());
-    BOOST_CHECK_EQUAL(rho0AD[ Water ][0], 1000.0);
+    V rho0AD_Water = boprops_ad.surfaceDensity(Water, cells);
+    BOOST_REQUIRE_EQUAL(rho0AD_Water.size(), cells.size());
+    BOOST_CHECK_EQUAL(rho0AD_Water[0], 1000.0);
 
     enum { Oil = Opm::BlackoilPropsAdFromDeck::Oil };
-    BOOST_REQUIRE_EQUAL(rho0AD[Oil].size(), cells.size());
-    BOOST_CHECK_EQUAL(rho0AD[ Oil ][0], 800.0);
+    V rho0AD_Oil = boprops_ad.surfaceDensity(Oil, cells);
+    BOOST_REQUIRE_EQUAL(rho0AD_Oil.size(), cells.size());
+    BOOST_CHECK_EQUAL(rho0AD_Oil[0], 800.0);
 
     enum { Gas = Opm::BlackoilPropsAdFromDeck::Gas };
-    BOOST_REQUIRE_EQUAL(rho0AD[Gas].size(), cells.size());
-    BOOST_CHECK_EQUAL(rho0AD[ Gas ][0], 1.0);
+    V rho0AD_Gas = boprops_ad.surfaceDensity(Gas, cells);
+    BOOST_REQUIRE_EQUAL(rho0AD_Gas.size(), cells.size());
+    BOOST_CHECK_EQUAL(rho0AD_Gas[0], 1.0);
 }
 
 


### PR DESCRIPTION
The surface density function returns one value pr cell to allow for non-constant surface densities.

Tested on the usual cases with no effects on the results. 


