### PR TITLE
Use local material manager by communication

### DIFF
--- a/examples/flow.cpp
+++ b/examples/flow.cpp
@@ -364,7 +364,7 @@ try
     // and initilialize new properties and states for it.
     if( mpi_size > 1 )
     {
-        Opm::distributeGridAndData( grid, eclipseState, state, new_props, geoprops, parallel_information, use_local_perm );
+        Opm::distributeGridAndData( grid, deck, eclipseState, state, new_props, geoprops, materialLawManager, parallel_information, use_local_perm );
     }
 
     // create output writer after grid is distributed, otherwise the parallel output

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -120,7 +120,7 @@ namespace Opm
 BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& props,
                                                  std::shared_ptr<MaterialLawManager> materialLawManager,
                                                  const int number_of_cells)
-    : rock_(number_of_cells)
+    : rock_(number_of_cells), satprops_(new SaturationPropsFromDeck())
 {
     const int original_size = props.cellPvtRegionIdx_.size();
     if (number_of_cells > original_size) {
@@ -133,7 +133,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
     materialLawManager_ = materialLawManager;
 
     // Copy properties that do not depend on the postion within the grid.
-    satprops_         = props.satprops_;
     phase_usage_      = props.phase_usage_;
     props_            = props.props_;
     densities_        = props.densities_;
@@ -143,6 +142,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
     // For data that is dependant on the subgrid we simply allocate space
     // and initialize with obviously bogus numbers.
     cellPvtRegionIdx_.resize(number_of_cells, std::numeric_limits<int>::min());
+    satprops_->init(phase_usage_, materialLawManager_);
 }
 
     /// Initializes the properties.

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -118,6 +118,7 @@ namespace Opm
 
 /// Constructor for properties on a subgrid
 BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& props,
+                                                 std::shared_ptr<MaterialLawManager> materialLawManager,
                                                  const int number_of_cells)
     : rock_(number_of_cells)
 {
@@ -129,7 +130,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         OPM_THROW(std::runtime_error, "The number of cells is has to be larger than 0.");
     }
 
-    materialLawManager_ = props.materialLawManager_;
+    materialLawManager_ = materialLawManager;
 
     // Copy properties that do not depend on the postion within the grid.
     satprops_         = props.satprops_;

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -138,8 +138,11 @@ namespace Opm
         /// the correct size but the values will be undefined.
         ///
         /// \param props            The property object to copy from.
-        /// \paramm number_of_cells The number of cells of the subgrid.
+        /// \param materialLawManager The container for the material law parameter objects.
+        ///                           Initialized only for the subgrid
+        /// \param number_of_cells  The number of cells of the subgrid.
         BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& props,
+                                std::shared_ptr<MaterialLawManager> materialLawManager,
                                 const int number_of_cells);
 
 

--- a/opm/autodiff/RedistributeDataHandles.hpp
+++ b/opm/autodiff/RedistributeDataHandles.hpp
@@ -358,7 +358,7 @@ void distributeGridAndData( Dune::CpGrid& grid,
     typedef Dune::CpGrid::ParallelIndexSet IndexSet;
     typedef IndexSet::IndexPair Pair;
     const IndexSet& local_indices  = grid.getCellIndexSet();
-    for(auto index : local_indices)
+    for ( auto index : local_indices )
     {
         distributed_material_law_manager->materialLawParamsPointer(index.local()) =
             material_law_manager->materialLawParamsPointer(index.global());


### PR DESCRIPTION
Since the refactoring to using opm-material a material law  manager for
the global grid was used. This meant that the properties used for
elements of the local grid were wrong. Additionally the 
SaturationPropsFromDeck with BlackoilPropsFromDeck was only copied. Leading at least to a waste of space.
Therefore we resort to initailizing a process local version with the local material layout manager.

Please note the this PR needs PR OPM/opm-material#77 merged first.

Also note that this PR will conflict with #518. Therefore I need to update the PR that will be merged later.