### PR TITLE
Adapts flow_solvent to change in redistribution interface.

### DIFF
--- a/examples/flow_solvent.cpp
+++ b/examples/flow_solvent.cpp
@@ -355,7 +355,7 @@ try
     // and initilialize new properties and states for it.
     if( mpi_size > 1 )
     {
-        Opm::distributeGridAndData( grid, eclipseState, state, new_props, geoprops, parallel_information, use_local_perm );
+        Opm::distributeGridAndData( grid, deck, eclipseState, state, new_props, geoprops, materialLawManager, parallel_information, use_local_perm );
     }
 
     // create output writer after grid is distributed, otherwise the parallel output

--- a/opm/autodiff/RedistributeDataHandles.hpp
+++ b/opm/autodiff/RedistributeDataHandles.hpp
@@ -356,7 +356,6 @@ void distributeGridAndData( Dune::CpGrid& grid,
     // really, really cumbersome for the underlying vector<shared_ptr>
     // where the classes pointed to even have more shared_ptr stored in them.
     typedef Dune::CpGrid::ParallelIndexSet IndexSet;
-    typedef IndexSet::IndexPair Pair;
     const IndexSet& local_indices  = grid.getCellIndexSet();
     for ( auto index : local_indices )
     {


### PR DESCRIPTION
In PR #523 the parameters of the method  distributeGridAndData were changed. Unfortunately this PR failed to change the call in flow_solvent accordingsly. This PR fixes this.

I am sorry for the produced trouble, in case you guys compile with MPI activated.