### PR TITLE
Only specialize distributeGridAndData for CpGrid if MPI is found.

### DIFF
--- a/opm/autodiff/RedistributeDataHandles.hpp
+++ b/opm/autodiff/RedistributeDataHandles.hpp
@@ -45,7 +45,7 @@ inline void distributeGridAndData( Grid& ,
 {
 }
 
-#if HAVE_DUNE_CORNERPOINT
+#if HAVE_DUNE_CORNERPOINT && HAVE_MPI
 /// \brief a data handle to distribute Derived Geology
 class GeologyDataHandle
 {


### PR DESCRIPTION
This is my proposed fix for #526. Note that this is yet untested. Hopefully @GitPaean can test it.

Closes #526 