### PR TITLE
BlackOilModelBase: revision of adaptive time stepping.

### DIFF
--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -180,7 +180,7 @@ namespace Opm {
 
         /// \brief compute the relative change between to simulation states
         //  \return || u^n+1 - u^n || / || u^n+1 ||
-        double computeTimeError( const SimulatorState& previous, const SimulatorState& current ) const;
+        double relativeChange( const SimulatorState& previous, const SimulatorState& current ) const;
 
         /// The size (number of unknowns) of the nonlinear system of equations.
         int sizeNonLinear() const;

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -178,6 +178,10 @@ namespace Opm {
         /// and afterwards the norm of the residual of the well flux and the well equation.
         std::vector<double> computeResidualNorms() const;
 
+        /// \brief compute the relative change between to simulation states
+        //  \return || u^n+1 - u^n || / || u^n+1 ||
+        double computeTimeError( const SimulatorState& previous, const SimulatorState& current ) const;
+
         /// The size (number of unknowns) of the nonlinear system of equations.
         int sizeNonLinear() const;
 

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -2387,8 +2387,8 @@ namespace detail {
     template <class Grid, class Implementation>
     double
     BlackoilModelBase<Grid, Implementation>::
-    computeTimeError(const SimulatorState& previous,
-                     const SimulatorState& current ) const
+    relativeChange(const SimulatorState& previous,
+                   const SimulatorState& current ) const
     {
         std::vector< double > p0  ( previous.pressure() );
         std::vector< double > sat0( previous.saturation() );

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -2398,7 +2398,7 @@ namespace detail {
 
         // compute u^n - u^n+1
         for( std::size_t i=0; i<pSize; ++i ) {
-            p0[ i ]   -= current.pressure()[ i ];
+            p0[ i ] -= current.pressure()[ i ];
         }
 
         for( std::size_t i=0; i<satSize; ++i ) {
@@ -2417,10 +2417,12 @@ namespace detail {
                                                                current.numPhases(),
                                                                linsolver_.parallelInformation() );
 
-        if( stateNew > 0.0 )
+        if( stateNew > 0.0 ) {
             return stateOld / stateNew ;
-        else
+        }
+        else {
             return 0.0;
+        }
     }
 
     template <class Grid, class Implementation>

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1800,11 +1800,11 @@ namespace detail {
             }
         }
 
-        /// \brief Compute the L-infinity norm of a vector
-        /// \warn This function is not suitable to compute on the well equations.
-        /// \param a The container to compute the infinity norm on.
-        ///          It has to have one entry for each cell.
-        /// \param info In a parallel this holds the information about the data distribution.
+        /// \brief Compute the Euclidian norm of a vector
+        /// \param it              begin iterator for the given vector
+        /// \param end             end iterator for the given vector
+        /// \param num_components  number of components (i.e. phases) in the vector
+        /// \param pinfo           In a parallel this holds the information about the data distribution.
         template <class Iterator>
         inline
         double euclidianNormSquared( Iterator it, const Iterator end, int num_components, const boost::any& pinfo = boost::any() )

--- a/opm/autodiff/NewtonSolver.hpp
+++ b/opm/autodiff/NewtonSolver.hpp
@@ -96,6 +96,9 @@ namespace Opm {
         /// Number of linear solver iterations used in the last call to step().
         unsigned int linearIterationsLastStep() const;
 
+        /// return reference to physical model
+        const PhysicalModel& model() const;
+
     private:
         // ---------  Data members  ---------
         SolverParameters param_;

--- a/opm/autodiff/NewtonSolver_impl.hpp
+++ b/opm/autodiff/NewtonSolver_impl.hpp
@@ -49,6 +49,12 @@ namespace Opm
         return linearIterations_;
     }
 
+    template <class PhysicalModel>
+    const PhysicalModel& NewtonSolver<PhysicalModel>::model() const
+    {
+        assert( model_ );
+        return *model_;
+    }
 
     template <class PhysicalModel>
     int

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -92,7 +92,7 @@ namespace Opm
         std::unique_ptr< AdaptiveTimeStepping > adaptiveTimeStepping;
         if( param_.getDefault("timestep.adaptive", true ) )
         {
-            adaptiveTimeStepping.reset( new AdaptiveTimeStepping( param_, solver_.parallelInformation(), terminal_output_ ) );
+            adaptiveTimeStepping.reset( new AdaptiveTimeStepping( param_, terminal_output_ ) );
         }
 
         // init output writer


### PR DESCRIPTION
This PR moves the computation of the relative time error from TimeStepControl.cpp to the Model class, BlackoilModelBase. The default behavior has not been changed. 

As a next step we can investigate better implementations of || u^n+1 -u^n || / || u^n+1 ||
