### PR TITLE
Calculate parallel averages in RateConverter.

### DIFF
--- a/opm/autodiff/RateConverter.hpp
+++ b/opm/autodiff/RateConverter.hpp
@@ -105,7 +105,7 @@ namespace Opm {
                 }
             };
             template<>
-            struct AverageIncrementCalculator<true>
+            struct AverageIncrementCalculator<false>
             {
                 std::tuple<double, double, int>
                 operator()(const std::vector<double>& pressure,

--- a/opm/autodiff/RateConverter.hpp
+++ b/opm/autodiff/RateConverter.hpp
@@ -618,9 +618,9 @@ namespace Opm {
              * \param[in] info        The information and communication utilities
              *                        about/of the parallelization.
              * \param[in] ownership   In a parallel run this is vector containing
-             *                        1 for every owned unknown, zero othercase.
-             *                        If it is no such run then it is not used.
-             * \tparam    is_parallel True if the runi is parallel. In this case
+             *                        1 for every owned unknown, zero otherwise.
+             *                        Not used in a sequential run.
+             * \tparam    is_parallel True if the run is parallel. In this case
              *                        info has to contain a ParallelISTLInformation
              *                        object.
              */

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -370,7 +370,9 @@ namespace Opm
 #if HAVE_MPI
         if ( solver_.parallelInformation().type() == typeid(ParallelISTLInformation) )
         {
-            global_number_resv_wells = boost::any_cast<const ParallelISTLInformation&>(solver_.parallelInformation()).communicator().sum(global_number_resv_wells);
+            const auto& info =
+                boost::any_cast<const ParallelISTLInformation&>(solver_.parallelInformation());
+            global_number_resv_wells = info.communicator().sum(global_number_resv_wells);
             if ( global_number_resv_wells )
             {
                 // At least one process has resv wells. Therefore rate converter needs


### PR DESCRIPTION
Previously, local averages were calculated and used in the
well equations. With this commit we add versions of defineState and
calcAverages that take into account the parallel domain decomposition
and calculate correct averages.