### PR TITLE
Add flow_solvent to list of programs to be installed.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -88,6 +88,7 @@ list (APPEND EXAMPLE_SOURCE_FILES
 list (APPEND PROGRAM_SOURCE_FILES
 	examples/sim_2p_incomp_ad.cpp
 	examples/flow.cpp
+	examples/flow_solvent.cpp
 	examples/opm_init_check.cpp
 	)
 


### PR DESCRIPTION
This was forgotten earlier.

I do not think this is critical to backport to the release, since flow_solvent is still somewhat experimental, but if @totto82 disagrees I'll reconsider it. The current situation is that flow_solvent is not installed with the binary packages because of this.