### PR TITLE
Fix bug in scalar autodiff

### DIFF
--- a/opm/autodiff/AutoDiff.hpp
+++ b/opm/autodiff/AutoDiff.hpp
@@ -256,7 +256,7 @@ namespace Opm
                const AutoDiff<Scalar>& rhs)
     {
         Scalar a =  Scalar(lhs) / rhs.val();
-        Scalar b = -Scalar(lhs) / (rhs.val() * rhs.val());
+        Scalar b = (-Scalar(lhs) / (rhs.val() * rhs.val())) * rhs.der();
 
         return AutoDiff<Scalar>::function(a, b);
     }

--- a/tests/test_syntax.cpp
+++ b/tests/test_syntax.cpp
@@ -154,7 +154,7 @@ BOOST_AUTO_TEST_CASE(Division)
     const double atol = 1.0e-14;
 
     AdFW a = AdFW::variable(10.0);
-    AdFW b = AdFW::variable(1.0);
+    AdFW b = AdFW::function(1.0, 4.0);
 
     AdFW aob = a / b;
     BOOST_CHECK_CLOSE(aob.val(), a.val() * b.val(), atol);


### PR DESCRIPTION
This fixes a bug in the (convertible to) Scalar / AutoDiff operator, and modifies the test to make the buggy code fail.

The AutoDiff class is not used much and may be removed in the future, still it's good to avoid having known bugs in it!