### PR TITLE
Refactor nonlinear solver

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -126,8 +126,8 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
 	opm/autodiff/NewtonIterationBlackoilSimple.hpp
 	opm/autodiff/NewtonIterationUtilities.hpp
-	opm/autodiff/NewtonSolver.hpp
-	opm/autodiff/NewtonSolver_impl.hpp
+	opm/autodiff/NonlinearSolver.hpp
+	opm/autodiff/NonlinearSolver_impl.hpp
 	opm/autodiff/LinearisedBlackoilResidual.hpp
 	opm/autodiff/ParallelDebugOutput.hpp
 	opm/autodiff/RateConverter.hpp

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -76,6 +76,17 @@ namespace Opm {
 
 
 
+    /// Class used for reporting the outcome of a nonlinearIteration() call.
+    struct IterationReport
+    {
+        bool failed;
+        bool converged;
+        int linear_iterations;
+    };
+
+
+
+
     /// Traits to encapsulate the types used by classes using or
     /// extending this model. Forward declared here, must be
     /// specialised for each concrete model class.
@@ -154,6 +165,22 @@ namespace Opm {
         void prepareStep(const double dt,
                          ReservoirState& reservoir_state,
                          WellState& well_state);
+
+        /// Called once per nonlinear iteration.
+        /// This model will perform a Newton-Raphson update, changing reservoir_state
+        /// and well_state. It will also use the nonlinear_solver to do relaxation of
+        /// updates if necessary.
+        /// \param[in] iteration              should be 0 for the first call of a new timestep
+        /// \param[in] dt                     time step size
+        /// \param[in] nonlinear_solver       nonlinear solver used (for oscillation/relaxation control)
+        /// \param[in, out] reservoir_state   reservoir state variables
+        /// \param[in, out] well_state        well state variables
+        template <class NonlinearSolverType>
+        IterationReport nonlinearIteration(const int iteration,
+                                           const double dt,
+                                           NonlinearSolverType& nonlinear_solver,
+                                           ReservoirState& reservoir_state,
+                                           WellState& well_state);
 
         /// Called once after each time step.
         /// In this class, this function does nothing.
@@ -290,6 +317,9 @@ namespace Opm {
         std::vector<int>         primalVariable_;
         V pvdt_;
         std::vector<std::string> material_name_;
+        std::vector<std::vector<double>> residual_norms_history_;
+        double current_relaxation_;
+        V dx_old_;
 
         // ---------  Protected methods  ---------
 

--- a/opm/autodiff/NonlinearSolver.hpp
+++ b/opm/autodiff/NonlinearSolver.hpp
@@ -97,8 +97,21 @@ namespace Opm {
         /// Number of linear solver iterations used in the last call to step().
         unsigned int linearIterationsLastStep() const;
 
-        /// return reference to physical model
+        /// Reference to physical model.
         const PhysicalModel& model() const;
+
+        /// Detect oscillation or stagnation in a given residual history.
+        void detectOscillations(const std::vector<std::vector<double>>& residual_history,
+                                const int it, bool& oscillate, bool& stagnate) const;
+
+        /// Apply a stabilization to dx, depending on dxOld and relaxation parameters.
+        void stabilizeNonlinearUpdate(V& dx, V& dxOld, const double omega) const;
+
+        /// The greatest relaxation factor (i.e. smallest factor) allowed.
+        double relaxMax() const          { return param_.relax_max_; }
+
+        /// The step-change size for the relaxation factor.
+        double relaxIncrement() const    { return param_.relax_increment_; }
 
     private:
         // ---------  Data members  ---------
@@ -111,15 +124,9 @@ namespace Opm {
 
         // ---------  Private methods  ---------
         enum RelaxType relaxType() const { return param_.relax_type_; }
-        double relaxMax() const          { return param_.relax_max_; }
-        double relaxIncrement() const    { return param_.relax_increment_; }
         double relaxRelTol() const       { return param_.relax_rel_tol_; }
         double maxIter() const           { return param_.max_iter_; }
         double minIter() const           { return param_.min_iter_; }
-        void detectOscillations(const std::vector<std::vector<double>>& residual_history,
-                                const int it, const double relaxRelTol,
-                                bool& oscillate, bool& stagnate) const;
-        void stabilizeNonlinearUpdate(V& dx, V& dxOld, const double omega, const RelaxType relax_type) const;
     };
 } // namespace Opm
 

--- a/opm/autodiff/NonlinearSolver_impl.hpp
+++ b/opm/autodiff/NonlinearSolver_impl.hpp
@@ -37,6 +37,9 @@ namespace Opm
           nonlinearIterationsLast_(0),
           linearIterationsLast_(0)
     {
+        if (!model_) {
+            OPM_THROW(std::logic_error, "Must provide a non-null model argument for NonlinearSolver.");
+        }
     }
 
     template <class PhysicalModel>
@@ -54,7 +57,6 @@ namespace Opm
     template <class PhysicalModel>
     const PhysicalModel& NonlinearSolver<PhysicalModel>::model() const
     {
-        assert( model_ );
         return *model_;
     }
 

--- a/opm/autodiff/NonlinearSolver_impl.hpp
+++ b/opm/autodiff/NonlinearSolver_impl.hpp
@@ -52,7 +52,7 @@ namespace Opm
     }
 
     template <class PhysicalModel>
-    const PhysicalModel& NewtonSolver<PhysicalModel>::model() const
+    const PhysicalModel& NonlinearSolver<PhysicalModel>::model() const
     {
         assert( model_ );
         return *model_;

--- a/opm/autodiff/SimulatorBase.hpp
+++ b/opm/autodiff/SimulatorBase.hpp
@@ -26,7 +26,6 @@
 #include <opm/common/ErrorMacros.hpp>
 
 #include <opm/autodiff/GeoProps.hpp>
-#include <opm/autodiff/NewtonSolver.hpp>
 #include <opm/autodiff/BlackoilModel.hpp>
 #include <opm/autodiff/BlackoilPropsAdInterface.hpp>
 #include <opm/autodiff/WellStateFullyImplicitBlackoil.hpp>

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -106,7 +106,7 @@ namespace Opm
             output_writer_.restore( timer, state, prev_well_state, restorefilename, desiredRestoreStep );
         }
 
-        unsigned int totalNewtonIterations = 0;
+        unsigned int totalNonlinearIterations = 0;
         unsigned int totalLinearIterations = 0;
 
         // Main simulation loop.
@@ -167,8 +167,8 @@ namespace Opm
             // take time that was used to solve system for this reportStep
             solver_timer.stop();
 
-            // accumulate the number of Newton and Linear Iterations
-            totalNewtonIterations += solver->newtonIterations();
+            // accumulate the number of nonlinear and linear Iterations
+            totalNonlinearIterations += solver->nonlinearIterations();
             totalLinearIterations += solver->linearIterations();
 
             // Report timing.
@@ -201,7 +201,7 @@ namespace Opm
         report.pressure_time = stime;
         report.transport_time = 0.0;
         report.total_time = total_timer.secsSinceStart();
-        report.total_newton_iterations = totalNewtonIterations;
+        report.total_newton_iterations = totalNonlinearIterations;
         report.total_linear_iterations = totalLinearIterations;
         return report;
     }

--- a/opm/autodiff/SimulatorFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoil.hpp
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013 SINTEF ICT, Applied Mathematics.
+  Copyright 2013, 2015 SINTEF ICT, Applied Mathematics.
   Copyright 2015 Andreas Lauser
 
   This file is part of the Open Porous Media project (OPM).
@@ -21,9 +21,8 @@
 #ifndef OPM_SIMULATORFULLYIMPLICITBLACKOIL_HEADER_INCLUDED
 #define OPM_SIMULATORFULLYIMPLICITBLACKOIL_HEADER_INCLUDED
 
-#include "SimulatorBase.hpp"
-
-#include "NewtonSolver.hpp"
+#include <opm/autodiff/SimulatorBase.hpp>
+#include <opm/autodiff/NonlinearSolver.hpp>
 
 namespace Opm {
 
@@ -38,7 +37,7 @@ struct SimulatorTraits<SimulatorFullyImplicitBlackoil<GridT> >
     typedef BlackoilOutputWriter OutputWriter;
     typedef GridT Grid;
     typedef BlackoilModel<Grid> Model;
-    typedef NewtonSolver<Model> Solver;
+    typedef NonlinearSolver<Model> Solver;
 };
 
 /// a simulator for the blackoil model

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilSolvent.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilSolvent.hpp
@@ -32,7 +32,7 @@
 #include <opm/autodiff/BlackoilPropsAdInterface.hpp>
 #include <opm/autodiff/SolventPropsAdFromDeck.hpp>
 #include <opm/autodiff/RateConverter.hpp>
-#include <opm/autodiff/NewtonSolver.hpp>
+#include <opm/autodiff/NonlinearSolver.hpp>
 #include <opm/autodiff/WellStateFullyImplicitBlackoilSolvent.hpp>
 
 #include <opm/core/grid.h>
@@ -88,7 +88,7 @@ namespace Opm
         typedef BlackoilOutputWriter OutputWriter;
         typedef GridT Grid;
         typedef BlackoilSolventModel<Grid> Model;
-        typedef NewtonSolver<Model> Solver;
+        typedef NonlinearSolver<Model> Solver;
     };
 
     /// Class collecting all necessary components for a blackoil simulation with polymer


### PR DESCRIPTION
This renames `NewtonSolver` -> `NonlinearSolver`, and changes the relationship between the solver and the model classes.

After this, the `NonlinearSolver` will call the `nonlinearIteration()` method of the model class, instead of calling `assemble()`, `solveJacobianSystem()`, `updateState()` and `getConvergence()` etc. The provided implementation of `nonlinearIteration()` in the `BlackoilModelBase` class does these things now, so the derived models do not need to change. The results, output and performance should be unchanged.

The change is intended to make the solver/model relation more flexible and less strongly coupled. This will make it possible to implement for example sequential implicit models.

Note that this conflicts with #529. It also requires a follow-up PR in opm-polymer (will appear shortly).