### PR TITLE
Make use of the PinchProcessor 

### DIFF
--- a/examples/flow.cpp
+++ b/examples/flow.cpp
@@ -411,6 +411,7 @@ try
     simtimer.init(timeMap);
 
     std::vector<double> threshold_pressures = thresholdPressures(parseMode, eclipseState, grid);
+    std::vector<double> threshold_pressures_nnc = thresholdPressuresNNC(parseMode, eclipseState, geoprops.nnc());
 
     SimulatorFullyImplicitBlackoil< Grid >  simulator(param,
                                                       grid,
@@ -423,7 +424,8 @@ try
                                                       deck->hasKeyword("VAPOIL"),
                                                       eclipseState,
                                                       outputWriter,
-                                                      threshold_pressures);
+                                                      threshold_pressures,
+                                                      threshold_pressures_nnc);
 
     if (!schedule->initOnly()){
         if( output_cout )

--- a/examples/flow_solvent.cpp
+++ b/examples/flow_solvent.cpp
@@ -381,6 +381,7 @@ try
     simtimer.init(timeMap);
 
     std::vector<double> threshold_pressures = thresholdPressures(parseMode, eclipseState, grid);
+    std::vector<double> threshold_pressures_nnc = thresholdPressuresNNC(parseMode, eclipseState, geoprops.nnc());
 
     SimulatorFullyImplicitBlackoilSolvent< Grid >  simulator(param,
                                                       grid,
@@ -396,6 +397,7 @@ try
                                                       outputWriter,
                                                       deck,
                                                       threshold_pressures,
+                                                      threshold_pressures_nnc,
                                                       deck->hasKeyword("SOLVENT") );
 
     if (!schedule->initOnly()){

--- a/opm/autodiff/AutoDiffHelpers.hpp
+++ b/opm/autodiff/AutoDiffHelpers.hpp
@@ -23,7 +23,11 @@
 
 #include <opm/autodiff/AutoDiffBlock.hpp>
 #include <opm/autodiff/GridHelpers.hpp>
+#include <opm/autodiff/GeoProps.hpp>
 #include <opm/core/grid.h>
+#include <opm/core/grid/PinchProcessor.hpp>
+#include <opm/core/props/rock/RockFromDeck.hpp>
+
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
@@ -69,7 +73,7 @@ struct HelperOps
 
     /// Constructs all helper vectors and matrices.
     template<class Grid>
-    HelperOps(const Grid& grid, Opm::EclipseStateConstPtr eclState = EclipseStateConstPtr () )
+    HelperOps(const Grid& grid, const NNC& nnc = NNC())
     {
         using namespace AutoDiffGrid;
         const int nc = numCells(grid);
@@ -78,39 +82,33 @@ struct HelperOps
 
         TwoColInt nbi;
         extractInternalFaces(grid, internal_faces, nbi);
-        int num_internal = internal_faces.size();
-        // num_connections may also include non-neighboring connections
-        int num_connections = num_internal;
-        int numNNC = 0;
+        const int num_internal = internal_faces.size();
 
         // handle non-neighboring connections
-        std::shared_ptr<const NNC> nnc = eclState ? eclState->getNNC()
-            : std::shared_ptr<const Opm::NNC>();
-        const bool has_nnc = nnc && nnc->hasNNC();
+        const bool has_nnc = nnc.hasNNC();
+        size_t numNNC = nnc.numNNC();
+
+        // num_connections may also include non-neighboring connections
+        const int num_connections = num_internal + numNNC;
         if (has_nnc) {
-            numNNC = nnc->numNNC();
-            num_connections += numNNC;
-            //std::cout << "Added " << numNNC << " NNC" <<std::endl;
-            nbi.resize(num_internal, 2);
+            const int *cartDims = AutoDiffGrid::cartDims(grid);
+            const int numCartesianCells = cartDims[0] * cartDims[1] * cartDims[2];
 
             // the nnc's acts on global indicies and must be mapped to cell indicies
-            size_t cartesianSize = eclState->getEclipseGrid()->getCartesianSize();
-            std::vector<int> global2localIdx(cartesianSize,0);
+            std::vector<int> global2localIdx(numCartesianCells,0);
             for (int i = 0; i< nc; ++i) {
                 global2localIdx[ globalCell( grid )[i] ] = i;
             }
-            const std::vector<size_t>& NNC1 = nnc->nnc1();
-            const std::vector<size_t>& NNC2 = nnc->nnc2();
+            const std::vector<size_t>& NNC1 = nnc.nnc1();
+            const std::vector<size_t>& NNC2 = nnc.nnc2();
             nnc_cells.resize(numNNC,2);
+            nnc_trans.resize(numNNC);
             for (int i = 0; i < numNNC; ++i) {
                 nnc_cells(i,0) = global2localIdx[NNC1[i]];
                 nnc_cells(i,1) = global2localIdx[NNC2[i]];
+                // store the nnc transmissibilities for later usage.
+                nnc_trans(i) = nnc.trans()[i];
             }
-            // store the nnc transmissibilities for later usage.
-            nnc_trans = Eigen::Map<const V>(nnc->trans().data(), numNNC);
-        } else {
-            nnc_trans.resize(0);
-            nnc_cells.resize(0, 2); // Required to have two columns.
         }
 
 
@@ -166,7 +164,6 @@ struct HelperOps
         fulldiv = fullngrad.transpose();
     }
 };
-
 // -------------------- upwinding helper class --------------------
 
 

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -145,7 +145,9 @@ namespace Opm {
         /// flow is prevented or reduced in both directions equally.
         /// \param[in]  threshold_pressures_by_face   array of size equal to the number of faces
         ///                                   of the grid passed in the constructor.
-        void setThresholdPressures(const std::vector<double>& threshold_pressures_by_face);
+        ///  \param[in]  threshold_pressures_by_nnc   array of size equal to the number of nncs
+        void setThresholdPressures(const std::vector<double>& threshold_pressures_by_face ,
+                                   const std::vector<double>& threshold_pressures_by_nnc);
 
         /// Called once before each time step.
         /// \param[in] dt                     time step size
@@ -266,7 +268,7 @@ namespace Opm {
         ModelParameters                 param_;
         bool use_threshold_pressure_;
         bool wells_active_;
-        V threshold_pressures_by_interior_face_;
+        V threshold_pressures;
 
         std::vector<ReservoirResidualQuant> rq_;
         std::vector<PhasePresence> phaseCondition_;

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -163,7 +163,7 @@ namespace detail {
         , active_(detail::activePhases(fluid.phaseUsage()))
         , canph_ (detail::active2Canonical(fluid.phaseUsage()))
         , cells_ (detail::buildAllCells(Opm::AutoDiffGrid::numCells(grid)))
-        , ops_   (grid, eclState)
+        , ops_   (grid, geo.nnc())
         , wops_  (wells_)
         , has_disgas_(has_disgas)
         , has_vapoil_(has_vapoil)
@@ -913,6 +913,7 @@ namespace detail {
         // for each active phase.
         const V transi = subset(geo_.transmissibility(), ops_.internal_faces);
         const V trans_nnc = ops_.nnc_trans;
+
         V trans_all(transi.size() + trans_nnc.size());
         trans_all << transi, trans_nnc;
 
@@ -2256,7 +2257,7 @@ namespace detail {
         const ADB rhoavg = ops_.caver * rho;
         rq_[ actph ].dh = ops_.ngrad * phasePressure - geo_.gravity()[2] * (rhoavg * (ops_.ngrad * geo_.z().matrix()));
         if (use_threshold_pressure_) {
-            applyThresholdPressures(rq_[ actph ].dh);
+            //applyThresholdPressures(rq_[ actph ].dh);
         }
 
         // Compute phase fluxes with upwinding of formation value factor and mobility.

--- a/opm/autodiff/BlackoilSolventModel.hpp
+++ b/opm/autodiff/BlackoilSolventModel.hpp
@@ -123,7 +123,7 @@ namespace Opm {
         using Base::has_vapoil_;
         using Base::param_;
         using Base::use_threshold_pressure_;
-        using Base::threshold_pressures_by_interior_face_;
+        using Base::threshold_pressures;
         using Base::rq_;
         using Base::phaseCondition_;
         using Base::well_perforation_pressure_diffs_;

--- a/opm/autodiff/GeoProps.hpp
+++ b/opm/autodiff/GeoProps.hpp
@@ -25,9 +25,11 @@
 #include <opm/common/ErrorMacros.hpp>
 //#include <opm/core/pressure/tpfa/trans_tpfa.h>
 #include <opm/core/pressure/tpfa/TransTpfa.hpp>
+#include <opm/core/grid/PinchProcessor.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <Eigen/Eigen>
@@ -90,10 +92,17 @@ namespace Opm
                 ntg = eclState->getDoubleGridProperty("NTG")->getData();
             }
 
-            // get grid from parser.
-
-            // Get original grid cell volume.
+            // Get grid from parser .
             EclipseGridConstPtr eclgrid = eclState->getEclipseGrid();
+
+            // Use volume weighted arithmetic average of the NTG values for
+            // the cells effected by the current OPM cpgrid process algorithm
+            // for MINPV.
+            // TODO: do similar manipulations for porosity etc.
+            if (eclgrid->getMinpvMode() == MinpvMode::ModeEnum::OpmFIL) {
+                minPvFillProps_(grid, eclState, ntg);
+            }
+
             // Pore volume.
             // New keywords MINPVF will add some PV due to OPM cpgrid process algorithm.
             // But the default behavior is to get the comparable pore volume with ECLIPSE.
@@ -109,15 +118,8 @@ namespace Opm
                     pvol_[cellIdx] *= eclgrid->getCellVolume(cartesianCellIdx);
                 }
             }
-            // Use volume weighted arithmetic average of the NTG values for
-            // the cells effected by the current OPM cpgrid process algorithm
-            // for MINPV. Note that the change does not effect the pore volume calculations
-            // as the pore volume is currently defaulted to be comparable to ECLIPSE, but
-            // only the transmissibility calculations.
-            minPvFillProps_(grid, eclState,ntg);
 
             // Transmissibility
-
             Vector htrans(AutoDiffGrid::numCellFaces(grid));
             Grid* ug = const_cast<Grid*>(& grid);
 
@@ -130,6 +132,36 @@ namespace Opm
 
             std::vector<double> mult;
             multiplyHalfIntersections_(grid, eclState, ntg, htrans, mult);
+
+            if (eclgrid->isPinchActive()) {
+                const double minpv = eclgrid->getMinpvValue();
+                const double thickness = eclgrid->getPinchThresholdThickness();
+                auto transMode = eclgrid->getPinchOption();
+                auto multzMode = eclgrid->getMultzOption();
+                PinchProcessor<Grid> pinch(minpv, thickness, transMode, multzMode);
+
+                std::vector<double> htrans_copy(htrans.size());
+                std::copy_n(htrans.data(), htrans.size(), htrans_copy.begin());
+
+                std::vector<int> actnum;
+                eclgrid->exportACTNUM(actnum);
+                auto transMult = eclState->getTransMult();
+                std::vector<double> multz(numCells, 0.0);
+                std::vector<double> dz(numCartesianCells, 0.0);
+                const int* global_cell = Opm::UgGridHelpers::globalCell(grid);
+
+                for (int i = 0; i < numCells; ++i) {
+                    multz[i] = transMult->getMultiplier(global_cell[i], Opm::FaceDir::ZPlus);
+                }
+
+                std::shared_ptr<const NNC> nnc_deck = eclState ? eclState->getNNC()
+                    : std::shared_ptr<const Opm::NNC>();
+
+                // Note the pore volume from eclState is used and not the pvol_ calculated above
+                std::vector<double> porv = eclState->getDoubleGridProperty("PORV")->getData();
+                NNC nnc_ (*nnc_deck);
+                pinch.process(grid, htrans_copy, actnum, multz, porv, dz, nnc_);
+            }
 
             // combine the half-face transmissibilites into the final face
             // transmissibilites.
@@ -180,6 +212,7 @@ namespace Opm
         const double* gravity()          const { return gravity_;}
         Vector&       poreVolume()             { return pvol_   ;}
         Vector&       transmissibility()       { return trans_  ;}
+        const NNC& nnc() const { return nnc_;}
 
     private:
         template <class Grid>
@@ -204,6 +237,9 @@ namespace Opm
         Vector gpot_ ;
         Vector z_;
         double gravity_[3]; // Size 3 even if grid is 2-dim.
+
+        /// Non-neighboring connections
+        NNC nnc_;
 
 
 

--- a/opm/autodiff/SimulatorBase.hpp
+++ b/opm/autodiff/SimulatorBase.hpp
@@ -118,7 +118,9 @@ namespace Opm
         /// \param[in] vapoil        true for vaporized oil option
         /// \param[in] eclipse_state
         /// \param[in] output_writer
-        /// \param[in] threshold_pressures_by_face   if nonempty, threshold pressures that inhibit flow
+        /// \param[in] threshold_pressures_by_face  if nonempty, threshold pressures that inhibit flow
+        /// \param[in] threshold_pressures_by_nnc   if nonempty, threshold pressures that inhibit flow
+
         SimulatorBase(const parameter::ParameterGroup& param,
                       const Grid& grid,
                       const DerivedGeology& geo,
@@ -130,7 +132,8 @@ namespace Opm
                       const bool vapoil,
                       std::shared_ptr<EclipseState> eclipse_state,
                       OutputWriter& output_writer,
-                      const std::vector<double>& threshold_pressures_by_face);
+                      const std::vector<double>& threshold_pressures_by_face,
+                      const std::vector<double>& threshold_pressures_by_nnc);
 
         /// Run the simulation.
         /// This will run succesive timesteps until timer.done() is true. It will
@@ -191,6 +194,8 @@ namespace Opm
         RateConverterType rateConverter_;
         // Threshold pressures.
         std::vector<double> threshold_pressures_by_face_;
+        std::vector<double> threshold_pressures_by_nnc_;
+
         // Whether this a parallel simulation or not
         bool is_parallel_run_;
     };

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -36,7 +36,9 @@ namespace Opm
                                                  const bool has_vapoil,
                                                  std::shared_ptr<EclipseState> eclipse_state,
                                                  OutputWriter& output_writer,
-                                                 const std::vector<double>& threshold_pressures_by_face)
+                                                 const std::vector<double>& threshold_pressures_by_face,
+                                                 const std::vector<double>& threshold_pressures_by_nnc
+                                                 )
         : param_(param),
           model_param_(param),
           solver_param_(param),
@@ -53,6 +55,7 @@ namespace Opm
           output_writer_(output_writer),
           rateConverter_(props_, std::vector<int>(AutoDiffGrid::numCells(grid_), 0)),
           threshold_pressures_by_face_(threshold_pressures_by_face),
+          threshold_pressures_by_nnc_(threshold_pressures_by_nnc),
           is_parallel_run_( false )
     {
         // Misc init.
@@ -346,7 +349,7 @@ namespace Opm
                                                       terminal_output_));
 
         if (!threshold_pressures_by_face_.empty()) {
-            model->setThresholdPressures(threshold_pressures_by_face_);
+            model->setThresholdPressures(threshold_pressures_by_face_, threshold_pressures_by_nnc_);
         }
 
         return std::unique_ptr<Solver>(new Solver(solver_param_, std::move(model)));

--- a/opm/autodiff/SimulatorFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoil.hpp
@@ -60,9 +60,10 @@ public:
                                    const bool vapoil,
                                    std::shared_ptr<EclipseState> eclipse_state,
                                    BlackoilOutputWriter& output_writer,
-                                   const std::vector<double>& threshold_pressures_by_face)
+                                   const std::vector<double>& threshold_pressures_by_face,
+                                   const std::vector<double>& threshold_pressures_by_nnc)
     : Base(param, grid, geo, props, rock_comp_props, linsolver, gravity, disgas, vapoil,
-           eclipse_state, output_writer, threshold_pressures_by_face)
+           eclipse_state, output_writer, threshold_pressures_by_face, threshold_pressures_by_nnc)
     {}
 };
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilSolvent.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilSolvent.hpp
@@ -118,6 +118,7 @@ namespace Opm
                                               BlackoilOutputWriter& output_writer,
                                               Opm::DeckConstPtr& deck,
                                               const std::vector<double>& threshold_pressures_by_face,
+                                              const std::vector<double>& threshold_pressures_by_nnc,
                                               const bool solvent);
 
         std::unique_ptr<Solver> createSolver(const Wells* wells);

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilSolvent_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilSolvent_impl.hpp
@@ -38,6 +38,7 @@ namespace Opm
                                           BlackoilOutputWriter& output_writer,
                                           Opm::DeckConstPtr& deck,
                                           const std::vector<double>& threshold_pressures_by_face,
+                                          const std::vector<double>& threshold_pressures_by_nnc,
                                           const bool has_solvent)
     : BaseType(param,
                grid,
@@ -50,7 +51,8 @@ namespace Opm
                has_vapoil,
                eclipse_state,
                output_writer,
-               threshold_pressures_by_face)
+               threshold_pressures_by_face,
+               threshold_pressures_by_nnc)
     , has_solvent_(has_solvent)
     , deck_(deck)
     , solvent_props_(solvent_props)
@@ -83,7 +85,7 @@ namespace Opm
                                                       has_solvent_));
 
         if (!BaseType::threshold_pressures_by_face_.empty()) {
-            model->setThresholdPressures(BaseType::threshold_pressures_by_face_);
+            model->setThresholdPressures(BaseType::threshold_pressures_by_face_, BaseType::threshold_pressures_by_nnc_);
         }
 
         return std::unique_ptr<Solver>(new Solver(BaseType::solver_param_, std::move(model)));


### PR DESCRIPTION
The pinchProcessor is used to generate NNC that handles flow across cells that are pinched-out using MINPV. 

Notes: 
1) This needs to be merged after OPM/opm-core#928 and OPM/opm-parser#635 
2) Some more testing should be done before this could be merged. I hope @qilicun could help me with the testing. 
3) Note that the MINPVFIL mode is not tested.   
4) Parallelism. Currently there is no support for NNC in parallel. This will thus break flow_mpi. One possible solutions is to add the pinched-out connections to the grid instead of using the NNCs another is to always use MINPVFIL for the parallel runs. 