### PR TITLE
Support multi-segment wells

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ macro (sources_hook)
 	if(DUNE_CORNERPOINT_FOUND OR dune-cornerpoint_FOUND)
 		list (APPEND examples_SOURCES
 			${PROJECT_SOURCE_DIR}/examples/flow_mpi.cpp
+			${PROJECT_SOURCE_DIR}/examples/flow_multisegment_mpi.cpp
 			)
 	endif()
 endmacro (sources_hook)

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -78,7 +78,6 @@ list (APPEND TEST_DATA_FILES
 list (APPEND EXAMPLE_SOURCE_FILES
 	examples/find_zero.cpp
 	examples/flow.cpp
-	examples/flow_multisegment_mpi.cpp
 	examples/flow_multisegment.cpp
 	examples/flow_solvent.cpp
 	examples/sim_2p_incomp_ad.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -78,6 +78,7 @@ list (APPEND TEST_DATA_FILES
 list (APPEND EXAMPLE_SOURCE_FILES
 	examples/find_zero.cpp
 	examples/flow.cpp
+	examples/flow_multisegment_mpi.cpp
 	examples/flow_multisegment.cpp
 	examples/flow_solvent.cpp
 	examples/sim_2p_incomp_ad.cpp

--- a/examples/flow_multisegment.cpp
+++ b/examples/flow_multisegment.cpp
@@ -99,6 +99,7 @@
 #ifdef _OPENMP
 #include <omp.h>
 #endif
+
 #include <memory>
 #include <algorithm>
 #include <cstdlib>
@@ -369,7 +370,7 @@ try
     // create output writer after grid is distributed, otherwise the parallel output
     // won't work correctly since we need to create a mapping from the distributed to
     // the global view
-    Opm::BlackoilOutputWriter outputWriter(grid, param, eclipseState, pu, new_props.permeability());
+    Opm::BlackoilOutputWriter outputWriter(grid, param, eclipseState, pu, new_props.permeability() );
 
     // Solver for Newton iterations.
     std::unique_ptr<NewtonIterationBlackoilInterface> fis_solver;

--- a/examples/flow_multisegment.cpp
+++ b/examples/flow_multisegment.cpp
@@ -409,7 +409,9 @@ try
     // initialize variables
     simtimer.init(timeMap);
 
-    std::vector<double> threshold_pressures = thresholdPressures(parseMode, eclipseState, grid);
+    std::map<std::pair<int, int>, double> maxDp;
+    computeMaxDp(maxDp, deck, eclipseState, grid, state, props, gravity[2]);
+    std::vector<double> threshold_pressures = thresholdPressures(deck, eclipseState, grid, maxDp);
 
     SimulatorFullyImplicitBlackoilMultiSegment< Grid >  simulator(param,
                                                       grid,

--- a/examples/flow_multisegment.cpp
+++ b/examples/flow_multisegment.cpp
@@ -141,7 +141,7 @@ try
     // Write parameters used for later reference. (only if rank is zero)
     const bool output_cout = ( mpi_rank == 0 );
 
-    if(output_cout)
+    if (output_cout)
     {
         std::string version = moduleVersionName();
         std::cout << "**********************************************************************\n";

--- a/examples/flow_multisegment_mpi.cpp
+++ b/examples/flow_multisegment_mpi.cpp
@@ -1,0 +1,2 @@
+#define WANT_DUNE_CORNERPOINTGRID 1
+#include "flow_multisegment.cpp"

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -392,7 +392,7 @@ namespace Opm {
         extractWellPerfProperties(std::vector<ADB>& mob_perfcells,
                                   std::vector<ADB>& b_perfcells) const;
 
-        void
+        bool
         solveWellEq(const std::vector<ADB>& mob_perfcells,
                     const std::vector<ADB>& b_perfcells,
                     SolutionState& state,

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -345,6 +345,8 @@ namespace Opm {
         // return wells object
         const Wells& wells () const { assert( bool(wells_ != 0) ); return *wells_; }
 
+        int numWellVars() const;
+
         void
         makeConstantState(SolutionState& state) const;
 

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -390,7 +390,7 @@ namespace Opm {
 
         void
         extractWellPerfProperties(std::vector<ADB>& mob_perfcells,
-                                  std::vector<ADB>& b_perfcells);
+                                  std::vector<ADB>& b_perfcells) const;
 
         void
         solveWellEq(const std::vector<ADB>& mob_perfcells,
@@ -403,12 +403,12 @@ namespace Opm {
                         const std::vector<ADB>& mob_perfcells,
                         const std::vector<ADB>& b_perfcells,
                         V& aliveWells,
-                        std::vector<ADB>& cq_s);
+                        std::vector<ADB>& cq_s) const;
 
         void
         updatePerfPhaseRatesAndPressures(const std::vector<ADB>& cq_s,
                                          const SolutionState& state,
-                                         WellState& xw);
+                                         WellState& xw) const;
 
         void
         addWellFluxEq(const std::vector<ADB>& cq_s,

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1629,7 +1629,7 @@ namespace detail {
                 const Eigen::SparseLU< Sp > solver(Jn0);
                 ADB::V total_residual_v = total_residual.value();
                 const Eigen::VectorXd& dx = solver.solve(total_residual_v.matrix());
-                assert(dx.size() == (well_state.numWells() * (well_state.numPhases()+1)));
+                // assert(dx.size() == (well_state.numWells() * (well_state.numPhases()+1)));
                 asImpl().updateWellState(dx.array(), well_state);
                 asImpl().updateWellControls(well_state);
             }

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -443,6 +443,19 @@ namespace detail {
 
 
     template <class Grid, class Implementation>
+    int
+    BlackoilModelBase<Grid, Implementation>::numWellVars() const
+    {
+        // For each well, we have a bhp variable, and one flux per phase.
+        const int nw = localWellsActive() ? wells().number_of_wells : 0;
+        return (numPhases() + 1) * nw;
+    }
+
+
+
+
+
+    template <class Grid, class Implementation>
     void
     BlackoilModelBase<Grid, Implementation>::makeConstantState(SolutionState& state) const
     {
@@ -1958,7 +1971,6 @@ namespace detail {
         using namespace Opm::AutoDiffGrid;
         const int np = fluid_.numPhases();
         const int nc = numCells(grid_);
-        const int nw = localWellsActive() ? wells().number_of_wells : 0;
         const V null;
         assert(null.size() == 0);
         const V zero = V::Zero(nc);
@@ -1973,7 +1985,7 @@ namespace detail {
         varstart += dxvar.size();
 
         // Extract well parts np phase rates + bhp
-        const V dwells = subset(dx, Span((np+1)*nw, 1, varstart));
+        const V dwells = subset(dx, Span(asImpl().numWellVars(), 1, varstart));
         varstart += dwells.size();
 
         assert(varstart == dx.size());

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1079,7 +1079,7 @@ namespace detail {
     template <class Grid, class Implementation>
     void
     BlackoilModelBase<Grid, Implementation>::extractWellPerfProperties(std::vector<ADB>& mob_perfcells,
-                                                                       std::vector<ADB>& b_perfcells)
+                                                                       std::vector<ADB>& b_perfcells) const
     {
         // If we have wells, extract the mobilities and b-factors for
         // the well-perforated cells.
@@ -1110,7 +1110,7 @@ namespace detail {
                                                              const std::vector<ADB>& mob_perfcells,
                                                              const std::vector<ADB>& b_perfcells,
                                                              V& aliveWells,
-                                                             std::vector<ADB>& cq_s)
+                                                             std::vector<ADB>& cq_s) const
     {
         if( ! localWellsActive() ) return ;
 
@@ -1258,7 +1258,7 @@ namespace detail {
     template <class Grid, class Implementation>
     void BlackoilModelBase<Grid, Implementation>::updatePerfPhaseRatesAndPressures(const std::vector<ADB>& cq_s,
                                                                                    const SolutionState& state,
-                                                                                   WellState& xw)
+                                                                                   WellState& xw) const
     {
         // Update the perforation phase rates (used to calculate the pressure drop in the wellbore).
         const int np = wells().number_of_phases;

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1584,6 +1584,7 @@ namespace detail {
         std::vector<ADB> cq_s(np, ADB::null());
         std::vector<int> indices = variableWellStateIndices();
         SolutionState state0 = state;
+        WellState well_state0 = well_state;
         asImpl().makeConstantState(state0);
 
         std::vector<ADB> mob_perfcells_const(np, ADB::null());
@@ -1659,6 +1660,10 @@ namespace detail {
                 state.qs = ADB::function(std::move(new_qs), std::move(old_derivs));
             }
             asImpl().computeWellConnectionPressures(state, well_state);
+        }
+
+        if (!converged) {
+            well_state = well_state0;
         }
 
         return converged;

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -978,6 +978,7 @@ namespace detail {
         trans_all << transi, trans_nnc;
 
         const std::vector<ADB> kr = asImpl().computeRelPerm(state);
+#pragma omp parallel for schedule(static)
         for (int phaseIdx = 0; phaseIdx < fluid_.numPhases(); ++phaseIdx) {
             asImpl().computeMassFlux(phaseIdx, trans_all, kr[canph_[phaseIdx]], state.canonical_phase_pressures[canph_[phaseIdx]], state);
 

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1574,7 +1574,7 @@ namespace detail {
 
 
     template <class Grid, class Implementation>
-    void BlackoilModelBase<Grid, Implementation>::solveWellEq(const std::vector<ADB>& mob_perfcells,
+    bool BlackoilModelBase<Grid, Implementation>::solveWellEq(const std::vector<ADB>& mob_perfcells,
                                                               const std::vector<ADB>& b_perfcells,
                                                               SolutionState& state,
                                                               WellState& well_state)
@@ -1629,7 +1629,7 @@ namespace detail {
                 const Eigen::SparseLU< Sp > solver(Jn0);
                 ADB::V total_residual_v = total_residual.value();
                 const Eigen::VectorXd& dx = solver.solve(total_residual_v.matrix());
-                // assert(dx.size() == (well_state.numWells() * (well_state.numPhases()+1)));
+                assert(dx.size() == total_residual_v.size());
                 asImpl().updateWellState(dx.array(), well_state);
                 asImpl().updateWellControls(well_state);
             }
@@ -1661,6 +1661,7 @@ namespace detail {
             asImpl().computeWellConnectionPressures(state, well_state);
         }
 
+        return converged;
     }
 
 

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -2700,7 +2700,7 @@ namespace detail {
                 for (int idx = 0; idx < np; ++idx) {
                     std::cout << "  W-FLUX(" << materialName(idx).substr(0, 1) << ")";
                 }
-                std::cout << "  WELL-CONT ";
+                // std::cout << "  WELL-CONT ";
                 std::cout << '\n';
             }
             const std::streamsize oprec = std::cout.precision(3);
@@ -2715,7 +2715,7 @@ namespace detail {
             for (int idx = 0; idx < np; ++idx) {
                 std::cout << std::setw(11) << well_flux_residual[idx];
             }
-            std::cout << std::setw(11) << residualWell;
+            // std::cout << std::setw(11) << residualWell;
             std::cout << std::endl;
             std::cout.precision(oprec);
             std::cout.flags(oflags);

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -876,9 +876,9 @@ namespace detail {
 #if 0
         std::cout << "well_perforation_densities_ " << std::endl;
         std::cout << well_perforation_densities_ << std::endl;
-
         std::cout << "well_perforation_pressure_diffs_ " << std::endl;
         std::cout << well_perforation_pressure_diffs_ << std::endl;
+        std::cin.ignore();
 #endif
     }
 

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -793,15 +793,6 @@ namespace detail {
             }
         }
 
-#if 0
-        std::cout << " state.bhp " << std::endl;
-        std::cout << state.bhp.value() << std::endl;
-        std::cout << " perf_press " << std::endl;
-        std::cout << perf_press << std::endl;
-        std::cout << " avg_press " << std::endl;
-        std::cout << avg_press << std::endl;
-#endif
-
         const std::vector<int>& well_cells = wops_.well_cells;
 
         // Use cell values for the temperature as the wells don't knows its temperature yet.
@@ -873,13 +864,6 @@ namespace detail {
         // 4. Store the results
         well_perforation_densities_ = Eigen::Map<const V>(cd.data(), nperf);
         well_perforation_pressure_diffs_ = Eigen::Map<const V>(cdp.data(), nperf);
-#if 0
-        std::cout << "well_perforation_densities_ " << std::endl;
-        std::cout << well_perforation_densities_ << std::endl;
-        std::cout << "well_perforation_pressure_diffs_ " << std::endl;
-        std::cout << well_perforation_pressure_diffs_ << std::endl;
-        std::cin.ignore();
-#endif
     }
 
 
@@ -2219,15 +2203,6 @@ namespace detail {
             const V dbhp_limited = sign(dbhp) * dbhp.abs().min(bhp_old.abs()*dpmaxrel);
             const V bhp = bhp_old - dbhp_limited;
             std::copy(&bhp[0], &bhp[0] + bhp.size(), well_state.bhp().begin());
-#if 0
-            std::cout << " output wr in updateWellState " << std::endl;
-            std::cout << wr << std::endl;
-            std::cin.ignore();
-
-            std::cout << " output bhp is updateWellState " << std::endl;
-            std::cout << bhp << std::endl;
-            std::cin.ignore();
-#endif
 
             //Get gravity for THP hydrostatic correction
             const double gravity = detail::getGravity(geo_.gravity(), UgGridHelpers::dimensions(grid_));

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -2707,6 +2707,7 @@ namespace detail {
                 for (int idx = 0; idx < np; ++idx) {
                     std::cout << "  W-FLUX(" << materialName(idx).substr(0, 1) << ")";
                 }
+                std::cout << "  WELL-CONT ";
                 std::cout << '\n';
             }
             const std::streamsize oprec = std::cout.precision(3);
@@ -2721,6 +2722,7 @@ namespace detail {
             for (int idx = 0; idx < np; ++idx) {
                 std::cout << std::setw(11) << well_flux_residual[idx];
             }
+            std::cout << std::setw(11) << residualWell;
             std::cout << std::endl;
             std::cout.precision(oprec);
             std::cout.flags(oflags);

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -205,6 +205,9 @@ namespace Opm {
         // the current one at the current iteration.
         std::vector<ADB> segment_comp_surf_volume_current_;
 
+        // the mass flow rate in the segments
+        ADB segment_mass_flow_rates_;
+
         const std::vector<WellMultiSegmentConstPtr> wells_multisegment_;
 
         std::vector<int> top_well_segments_;

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -219,6 +219,20 @@ namespace Opm {
         // to handle the volume effects of the segment
         V segvdt_;
 
+        // Well operations and data needed.
+        struct MultiSegmentWellOps {
+            explicit MultiSegmentWellOps(const std::vector<WellMultiSegmentConstPtr>& wells_ms);
+            // Eigen::SparseMatrix<double> w2p;              // well -> perf (scatter)
+            // Eigen::SparseMatrix<double> p2w;              // perf -> well (gather)
+            Eigen::SparseMatrix<double> s2p;              // segment -> perf (scatter)
+            Eigen::SparseMatrix<double> p2s;              // perf -> segment (gather)
+            std::vector<int> well_cells;                  // the set of perforated cells
+            V conn_trans_factors;                         // connection transmissibility factors
+        };
+
+        MultiSegmentWellOps wops_ms_;
+
+
         // return wells object
         // TODO: remove this wells structure
         using Base::wells;

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -222,8 +222,10 @@ namespace Opm {
         // Well operations and data needed.
         struct MultiSegmentWellOps {
             explicit MultiSegmentWellOps(const std::vector<WellMultiSegmentConstPtr>& wells_ms);
-            // Eigen::SparseMatrix<double> w2p;              // well -> perf (scatter)
-            // Eigen::SparseMatrix<double> p2w;              // perf -> well (gather)
+            Eigen::SparseMatrix<double> w2p;              // well -> perf (scatter)
+            Eigen::SparseMatrix<double> p2w;              // perf -> well (gather)
+            Eigen::SparseMatrix<double> w2s;              // well -> segment (scatter)
+            Eigen::SparseMatrix<double> s2w;              // segment -> well (gather)
             Eigen::SparseMatrix<double> s2p;              // segment -> perf (scatter)
             Eigen::SparseMatrix<double> p2s;              // perf -> segment (gather)
             Eigen::SparseMatrix<double> s2s_inlets;       // segment -> its inlet segments

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -230,6 +230,7 @@ namespace Opm {
             Eigen::SparseMatrix<double> p2s;              // perf -> segment (gather)
             Eigen::SparseMatrix<double> s2s_inlets;       // segment -> its inlet segments
             Eigen::SparseMatrix<double> s2s_outlet;       // segment -> its outlet segment
+            Eigen::SparseMatrix<double> topseg2w;         // top segment -> well
             std::vector<int> well_cells;                  // the set of perforated cells
             V conn_trans_factors;                         // connection transmissibility factors
         };

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -262,11 +262,7 @@ namespace Opm {
                                       SolutionState& state) const;
 
         void
-        computeSegmentDensities(const SolutionState& state,
-                                const WellState& xw); //,
-                                // const std::vector<ADB>& b_seg,
-                                // const ADB& rsmax_seg,
-                                // const ADB& rvmax_seg);
+        computeSegmentDensities(const SolutionState& state);
 
 
     };

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -188,7 +188,7 @@ namespace Opm {
         V well_perforation_cell_densities_;
         ADB well_perforation_cell_densities_adb_; // TODO: NOT NEEDED
 
-        V well_perforatoin_cell_pressure_diffs_;
+        V well_perforation_cell_pressure_diffs_;
 
         // the density of the fluid mixture in the segments
         // which is calculated in an implicit way

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -106,14 +106,6 @@ namespace Opm {
                       WellState& well_state,
                       const bool initial_assembly);
 
-
-        /// Apply an update to the primary variables, chopped if appropriate.
-        /// \param[in]      dx                updates to apply to primary variables
-        /// \param[in, out] reservoir_state   reservoir state variables
-        /// \param[in, out] well_state        well state variables
-        void updateState(const V& dx,
-                         ReservoirState& reservoir_state,
-                         WellState& well_state);
         using Base::numPhases;
         using Base::numMaterials;
         using Base::materialName;
@@ -299,6 +291,8 @@ namespace Opm {
         addWellControlEq(const SolutionState& state,
                          const WellState& xw,
                          const V& aliveWells);
+
+        int numWellVars() const;
 
         void
         makeConstantState(SolutionState& state) const;

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -226,6 +226,8 @@ namespace Opm {
             // Eigen::SparseMatrix<double> p2w;              // perf -> well (gather)
             Eigen::SparseMatrix<double> s2p;              // segment -> perf (scatter)
             Eigen::SparseMatrix<double> p2s;              // perf -> segment (gather)
+            Eigen::SparseMatrix<double> s2s_inlets;       // segment -> its inlet segments
+            Eigen::SparseMatrix<double> s2s_outlet;       // segment -> its outlet segment
             std::vector<int> well_cells;                  // the set of perforated cells
             V conn_trans_factors;                         // connection transmissibility factors
         };

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -272,7 +272,7 @@ namespace Opm {
         void computeWellConnectionPressures(const SolutionState& state,
                                             const WellState& xw);
 
-        void
+        bool
         solveWellEq(const std::vector<ADB>& mob_perfcells,
                     const std::vector<ADB>& b_perfcells,
                     SolutionState& state,

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -1,8 +1,5 @@
 /*
   Copyright 2013, 2015 SINTEF ICT, Applied Mathematics.
-  Copyright 2014, 2015 Statoil ASA.
-  Copyright 2014, 2015 Dr. Markus Blatt - HPC-Simulation-Software & Services
-  Copyright 2015 NTNU
 
   This file is part of the Open Porous Media project (OPM).
 

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -64,18 +64,19 @@ namespace Opm {
         /// Construct the model. It will retain references to the
         /// arguments of this functions, and they are expected to
         /// remain in scope for the lifetime of the solver.
-        /// \param[in] param            parameters
-        /// \param[in] grid             grid data structure
-        /// \param[in] fluid            fluid properties
-        /// \param[in] geo              rock properties
-        /// \param[in] rock_comp_props  if non-null, rock compressibility properties
-        /// \param[in] wells            well structure
-        /// \param[in] vfp_properties   Vertical flow performance tables
-        /// \param[in] linsolver        linear solver
-        /// \param[in] eclState         eclipse state
-        /// \param[in] has_disgas       turn on dissolved gas
-        /// \param[in] has_vapoil       turn on vaporized oil feature
-        /// \param[in] terminal_output  request output to cout/cerr
+        /// \param[in] param              parameters
+        /// \param[in] grid               grid data structure
+        /// \param[in] fluid              fluid properties
+        /// \param[in] geo                rock properties
+        /// \param[in] rock_comp_props    if non-null, rock compressibility properties
+        /// \param[in] wells              well structure
+        /// \param[in] vfp_properties     Vertical flow performance tables
+        /// \param[in] linsolver          linear solver
+        /// \param[in] eclState           eclipse state
+        /// \param[in] has_disgas         turn on dissolved gas
+        /// \param[in] has_vapoil         turn on vaporized oil feature
+        /// \param[in] terminal_output    request output to cout/cerr
+        /// \param[in] wells_multisegment a vector of multisegment wells
         BlackoilMultiSegmentModel(const typename Base::ModelParameters&  param,
                           const Grid&                     grid ,
                           const BlackoilPropsAdInterface& fluid,
@@ -111,16 +112,10 @@ namespace Opm {
         using Base::materialName;
 
     protected:
-     /*
-        // ---------  Types and enums  ---------
-        // using Base::DataBlock;
-        // using Base::ReservoirResidualQuant;
-     */
         // ---------  Data members  ---------
 
-        // For the non-segmented well, it should be the density with AVG or SEG way.
-        // while usually SEG way
-        using Base::wops_; // Only for well_cells, the w2p and p2w members may have wrong perf order.
+        // For non-segmented wells, it should be the density calculated with AVG or SEG way.
+        // while usually SEG way by default.
         using Base::well_perforation_densities_; //Density of each well perforation
         using Base::pvdt_;
         using Base::geo_;
@@ -141,44 +136,27 @@ namespace Opm {
         using Base::param_;
         using Base::linsolver_;
 
-
-        // Diff to the pressure of the related segment.
-        // When the well is a usual well, the bhp will be the pressure of the top segment
-        // For mutlti-segmented wells, only AVG is allowed.
-        // For non-segmented wells, typically SEG is used. AVG way might not have been
-        // implemented yet.
-
         // Diff to bhp for each well perforation. only for usual wells.
         // For segmented wells, they are zeros.
-        using Base::well_perforation_pressure_diffs_; // Diff to bhp for each well perforation.
-
-        // ADB version of the densities, when using AVG way, the calculation of the density and hydrostatic head
-        // is implicit
-        // ADB well_perforation_densities_adb_; // TODO: NOT NEEDED for explicit SEG way
-
-        // ADB version. Eventually, only ADB version will be kept.
-        // ADB well_perforation_pressure_diffs_adb_; // TODO: NOT NEEDED for explicit SEG way
+        using Base::well_perforation_pressure_diffs_;
 
         // Pressure correction due to the different depth of the perforation
         // and the cell center of the grid block
         // For the non-segmented wells, since the perforation are forced to be
         // at the center of the grid cell, it should be ZERO.
-        // It should only apply to the mutli-segmented wells.
+        // It only applies to the mutli-segmented wells.
         V well_perforation_cell_pressure_diffs_;
 
         // Pressure correction due to the depth differennce between segment depth and perforation depth.
-        // TODO: It will only be able to be merge as a part of the perforation_pressure_diffs_
         ADB well_segment_perforation_pressure_diffs_;
 
         // The depth difference between segment nodes and perforations
-        // TODO: it should be a member in a global wells class later
         V well_segment_perforation_depth_diffs_;
 
         // the average of the fluid densities in the grid block
         // which is used to calculate the hydrostatic head correction due to the depth difference of the perforation
         // and the cell center of the grid block
         V well_perforation_cell_densities_;
-
 
         // the density of the fluid mixture in the segments
         // which is calculated in an implicit way
@@ -190,9 +168,10 @@ namespace Opm {
         ADB well_segment_pressures_delta_;
 
         // the surface volume of components in the segments
-        // initial one at the beginning of the time step
+        // the initial value at the beginning of the time step
         std::vector<V>   segment_comp_surf_volume_initial_;
-        // the current one at the current iteration.
+
+        // the value within the current iteration.
         std::vector<ADB> segment_comp_surf_volume_current_;
 
         // the mass flow rate in the segments
@@ -200,7 +179,7 @@ namespace Opm {
 
         // the viscosity of the fluid mixture in the segments
         // TODO: it is only used to calculate the Reynolds number as we know
-        //       maybe it is not better just to store the Reynolds number here?
+        //       maybe it is not better just to store the Reynolds number?
         ADB segment_viscosities_;
 
         const std::vector<WellMultiSegmentConstPtr> wells_multisegment_;

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -194,6 +194,11 @@ namespace Opm {
         // which is calculated in an implicit way
         ADB well_segment_densities_;
 
+        // the hydrostatic pressure drop between segment nodes
+        // calculated with the above density of fluid mixtures
+        // for the top segment, they should always be zero for the moment.
+        ADB well_segment_pressures_delta_;
+
         const std::vector<WellMultiSegmentConstPtr> wells_multisegment_;
 
         std::vector<int> top_well_segments_;
@@ -263,6 +268,9 @@ namespace Opm {
 
         void
         computeSegmentDensities(const SolutionState& state);
+
+        void
+        computeSegmentPressuresDelta(const SolutionState& state);
 
 
     };

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -208,6 +208,11 @@ namespace Opm {
         // the mass flow rate in the segments
         ADB segment_mass_flow_rates_;
 
+        // the viscosity of the fluid mixture in the segments
+        // TODO: it is only used to calculate the Reynolds number as we know
+        //       maybe it is better just to store the Reynolds number here?
+        ADB segment_viscosities_;
+
         const std::vector<WellMultiSegmentConstPtr> wells_multisegment_;
 
         std::vector<int> top_well_segments_;

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -165,30 +165,27 @@ namespace Opm {
 
         // ADB version of the densities, when using AVG way, the calculation of the density and hydrostatic head
         // is implicit
-        ADB well_perforation_densities_adb_; // TODO: NOT NEEDED
+        // ADB well_perforation_densities_adb_; // TODO: NOT NEEDED for explicit SEG way
 
         // ADB version. Eventually, only ADB version will be kept.
-        ADB well_perforation_pressure_diffs_adb_; // TODO: NOT NEEDED
+        // ADB well_perforation_pressure_diffs_adb_; // TODO: NOT NEEDED for explicit SEG way
 
         // Pressure correction due to the different depth of the perforation
         // and the cell center of the grid block
         // For the non-segmented wells, since the perforation are forced to be
         // at the center of the grid cell, it should be ZERO.
         // It should only apply to the mutli-segmented wells.
-        V well_perforation_pressure_cell_diffs_;
-        ADB well_perforation_pressure_cell_diffs_adb_; // TODO: NOT NEEDED
+        V well_perforation_cell_pressure_diffs_;
 
         // Pressure correction due to the depth differennce between segment depth and perforation depth.
-        // TODO: It should be able to be merge as a part of the perforation_pressure_diffs_.
+        // TODO: It will only be able to be merge as a part of the perforation_pressure_diffs_
         ADB well_perforations_segment_pressure_diffs_;
 
         // the average of the fluid densities in the grid block
         // which is used to calculate the hydrostatic head correction due to the depth difference of the perforation
         // and the cell center of the grid block
         V well_perforation_cell_densities_;
-        ADB well_perforation_cell_densities_adb_; // TODO: NOT NEEDED
 
-        V well_perforation_cell_pressure_diffs_;
 
         // the density of the fluid mixture in the segments
         // which is calculated in an implicit way

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -203,6 +203,10 @@ namespace Opm {
 
         std::vector<int> top_well_segments_;
 
+        // segment volume by dt (time step)
+        // to handle the volume effects of the segment
+        V segvdt_;
+
         // return wells object
         // TODO: remove this wells structure
         using Base::wells;

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -252,12 +252,12 @@ namespace Opm {
                         const std::vector<ADB>& mob_perfcells,
                         const std::vector<ADB>& b_perfcells,
                         V& aliveWells,
-                        std::vector<ADB>& cq_s);
+                        std::vector<ADB>& cq_s) const;
 
         void
         updatePerfPhaseRatesAndPressures(const std::vector<ADB>& cq_s,
                                          const SolutionState& state,
-                                         WellState& xw);
+                                         WellState& xw) const;
 
         void
         addWellFluxEq(const std::vector<ADB>& cq_s,

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -273,6 +273,12 @@ namespace Opm {
                                             const WellState& xw);
 
         void
+        solveWellEq(const std::vector<ADB>& mob_perfcells,
+                    const std::vector<ADB>& b_perfcells,
+                    SolutionState& state,
+                    WellState& well_state);
+
+        void
         computeWellFlux(const SolutionState& state,
                         const std::vector<ADB>& mob_perfcells,
                         const std::vector<ADB>& b_perfcells,

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -199,6 +199,12 @@ namespace Opm {
         // for the top segment, they should always be zero for the moment.
         ADB well_segment_pressures_delta_;
 
+        // the surface volume of components in the segments
+        // initial one at the beginning of the time step
+        std::vector<V>   segment_comp_surf_volume_initial_;
+        // the current one at the current iteration.
+        std::vector<ADB> segment_comp_surf_volume_current_;
+
         const std::vector<WellMultiSegmentConstPtr> wells_multisegment_;
 
         std::vector<int> top_well_segments_;
@@ -270,8 +276,10 @@ namespace Opm {
                                       std::vector<ADB>& vars,
                                       SolutionState& state) const;
 
+        // Calculate the density of the mixture in the segments
+        // And the surface volume of the components in the segments by dt
         void
-        computeSegmentDensities(const SolutionState& state);
+        computeSegmentDensitiesAndCompVolumeDt(const SolutionState& state);
 
         void
         computeSegmentPressuresDelta(const SolutionState& state);

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -179,7 +179,11 @@ namespace Opm {
 
         // Pressure correction due to the depth differennce between segment depth and perforation depth.
         // TODO: It will only be able to be merge as a part of the perforation_pressure_diffs_
-        ADB well_perforations_segment_pressure_diffs_;
+        ADB well_segment_perforation_pressure_diffs_;
+
+        // The depth difference between segment nodes and perforations
+        // TODO: it should be a member in a global wells class later
+        V well_segment_perforation_depth_diffs_;
 
         // the average of the fluid densities in the grid block
         // which is used to calculate the hydrostatic head correction due to the depth difference of the perforation
@@ -207,7 +211,7 @@ namespace Opm {
 
         // the viscosity of the fluid mixture in the segments
         // TODO: it is only used to calculate the Reynolds number as we know
-        //       maybe it is better just to store the Reynolds number here?
+        //       maybe it is not better just to store the Reynolds number here?
         ADB segment_viscosities_;
 
         const std::vector<WellMultiSegmentConstPtr> wells_multisegment_;

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -279,7 +279,7 @@ namespace Opm {
         // Calculate the density of the mixture in the segments
         // And the surface volume of the components in the segments by dt
         void
-        computeSegmentDensitiesAndCompVolumeDt(const SolutionState& state);
+        computeSegmentFluidProperties(const SolutionState& state);
 
         void
         computeSegmentPressuresDelta(const SolutionState& state);

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -231,6 +231,7 @@ namespace Opm {
             Eigen::SparseMatrix<double> s2s_inlets;       // segment -> its inlet segments
             Eigen::SparseMatrix<double> s2s_outlet;       // segment -> its outlet segment
             Eigen::SparseMatrix<double> topseg2w;         // top segment -> well
+            AutoDiffMatrix eliminate_topseg;              // change the top segment related to be zero
             std::vector<int> well_cells;                  // the set of perforated cells
             V conn_trans_factors;                         // connection transmissibility factors
         };

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -129,16 +129,16 @@ namespace Opm {
         // Create well_cells and conn_trans_factors.
         well_cells.reserve(total_nperf);
         conn_trans_factors.resize(total_nperf);
-        int perf_start = 0;
+        int well_perf_start = 0;
         for (int w = 0; w < nw; ++w) {
-            WellMultiSegmentConstPtr well = wellsMultiSegment()[w];
+            WellMultiSegmentConstPtr well = wells_ms[w];
             well_cells.insert(well_cells.end(), well->wellCells().begin(), well->wellCells().end());
             const std::vector<double>& perf_trans = well->wellIndex();
-            std::copy(perf_trans.begin(), perf_trans.end(), conn_trans_factors.data() + perf_start);
-            perf_start += well->numberOfPerforations();
+            std::copy(perf_trans.begin(), perf_trans.end(), conn_trans_factors.data() + well_perf_start);
+            well_perf_start += well->numberOfPerforations();
         }
-        assert(perf_start == total_nperf);
-        assert(int(well_cells.size() == total_nperf));
+        assert(well_perf_start == total_nperf);
+        assert(int(well_cells.size()) == total_nperf);
 
         // Create the segment <-> perforation operator matrices,
         // using the setFromTriplets() method.
@@ -151,9 +151,9 @@ namespace Opm {
         int seg_start = 0;
         int perf_start = 0;
         for (int w = 0; w < nw; ++w) {
-            const int ns = well_ms[w]->numberOfSegments();
+            const int ns = wells_ms[w]->numberOfSegments();
             for (int seg = 0; seg < ns; ++seg) {
-                const auto& segPerf = well_ms[w]->segmentPerforations()[seg];
+                const auto& segPerf = wells_ms[w]->segmentPerforations()[seg];
                 const int np = segPerf.size();
                 for (int perf = 0; perf < np; ++perf) {
                     const int perf_ind = perf_start + segPerf[perf];

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -456,7 +456,7 @@ namespace Opm {
         // TODO
         well_perforations_segment_pressure_diffs_ = ADB::constant(V::Zero(xw.numPerforations()));
         well_perforation_pressure_cell_diffs_ = V::Zero(xw.numPerforations());
-        well_perforatoin_cell_pressure_diffs_ = V::Zero(xw.numPerforations());
+        well_perforation_cell_pressure_diffs_ = V::Zero(xw.numPerforations());
 #if 0
         std::cout << " avg_press " << std::endl;
         std::cout << avg_press << std::endl;
@@ -638,7 +638,7 @@ namespace Opm {
             {
                 // get H_nc
                 const ADB& h_nc = subset(well_perforations_segment_pressure_diffs_, Span(nperf, 1, start_perforation));
-                const V& h_cj = subset(well_perforatoin_cell_pressure_diffs_, Span(nperf, 1, start_perforation));
+                const V& h_cj = subset(well_perforation_cell_pressure_diffs_, Span(nperf, 1, start_perforation));
 
                 // V seg_pressures_perf = V::Zero(nperf);
                 // for (int i = 0; i < nseg; ++i) {

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -1197,8 +1197,8 @@ namespace Opm {
             WellMultiSegmentConstPtr well = wellsMultiSegment()[w];
             const int nseg = well->numberOfSegments();
             ADB segp = subset(state.segp, Span(nseg, 1, start_segment));
-            ADB well_residual = segp - well->wellOps().s2s_outlet * segp;
-            // - subset(well_segment_pressures_delta_, Span(nseg, 1, start_segment));
+            ADB well_residual = segp - well->wellOps().s2s_outlet * segp
+                                 + subset(well_segment_pressures_delta_, Span(nseg, 1, start_segment));
             ADB others_well_residual = subset(well_residual, Span(nseg - 1, 1, 1));
             others_residual = others_residual +  superset(others_well_residual, Span(nseg - 1, 1, start_segment + 1), nseg_total);
             start_segment += nseg;

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -516,6 +516,9 @@ namespace Opm {
             return;
         }
 
+        asImpl().computeSegmentDensities(state);
+        asImpl().computeSegmentPressuresDelta(state);
+
         std::vector<ADB> mob_perfcells;
         std::vector<ADB> b_perfcells;
         asImpl().extractWellPerfProperties(mob_perfcells, b_perfcells);
@@ -530,8 +533,6 @@ namespace Opm {
         V aliveWells;
         std::vector<ADB> cq_s;
         asImpl().computeWellFlux(state, mob_perfcells, b_perfcells, aliveWells, cq_s);
-        asImpl().computeSegmentDensities(state, well_state);
-        asImpl().computeSegmentPressuresDelta(state);
         asImpl().updatePerfPhaseRatesAndPressures(cq_s, state, well_state);
         asImpl().addWellFluxEq(cq_s, state);
         asImpl().addWellContributionToMassBalanceEq(cq_s, state, well_state);

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -566,10 +566,10 @@ namespace Opm {
     template <class Grid>
     void
     BlackoilMultiSegmentModel<Grid>::computeWellFlux(const SolutionState& state,
-                                                             const std::vector<ADB>& ,
-                                                             const std::vector<ADB>& ,
-                                                             V& aliveWells,
-                                                             std::vector<ADB>& cq_s)
+                                                     const std::vector<ADB>& /* mob_perfcells */,
+                                                     const std::vector<ADB>& /* b_perfcells */,
+                                                     V& aliveWells,
+                                                     std::vector<ADB>& cq_s) const
     {
         // if( ! wellsActive() ) return ;
         if (wellsMultiSegment().size() == 0) return;
@@ -808,7 +808,7 @@ namespace Opm {
     template <class Grid>
     void BlackoilMultiSegmentModel<Grid>::updatePerfPhaseRatesAndPressures(const std::vector<ADB>& cq_s,
                                                                            const SolutionState& state,
-                                                                           WellState& xw)
+                                                                           WellState& xw) const
     {
         // Update the perforation phase rates (used to calculate the pressure drop in the wellbore).
         // TODO: now it is so necesary to have a gobal wellsMultiSegment class to store some global information.

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -721,8 +721,8 @@ namespace Opm {
     template <class Grid>
     void
     BlackoilMultiSegmentModel<Grid>::computeWellFlux(const SolutionState& state,
-                                                     const std::vector<ADB>& /* mob_perfcells */,
-                                                     const std::vector<ADB>& /* b_perfcells */,
+                                                     const std::vector<ADB>& mob_perfcells,
+                                                     const std::vector<ADB>& b_perfcells,
                                                      V& aliveWells,
                                                      std::vector<ADB>& cq_s) const
     {
@@ -759,14 +759,6 @@ namespace Opm {
             const V& Tw = wops_ms_.conn_trans_factors;
             // const std::vector<int>& well_cells = well->wellCells();
             const std::vector<int>& well_cells = wops_ms_.well_cells;
-
-            // extract mob_perfcells and b_perfcells.
-            std::vector<ADB> mob_perfcells(np, ADB::null());
-            std::vector<ADB> b_perfcells(np, ADB::null());
-            for (int phase = 0; phase < np; ++phase) {
-                mob_perfcells[phase] = subset(rq_[phase].mob, well_cells);
-                b_perfcells[phase] = subset(rq_[phase].b, well_cells);
-            }
 
             // determining in-flow (towards well-bore) or out-flow (towards reservoir)
             // for mutli-segmented wells and non-segmented wells, the calculation of the drawdown are different.

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -1,9 +1,5 @@
 /*
   Copyright 2013, 2015 SINTEF ICT, Applied Mathematics.
-  Copyright 2014, 2015 Dr. Blatt - HPC-Simulation-Software & Services
-  Copyright 2014, 2015 Statoil ASA.
-  Copyright 2015 NTNU
-  Copyright 2015 IRIS AS
 
   This file is part of the Open Porous Media project (OPM).
 

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -509,7 +509,7 @@ namespace Opm {
             // Compute initial accumulation contributions
             // and well connection pressures.
             asImpl().computeAccum(state0, 0);
-            asImpl().computeSegmentDensitiesAndCompVolumeDt(state0);
+            asImpl().computeSegmentFluidProperties(state0);
             const int np = numPhases();
             assert(np == int(segment_comp_surf_volume_initial_.size()));
             for (int phase = 0; phase < np; ++phase) {
@@ -536,7 +536,7 @@ namespace Opm {
             return;
         }
 
-        asImpl().computeSegmentDensitiesAndCompVolumeDt(state);
+        asImpl().computeSegmentFluidProperties(state);
         asImpl().computeSegmentPressuresDelta(state);
 
         std::vector<ADB> mob_perfcells;
@@ -1667,7 +1667,7 @@ namespace Opm {
 
     template <class Grid>
     void
-    BlackoilMultiSegmentModel<Grid>::computeSegmentDensitiesAndCompVolumeDt(const SolutionState& state)
+    BlackoilMultiSegmentModel<Grid>::computeSegmentFluidProperties(const SolutionState& state)
     {
         const int nw = wellsMultiSegment().size();
         const int nseg_total = state.segp.size();

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -528,8 +528,7 @@ namespace Opm {
         V aliveWells;
         std::vector<ADB> cq_s;
         asImpl().computeWellFlux(state, mob_perfcells, b_perfcells, aliveWells, cq_s);
-        // asImpl().computeSegmentDensities(state, cq_s, b_perfcells, well_state);
-        asImpl().computeSegmentDensities(state, well_state);
+        asImpl().computeSegmentDensities(state);
         asImpl().updatePerfPhaseRatesAndPressures(cq_s, state, well_state);
         asImpl().addWellFluxEq(cq_s, state);
         asImpl().addWellContributionToMassBalanceEq(cq_s, state, well_state);
@@ -1637,14 +1636,10 @@ namespace Opm {
 
     template <class Grid>
     void
-    BlackoilMultiSegmentModel<Grid>::computeSegmentDensities(const SolutionState& state,
-                                                             const WellState& xw) //,
-                                                             // const std::vector<ADB>& /*b_seg*/,
-                                                             // const ADB& /*rsmax_seg*/,
-                                                             // const ADB& /*rvmax_seg*/)
+    BlackoilMultiSegmentModel<Grid>::computeSegmentDensities(const SolutionState& state)
     {
-        const int nw = xw.numWells();
-        const int nseg_total = xw.numSegments();
+        const int nw = wellsMultiSegment().size();
+        const int nseg_total = state.segp.size();
         const int np = numPhases();
 
         // although we will calculate segment density for non-segmented wells at the same time,
@@ -1665,7 +1660,7 @@ namespace Opm {
             const std::vector<int>& segment_cells_well = wellsMultiSegment()[w]->segmentCells();
             segment_cells.insert(segment_cells.end(), segment_cells_well.begin(), segment_cells_well.end());
         }
-        assert(segment_cells.size() == nseg_total);
+        assert(int(segment_cells.size()) == nseg_total);
 
         const ADB segment_temp = subset(state.temperature,segment_cells);
 
@@ -1717,7 +1712,7 @@ namespace Opm {
         std::cout << rvmax_seg.value() << std::endl;
 
         std::cout << " b_seg " << std::endl;
-        for (int p = 0; p < b_seg.size(); ++p){
+        for (size_t p = 0; p < b_seg.size(); ++p){
             std::cout << b_seg[p].value() << std::endl;
         }
 #endif

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -370,8 +370,6 @@ namespace Opm {
         // Compute b, rsmax, rvmax values for perforations.
         // Evaluate the properties using average well block pressures
         // and cell values for rs, rv, phase condition and temperature.
-        std::cout << " avg_press " << std::endl;
-        std::cout << avg_press << std::endl;
         const ADB avg_press_ad = ADB::constant(avg_press);
         std::vector<PhasePresence> perf_cond(nperf);
         const std::vector<PhasePresence>& pc = phaseCondition();
@@ -445,9 +443,12 @@ namespace Opm {
         well_perforations_segment_pressure_diffs_ = ADB::constant(V::Zero(xw.numPerforations()));
         well_perforation_pressure_cell_diffs_ = V::Zero(xw.numPerforations());
         well_perforatoin_cell_pressure_diffs_ = V::Zero(xw.numPerforations());
+#if 0
+        std::cout << " avg_press " << std::endl;
+        std::cout << avg_press << std::endl;
+
         std::cout << "well_perforation_densities_ " << std::endl;
         std::cout << well_perforation_densities_ << std::endl;
-#if 0
 
         std::cout << "well_perforation_pressure_diffs_ " << std::endl;
         std::cout << well_perforation_pressure_diffs_ << std::endl;
@@ -1704,7 +1705,7 @@ namespace Opm {
             // why rvmax depends on oil staturation also?
             rvmax_seg = fluidRvSat(segment_press, segment_so, segment_cells);
         }
-#if 1
+#if 0
         std::cout << " segment_press " << std::endl;
         std::cout << segment_press.value() << std::endl;
 
@@ -1765,7 +1766,7 @@ namespace Opm {
             mix[phase] = non_zero_tot_rate.select(segqs[phase] / tot_surface_rate, mix[phase]);
         }
 
-#if 1
+#if 0
         std::cout << " mix " << std::endl;
         for (int phase = 0; phase < np; ++phase) {
             std::cout << mix[phase].value() << std::endl;
@@ -1842,10 +1843,9 @@ namespace Opm {
 
         well_segment_densities_ = dens / volrat;
 
-#if 1
+#if 0
         std::cout << " output the well_segment_densities_ " << std::endl;
         std::cout << well_segment_densities_.value() << std::endl;
-        std::cin.ignore();
 #endif
     }
 
@@ -1876,11 +1876,12 @@ namespace Opm {
         const double grav = detail::getGravity(geo_.gravity(), UgGridHelpers::dimensions(grid_));
         const ADB grav_adb = ADB::constant(V::Constant(nseg_total, grav));
         well_segment_pressures_delta_ = segment_depth_delta * grav_adb * well_segment_densities_;
-#if 1
+#if 0
         std::cout << " segment_depth_delta " << std::endl;
         std::cout << segment_depth_delta << std::endl;
         std::cout << " well_segment_pressures_delta_ " << std::endl;
         std::cout << well_segment_pressures_delta_.value() << std::endl;
+        std::cin.ignore();
 #endif
     }
 

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -1196,7 +1196,7 @@ namespace Opm {
         for (int w = 0; w < nw; ++w) {
             WellMultiSegmentConstPtr well = wellsMultiSegment()[w];
             const int nseg = well->numberOfSegments();
-            ADB segp = subset(state.segqs, Span(nseg, 1, start_segment));
+            ADB segp = subset(state.segp, Span(nseg, 1, start_segment));
             ADB well_residual = segp - well->wellOps().s2s_outlet * segp;
             // - subset(well_segment_pressures_delta_, Span(nseg, 1, start_segment));
             ADB others_well_residual = subset(well_residual, Span(nseg - 1, 1, 1));

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -879,7 +879,7 @@ namespace Opm {
                 const ADB& cq_s_perf = subset(cq_s[phase], Span(nperf, 1, start_perforation));
 
                 // sum of the perforate rates to its related segment
-                const ADB& cq_s_seg = well->wellOps().p2s_gather * cq_s_perf;
+                const ADB& cq_s_seg = well->wellOps().p2s * cq_s_perf;
 
                 const int start_position = start_segment + phase * nseg_total;
                 // the segment rates of this well

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -874,7 +874,7 @@ namespace Opm {
                 const int pos = pu.phase_pos[phase];
 
                 // this is per segment
-                wbq[phase] = (compi.col(pos) * injectingPhase_selector.select(q_s, ADB::constant(V::Zero(nseg)))) - q_ps;
+                wbq[phase] = (wops_ms_.w2s * ADB::constant(compi.col(pos)) * injectingPhase_selector.select(q_s, ADB::constant(V::Zero(nseg)))) - q_ps;
 
                 // TODO: it should be a single value for this certain well.
                 // TODO: it need to be changed later to handle things more consistently
@@ -899,6 +899,7 @@ namespace Opm {
             // compute wellbore mixture at standard conditions.
             // before, the determination of alive wells is based on wells.
             // now, will there be any dead segment? I think no.
+            // TODO: it is not clear if the cmix_s should be based on segment or the well
             std::vector<ADB> cmix_s(np, ADB::null());
             Selector<double> aliveWells_selector(aliveWells, Selector<double>::NotEqualZero);
             for (int phase = 0; phase < np; ++phase) {

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -122,6 +122,18 @@ namespace Opm {
         top_well_segments_ = well_state.topSegmentLoc();
 
         //TODO: handle the volume related.
+        // again, we need a global wells class
+        const int nw = wellsMultiSegment().size();
+        const int nseg_total = well_state.numSegments();
+        std::vector<double> segment_volume;
+        segment_volume.reserve(nseg_total);
+        for (int w = 0; w < nw; ++w) {
+            WellMultiSegmentConstPtr well = wellsMultiSegment()[w];
+            const std::vector<double>& segment_volume_well = well->segmentVolume();
+            segment_volume.insert(segment_volume.end(), segment_volume_well.begin(), segment_volume_well.end());
+        }
+        assert(int(segment_volume.size()) == nseg_total);
+        segvdt_ = Eigen::Map<V>(segment_volume.data(), nseg_total) / dt;
     }
 
 

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -885,13 +885,9 @@ namespace Opm {
                 // the segment rates of this well
                 const ADB& segqs_well = subset(segqs, Span(nseg, 1, start_position));
 
-                if (well->isMultiSegmented()) {
-                    segqs -= superset(cq_s_seg + well->wellOps().s2s_inlets * segqs_well, Span(nseg, 1, start_position), np * nseg_total);
-                }
-                else
-                {
-                    segqs -= superset(cq_s_seg, Span(1, 1, start_position), np * nseg_total);
-                }
+                segqs -= superset(cq_s_seg + well->wellOps().s2s_inlets * segqs_well, Span(nseg, 1, start_position), np * nseg_total);
+                // another form for non-segment wells, keep here for future reference
+                // segqs -= superset(cq_s_seg, Span(1, 1, start_position), np * nseg_total);
                 start_segment += nseg;
                 start_perforation += nperf;
             }

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -76,12 +76,7 @@ namespace Opm {
                   const std::vector<WellMultiSegmentConstPtr>& wells_multisegment)
         : Base(param, grid, fluid, geo, rock_comp_props, wells_arg, linsolver,
                eclState, has_disgas, has_vapoil, terminal_output)
-          // not all will be necessary eventually
-        , well_perforation_densities_adb_(ADB::null())
-        , well_perforation_pressure_diffs_adb_(ADB::null())
-        , well_perforation_pressure_cell_diffs_adb_(ADB::null())
         , well_perforations_segment_pressure_diffs_(ADB::null())
-        , well_perforation_cell_densities_adb_(ADB::null())
         , well_segment_densities_(ADB::null())
         , well_segment_pressures_delta_(ADB::null())
         , segment_comp_surf_volume_initial_(fluid.numPhases())
@@ -457,7 +452,6 @@ namespace Opm {
         // Are they actually zero for the current cases?
         // TODO
         well_perforations_segment_pressure_diffs_ = ADB::constant(V::Zero(xw.numPerforations()));
-        well_perforation_pressure_cell_diffs_ = V::Zero(xw.numPerforations());
         well_perforation_cell_pressure_diffs_ = V::Zero(xw.numPerforations());
 #if 0
         std::cout << " avg_press " << std::endl;

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -86,6 +86,7 @@ namespace Opm {
         , well_segment_pressures_delta_(ADB::null())
         , segment_comp_surf_volume_initial_(fluid.numPhases())
         , segment_comp_surf_volume_current_(fluid.numPhases(), ADB::null())
+        , segment_mass_flow_rates_(ADB::null())
         , wells_multisegment_(wells_multisegment)
         {
             // Modify the wops_.well_cell member, since the
@@ -1852,6 +1853,12 @@ namespace Opm {
         const ADB segment_surface_volume = segvdt_ / volrat;
         for (int phase = 0; phase < np; ++phase) {
             segment_comp_surf_volume_current_[phase] = segment_surface_volume * mix[phase];
+        }
+
+        // Mass flow rate of the segments
+        segment_mass_flow_rates_ = ADB::constant(V::Zero(nseg_total));
+        for (int phase = 0; phase < np; ++phase) {
+            segment_mass_flow_rates_ += surf_dens[pu.phase_pos[phase]] * segqs[phase];
         }
 
 #if 0

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -1002,7 +1002,17 @@ namespace Opm {
     void BlackoilMultiSegmentModel<Grid>::addWellFluxEq(const std::vector<ADB>& cq_s,
                                                         const SolutionState& state)
     {
-        // the equations is for each segment
+        // the well flux equations are for each segment and each phase.
+        //    /delta m_p_n / dt  - /sigma Q_pi - /sigma q_pj + Q_pn = 0
+        // 1. It is the gain of the amount of the component p in the segment n during the
+        //    current time step under stock-tank conditions.
+        //    It is used to handle the volume storage effects of the wellbore.
+        //    We need the information from the previous step and the crrent time step.
+        // 2. for the second term, it is flow into the segment from the inlet segments,
+        //    which are unknown and treated implictly.
+        // 3. for the third term, it is the inflow through the perforations.
+        // 4. for the last term, it is the outlet rates and also the segment rates,
+        //    which are the primary variable.
         const int np = numPhases();
         const int nseg_total = state.segp.size();
 

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -870,6 +870,13 @@ namespace Opm {
 
         ADB segqs = state.segqs;
 
+        // Gain of the surface volume of each component in the segment by dt
+        std::vector<ADB> segment_volume_change_dt(np, ADB::null());
+        for (int phase = 0; phase < np; ++phase) {
+            segment_volume_change_dt[phase] = segment_comp_surf_volume_current_[phase] -
+                                              segment_comp_surf_volume_initial_[phase];
+        }
+
         for (int phase = 0; phase < np; ++phase) {
             int start_segment = 0;
             int start_perforation = 0;
@@ -906,7 +913,10 @@ namespace Opm {
                 // the segment rates of this well
                 const ADB& segqs_well = subset(segqs, Span(nseg, 1, start_position));
 
-                segqs -= superset(cq_s_seg + well->wellOps().s2s_inlets * segqs_well, Span(nseg, 1, start_position), np * nseg_total);
+                const ADB segment_volume_change_dt_well = subset(segment_volume_change_dt[phase],
+                                                          Span(nseg, 1, start_segment));
+                segqs -= superset(cq_s_seg + well->wellOps().s2s_inlets * segqs_well + segment_volume_change_dt_well,
+                                  Span(nseg, 1, start_position), np * nseg_total);
                 // another form for non-segment wells, keep here for future reference
                 // segqs -= superset(cq_s_seg, Span(1, 1, start_position), np * nseg_total);
                 start_segment += nseg;

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment.hpp
@@ -21,7 +21,7 @@
 #ifndef OPM_SIMULATORFULLYIMPLICITBLACKOILMULTISEGMENT_HEADER_INCLUDED
 #define OPM_SIMULATORFULLYIMPLICITBLACKOILMULTISEGMENT_HEADER_INCLUDED
 
-#include "SimulatorBase.hpp"
+#include <opm/autodiff/SimulatorBase.hpp>
 
 
 #include <opm/autodiff/NonlinearSolver.hpp>

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment.hpp
@@ -23,8 +23,8 @@
 
 #include "SimulatorBase.hpp"
 
-#include "NewtonSolver.hpp"
 
+#include <opm/autodiff/NonlinearSolver.hpp>
 #include <opm/autodiff/BlackoilMultiSegmentModel.hpp>
 #include <opm/autodiff/WellStateMultiSegment.hpp>
 
@@ -41,7 +41,7 @@ struct SimulatorTraits<SimulatorFullyImplicitBlackoilMultiSegment<GridT> >
     typedef BlackoilOutputWriter OutputWriter;
     typedef GridT Grid;
     typedef BlackoilMultiSegmentModel<Grid> Model;
-    typedef NewtonSolver<Model> Solver;
+    typedef NonlinearSolver<Model> Solver;
 };
 
 /// a simulator for the blackoil model

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment.hpp
@@ -59,7 +59,7 @@ public:
     // forward the constructor to the base class
     SimulatorFullyImplicitBlackoilMultiSegment(const parameter::ParameterGroup& param,
                                    const GridT& grid,
-                                   const DerivedGeology& geo,
+                                   DerivedGeology& geo,
                                    BlackoilPropsAdInterface& props,
                                    const RockCompressibility* rock_comp_props,
                                    NewtonIterationBlackoilInterface& linsolver,

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
@@ -70,7 +70,7 @@ namespace Opm
         std::unique_ptr< AdaptiveTimeStepping > adaptiveTimeStepping;
         if( param_.getDefault("timestep.adaptive", true ) )
         {
-            adaptiveTimeStepping.reset( new AdaptiveTimeStepping( param_, solver_.parallelInformation(), terminal_output_ ) );
+            adaptiveTimeStepping.reset( new AdaptiveTimeStepping( param_, terminal_output_ ) );
         }
 
         // init output writer

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
@@ -119,7 +119,20 @@ namespace Opm
                 if (wells_ecl[i]->getStatus(timer.currentStepNum()) == WellCommon::SHUT) {
                     continue;
                 }
-                wells_multisegment.push_back(std::make_shared<WellMultiSegment>(wells_ecl[i], timer.currentStepNum(), wells));
+                // checking if the well can be found in the wells
+                const std::string& well_name = wells_ecl[i]->name();
+                // number of wells in wells
+                const int nw_wells = wells->number_of_wells;
+                int index_well;
+                for (index_well = 0; index_well < nw_wells; ++index_well) {
+                    if (well_name == std::string(wells->name[index_well])) {
+                        break;
+                    }
+                }
+
+                if (index_well != nw_wells) { // found in the wells
+                    wells_multisegment.push_back(std::make_shared<WellMultiSegment>(wells_ecl[i], timer.currentStepNum(), wells));
+                }
             }
 
             well_state.init(wells_multisegment, state, prev_well_state);

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
@@ -115,84 +115,12 @@ namespace Opm
             std::vector<WellMultiSegmentConstPtr> wells_multisegment;
             wells_multisegment.reserve(wells_ecl.size());
             for (size_t i = 0; i < wells_ecl.size(); ++i) {
+                // not processing SHUT wells.
                 if (wells_ecl[i]->getStatus(timer.currentStepNum()) == WellCommon::SHUT) {
                     continue;
                 }
                 wells_multisegment.push_back(std::make_shared<WellMultiSegment>(wells_ecl[i], timer.currentStepNum(), wells));
             }
-
-#if 0
-            // for DEBUGGING OUTPUT
-            std::cout << " the number of the wells from EclipseState " << wells_ecl.size() << std::endl;
-            for (size_t i = 0; i < wells_ecl.size(); ++i) {
-                std::cout << " well name " << wells_ecl[i]->name() << std::endl;
-                std::cout << " segment wells " << wells_ecl[i]->isMultiSegment() << std::endl;
-            }
-
-            std::cout << " output all the well information for debugging " << std::endl;
-
-            int nw = wells_multisegment.size();
-            for (int w = 0; w < nw; ++w) {
-                WellMultiSegmentConstPtr well = wells_multisegment[w];
-                std::cout << " well name " << well->name() << std::endl;
-                std::cout << " is mutli-segmented ? : " << well->isMultiSegmented() << std::endl;
-                std::cout << " number of segments : " << well->numberOfSegments() << std::endl;
-                std::cout << " number of perforations : " << well->numberOfPerforations() << std::endl;
-
-                std::cout << " beginning outputing segment informations " << std::endl;
-                for (int s = 0; s < well->numberOfSegments(); ++s) {
-                    std::cout << "    segment number : " << s << std::endl;
-                    int n_perf_segment = well->segmentPerforations()[s].size();
-                    std::cout << "    number of perforations for this segment " << n_perf_segment << std::endl;
-                    std::cout << "    the depth of the segment " << well->segmentDepth()[s] << std::endl;
-                    std::cout << "    the length of the segment " << well->segmentLength()[s] << std::endl;
-                    std::cout << "    the volume of the segment " << well->segmentVolume()[s] << std::endl;
-                    std::cout << "    the roughness of the segment " << well->segmentRoughness()[s] << std::endl;
-                    std::cout << "    the cross area of the segment " << well->segmentCrossArea()[s] << std::endl;
-                    std::cout << "    its outletSegment " << well->outletSegment()[s] << std::endl;
-                    std::cout << "    the number of the inlet segments " << well->inletSegments()[s].size() << std::endl;
-                    std::cout << "    its inlet segments are  ";
-                    for (int inlet = 0; inlet < well->inletSegments()[s].size(); ++inlet) {
-                        std::cout << well->inletSegments()[s][inlet] << " ";
-                    }
-                    std::cout << std::endl;
-                    std::cout << "    its perforations infromations " << std::endl;
-                    for (int perf = 0; perf < n_perf_segment; ++perf) {
-                        int perf_number = well->segmentPerforations()[s][perf];
-                        std::cout << "      perforation " << perf_number;
-                        std::cout << "   peforation depth " << well->perfDepth()[perf_number] << std::endl;;
-                    }
-                    std::cout << std::endl;
-                }
-                std::cout << " output all the mapping informations " << std::endl;
-                std::cout << " matrix s2p " << std::endl;
-                std::cout << well->wellOps().s2p << std::endl;
-
-
-                std::cout << " maxtrix p2s " << std::endl;
-                std::cout << well->wellOps().p2s << std::endl;
-
-                std::cout << " matrix p2s_average " << std::endl;
-                std::cout << well->wellOps().p2s_average << std::endl;
-
-                std::cout << " maxtrix s2s_gather " << std::endl;
-                std::cout << well->wellOps().s2s_gather << std::endl;
-
-                std::cout << " maxtrix p2s_gather " << std::endl;
-                std::cout << well->wellOps().p2s_gather << std::endl;
-
-                std::cout << " s2s_inlets " << std::endl;
-                std::cout << well->wellOps().s2s_inlets << std::endl;
-
-                std::cout << " s2s_outlet " << std::endl;
-                std::cout << well->wellOps().s2s_outlet << std::endl;
-
-                std::cout << " output well information for well " << well->name() << " done!!!! " << std::endl;
-            }
-            std::cin.ignore();
-#endif
-            // DEBUGGING OUTPUT is DONE
-
 
             well_state.init(wells_multisegment, state, prev_well_state);
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
@@ -112,10 +112,13 @@ namespace Opm
             // well_state.init(wells, state, prev_well_state);
 
             const std::vector<WellConstPtr>& wells_ecl = eclipse_state_->getSchedule()->getWells(timer.currentStepNum());
-            std::vector<WellMultiSegmentConstPtr> wells_multisegment(wells_ecl.size());
-            // wells_multisegment.resize(wells_ecl.size());
-            for (size_t i = 0; i < wells_multisegment.size(); ++i) {
-                wells_multisegment[i].reset(new WellMultiSegment(wells_ecl[i], timer.currentStepNum(), wells));
+            std::vector<WellMultiSegmentConstPtr> wells_multisegment;
+            wells_multisegment.reserve(wells_ecl.size());
+            for (size_t i = 0; i < wells_ecl.size(); ++i) {
+                if (wells_ecl[i]->getStatus(timer.currentStepNum()) == WellCommon::SHUT) {
+                    continue;
+                }
+                wells_multisegment.push_back(std::make_shared<WellMultiSegment>(wells_ecl[i], timer.currentStepNum(), wells));
             }
 
 #if 0

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
@@ -84,7 +84,7 @@ namespace Opm
             output_writer_.restore( timer, state, prev_well_state, restorefilename, desiredRestoreStep );
         }
 
-        unsigned int totalNewtonIterations = 0;
+        unsigned int totalNonlinearIterations = 0;
         unsigned int totalLinearIterations = 0;
 
         // Main simulation loop.
@@ -227,8 +227,8 @@ namespace Opm
             // take time that was used to solve system for this reportStep
             solver_timer.stop();
 
-            // accumulate the number of Newton and Linear Iterations
-            totalNewtonIterations += solver->newtonIterations();
+            // accumulate the number of nonlinear and linear Iterations
+            totalNonlinearIterations += solver->nonlinearIterations();
             totalLinearIterations += solver->linearIterations();
 
             // Report timing.
@@ -261,7 +261,7 @@ namespace Opm
         report.pressure_time = stime;
         report.transport_time = 0.0;
         report.total_time = total_timer.secsSinceStart();
-        report.total_newton_iterations = totalNewtonIterations;
+        report.total_newton_iterations = totalNonlinearIterations;
         report.total_linear_iterations = totalLinearIterations;
         return report;
     }

--- a/opm/autodiff/WellMultiSegment.cpp
+++ b/opm/autodiff/WellMultiSegment.cpp
@@ -41,19 +41,15 @@ namespace Opm
             m_comp_pressure_drop_ = segment_set->compPressureDrop();
             m_multiphase_model_ = segment_set->multiPhaseModel();
 
-            // m_number_of_perforations_ from wells
-            // m_well_index_ from wells
             m_outlet_segment_.resize(m_number_of_segments_);
             m_inlet_segments_.resize(m_number_of_segments_);
             m_segment_length_.resize(m_number_of_segments_);
             m_segment_depth_.resize(m_number_of_segments_);
             m_segment_internal_diameter_.resize(m_number_of_segments_);
             m_segment_roughness_.resize(m_number_of_segments_);
-            // TODO: the cross area needs to be calculated.
             m_segment_cross_area_.resize(m_number_of_segments_, 0.);
             m_segment_volume_.resize(m_number_of_segments_);
             m_segment_perforations_.resize(m_number_of_segments_);
-            // what is the point to do this?
 
             // we change the ID to location now for easier use later.
             for (int i = 0; i < m_number_of_segments_; ++i) {
@@ -63,6 +59,7 @@ namespace Opm
                 m_segment_depth_[i] = (*segment_set)[i]->depth();
                 m_segment_internal_diameter_[i] = (*segment_set)[i]->internalDiameter();
                 m_segment_roughness_[i] = (*segment_set)[i]->roughness();
+                m_segment_cross_area_[i] = (*segment_set)[i]->crossArea();
                 m_segment_volume_[i] = (*segment_set)[i]->volume();
             }
 
@@ -172,7 +169,6 @@ namespace Opm
 
             m_outlet_segment_.resize(m_number_of_segments_, -1);
             m_segment_length_.resize(m_number_of_segments_, 0.);
-            // TODO: should set to be the bhp reference depth
             m_segment_depth_.resize(m_number_of_segments_, 0.);
             m_segment_internal_diameter_.resize(m_number_of_segments_, 0.);
             m_segment_roughness_.resize(m_number_of_segments_, 0.);
@@ -194,6 +190,8 @@ namespace Opm
                 m_well_type_ = wells->type[index_well];
                 m_well_controls_ = wells->ctrls[index_well];
                 m_number_of_phases_ = wells->number_of_phases;
+                // set the segment depth to be the bhp reference depth
+                m_segment_depth_[0] = wells->depth_ref[index_well];
                 m_comp_frac_.resize(m_number_of_phases_);
                 std::copy(wells->comp_frac + index_well * m_number_of_phases_,
                         wells->comp_frac + (index_well + 1) * m_number_of_phases_, m_comp_frac_.begin());

--- a/opm/autodiff/WellMultiSegment.cpp
+++ b/opm/autodiff/WellMultiSegment.cpp
@@ -383,6 +383,10 @@ namespace Opm
         return m_number_of_segments_;
     }
 
+    std::string WellMultiSegment::compPressureDrop() const {
+        return WellSegment::CompPresureDropEnumToString(m_comp_pressure_drop_);
+    }
+
     const std::vector<double>& WellMultiSegment::compFrac() const {
         return m_comp_frac_;
     }

--- a/opm/autodiff/WellMultiSegment.cpp
+++ b/opm/autodiff/WellMultiSegment.cpp
@@ -427,6 +427,10 @@ namespace Opm
         return m_segment_depth_;
     }
 
+    const std::vector<double>& WellMultiSegment::segmentDiameter() const {
+        return m_segment_internal_diameter_;
+    }
+
     const std::vector<double>& WellMultiSegment::segmentCrossArea() const {
         return m_segment_cross_area_;
     }

--- a/opm/autodiff/WellMultiSegment.cpp
+++ b/opm/autodiff/WellMultiSegment.cpp
@@ -230,8 +230,8 @@ namespace Opm
     }
 
     void WellMultiSegment::updateWellOps() {
-        m_wops_.s2p = M(m_number_of_perforations_, m_number_of_segments_);
-        m_wops_.p2s = M(m_number_of_segments_, m_number_of_perforations_);
+        m_wops_.s2p = Matrix(m_number_of_perforations_, m_number_of_segments_);
+        m_wops_.p2s = Matrix(m_number_of_segments_, m_number_of_perforations_);
 
         typedef Eigen::Triplet<double> Tri;
 
@@ -254,7 +254,7 @@ namespace Opm
         m_wops_.s2p.setFromTriplets(s2p.begin(), s2p.end());
         m_wops_.p2s.setFromTriplets(p2s.begin(), p2s.end());
 
-        m_wops_.s2s_gather = M(m_number_of_segments_, m_number_of_segments_);
+        m_wops_.s2s_gather = Matrix(m_number_of_segments_, m_number_of_segments_);
         std::vector<Tri> s2s_gather;
 
         s2s_gather.reserve(m_number_of_segments_ * m_number_of_segments_);
@@ -280,16 +280,16 @@ namespace Opm
 
         m_wops_.s2s_gather.setFromTriplets(s2s_gather.begin(), s2s_gather.end());
 
-        m_wops_.p2s_gather = M(m_number_of_segments_, m_number_of_perforations_);
+        m_wops_.p2s_gather = Matrix(m_number_of_segments_, m_number_of_perforations_);
         m_wops_.p2s_gather = m_wops_.s2s_gather * m_wops_.p2s;
 
-        m_wops_.s2s_inlets = M(m_number_of_segments_, m_number_of_segments_);
+        m_wops_.s2s_inlets = Matrix(m_number_of_segments_, m_number_of_segments_);
         m_wops_.s2s_inlets.setFromTriplets(s2s_inlets.begin(), s2s_inlets.end());
 
-        m_wops_.s2s_outlet = M(m_number_of_segments_, m_number_of_segments_);
+        m_wops_.s2s_outlet = Matrix(m_number_of_segments_, m_number_of_segments_);
         m_wops_.s2s_outlet.setFromTriplets(s2s_outlet.begin(), s2s_outlet.end());
 
-        m_wops_.p2s_average = M(m_number_of_segments_, m_number_of_perforations_);
+        m_wops_.p2s_average = Matrix(m_number_of_segments_, m_number_of_perforations_);
         std::vector<Tri> p2s_average;
         p2s_average.reserve(m_number_of_segments_);
 
@@ -301,7 +301,7 @@ namespace Opm
         }
 
         // constructing the diagonal matrix to do the averaging for p2s
-        M temp_averaging_p2s = M(m_number_of_segments_, m_number_of_segments_);
+        Matrix temp_averaging_p2s = Matrix(m_number_of_segments_, m_number_of_segments_);
         temp_averaging_p2s.setFromTriplets(p2s_average.begin(), p2s_average.end());
         m_wops_.p2s_average = temp_averaging_p2s * m_wops_.p2s;
     }

--- a/opm/autodiff/WellMultiSegment.cpp
+++ b/opm/autodiff/WellMultiSegment.cpp
@@ -19,7 +19,6 @@
 */
 
 #include <opm/autodiff/WellMultiSegment.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/SegmentSet.hpp>
 
 
 namespace Opm
@@ -35,7 +34,7 @@ namespace Opm
         m_well_name_ = well->name();
         CompletionSetConstPtr completion_set = well->getCompletions(time_step);
 
-        if (well->isMultiSegment()) {
+        if (well->isMultiSegment(time_step)) {
             m_is_multi_segment_ = true;
             SegmentSetConstPtr segment_set = well->getSegmentSet(time_step);
             m_number_of_segments_ = segment_set->numberSegment();
@@ -62,7 +61,7 @@ namespace Opm
                 // now the segment for top segment is 0, then its outlet segment will be -1
                 // it is also the flag to indicate the top segment
                 m_outlet_segment_[i] = segment_set->numberToLocation((*segment_set)[i]->outletSegment());
-                m_segment_length_[i] = (*segment_set)[i]->length();
+                m_segment_length_[i] = (*segment_set)[i]->totalLength();
                 m_segment_depth_[i] = (*segment_set)[i]->depth();
                 m_segment_internal_diameter_[i] = (*segment_set)[i]->internalDiameter();
                 m_segment_roughness_[i] = (*segment_set)[i]->roughness();
@@ -384,7 +383,7 @@ namespace Opm
     }
 
     std::string WellMultiSegment::compPressureDrop() const {
-        return WellSegment::CompPresureDropEnumToString(m_comp_pressure_drop_);
+        return WellSegment::CompPressureDropEnumToString(m_comp_pressure_drop_);
     }
 
     const std::vector<double>& WellMultiSegment::compFrac() const {

--- a/opm/autodiff/WellMultiSegment.hpp
+++ b/opm/autodiff/WellMultiSegment.hpp
@@ -31,7 +31,7 @@
 #include <opm/core/simulator/WellState.hpp>
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/SegmentSet.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/MSW/SegmentSet.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
 #include <vector>
 #include <cassert>
@@ -121,7 +121,7 @@ namespace Opm
         // changing it when figuring out how to using it
         struct WellControls *m_well_controls_;
         // components of the pressure drop to be included
-        WellSegment::CompPresureDropEnum m_comp_pressure_drop_;
+        WellSegment::CompPressureDropEnum m_comp_pressure_drop_;
         // multi-phase flow model
         WellSegment::MultiPhaseModelEnum m_multiphase_model_;
         // number of perforation for this well

--- a/opm/autodiff/WellMultiSegment.hpp
+++ b/opm/autodiff/WellMultiSegment.hpp
@@ -101,7 +101,9 @@ namespace Opm
     private:
         // for the moment, we use the information from wells.
         // TODO: remove the dependency on wells from opm-core.
-        void init(WellConstPtr well, size_t time_step, const Wells* wells);
+        void initMultiSegmentWell(WellConstPtr well, size_t time_step, const Wells* wells);
+        void initNonMultiSegmentWell(WellConstPtr well, size_t time_step, const Wells* wells);
+        void updateWellOps();
 
     private:
         // name of the well

--- a/opm/autodiff/WellMultiSegment.hpp
+++ b/opm/autodiff/WellMultiSegment.hpp
@@ -48,8 +48,7 @@ namespace Opm
     {
     public:
 
-        typedef Eigen::Array<double, Eigen::Dynamic, 1> V;
-        typedef Eigen::SparseMatrix<double> M;
+        typedef Eigen::SparseMatrix<double> Matrix;
 
         /// Constructor of WellMultiSegment
         /// \param[in]       well information from EclipseState
@@ -130,15 +129,15 @@ namespace Opm
         /// Struct for the well operator matrices.
         /// All the operator matrics only apply to the one specifi well.
         struct WellOps {
-            M s2p;              // segment -> perf (scatter)
-            M p2s;              // perf -> segment (gather)
-            M p2s_average;      // perf -> segment (avarage)
-            M s2s_gather;       // segment -> segment (in an accumlative way)
+            Matrix s2p;              // segment -> perf (scatter)
+            Matrix p2s;              // perf -> segment (gather)
+            Matrix p2s_average;      // perf -> segment (avarage)
+            Matrix s2s_gather;       // segment -> segment (in an accumlative way)
                                 // means the outlet segments will gather all the contribution
                                 // from all the inlet segments in a recurisive way
-            M p2s_gather;       // perforation -> segment (in an accumative way)
-            M s2s_inlets;       // segment -> its inlet segments
-            M s2s_outlet;      // segment -> its outlet segment
+            Matrix p2s_gather;       // perforation -> segment (in an accumative way)
+            Matrix s2s_inlets;       // segment -> its inlet segments
+            Matrix s2s_outlet;      // segment -> its outlet segment
         };
 
         /// Well operator matrics

--- a/opm/autodiff/WellMultiSegment.hpp
+++ b/opm/autodiff/WellMultiSegment.hpp
@@ -51,43 +51,88 @@ namespace Opm
         typedef Eigen::Array<double, Eigen::Dynamic, 1> V;
         typedef Eigen::SparseMatrix<double> M;
 
+        /// Constructor of WellMultiSegment
+        /// \param[in]       well information from EclipseState
+        /// \param[in]       current time step
+        /// \param[in[       pointer to Wells structure, to be removed eventually
         WellMultiSegment(WellConstPtr well, size_t time_step, const Wells* wells);
 
+        /// Well name.
         const std::string& name() const;
+
+        /// Flag indicating if the well is a multi-segment well.
         bool isMultiSegmented() const;
+
+        /// Number of the perforations.
         int numberOfPerforations() const;
+
+        /// Number of the segments.
         int numberOfSegments() const;
+
+        /// Components of the pressure drop invloved.
+        /// HFA Hydrostatic + friction + acceleration
+        /// HF- Hydrostatic + friction
+        /// H-- Hydrostatic only.
         std::string compPressureDrop() const;
 
+        /// Well control.
         const WellControls* wellControls() const;
+
+        /// Component fractions for each well.
         const std::vector<double>& compFrac() const;
 
+        /// Number of phases.
         int numberOfPhases() const;
 
+        /// Well type.
         WellType wellType() const;
+
+        /// Well productivity index.
         const std::vector<double>& wellIndex() const;
+
+        /// Depth of the perforations.
         const std::vector<double>& perfDepth() const;
+
+        /// Indices of the grid blocks that perforations are completed in.
         const std::vector<int>& wellCells() const;
+
+        /// Indices of the gird blocks that segments locate at.
         const std::vector<int>& segmentCells() const;
+
+        /// Outlet segments, a segment (except top segment) can only have one outlet segment.
+        /// For top segment, its outlet segments is -1 always, which means no outlet segment for top segment.
         const std::vector<int>& outletSegment() const;
+
+        /// Inlet segments. a segment can have more than one inlet segments.
         const std::vector<std::vector<int>>& inletSegments() const;
+
+        /// The length of the segment nodes down the wellbore from the reference point.
         const std::vector<double>& segmentLength() const;
+
+        /// The depth of the segment nodes.
         const std::vector<double>& segmentDepth() const;
+
+        /// Tubing internal diameter.
         const std::vector<double>& segmentDiameter() const;
+
+        /// Cross-sectional area.
         const std::vector<double>& segmentCrossArea() const;
+
+        /// Effective absolute roughness of the tube.
         const std::vector<double>& segmentRoughness() const;
+
+        /// Volume of segment.
         const std::vector<double>& segmentVolume() const;
+
+        /// Perforations related to each segment.
         const std::vector<std::vector<int>>& segmentPerforations() const;
 
+        /// Struct for the well operator matrices.
+        /// All the operator matrics only apply to the one specifi well.
         struct WellOps {
             M s2p;              // segment -> perf (scatter)
             M p2s;              // perf -> segment (gather)
             M p2s_average;      // perf -> segment (avarage)
-            // M w2p;              // well -> perf (scatter)
-            // M p2w;              // perf - > well (gather)
-                                // but since only one well, so it is just an arrary
-                                // not needed now.
-            // M w2s;              // well -> segment (scatter)
             M s2s_gather;       // segment -> segment (in an accumlative way)
                                 // means the outlet segments will gather all the contribution
                                 // from all the inlet segments in a recurisive way
@@ -96,6 +141,7 @@ namespace Opm
             M s2s_outlet;      // segment -> its outlet segment
         };
 
+        /// Well operator matrics
         const WellOps& wellOps() const;
 
     private:

--- a/opm/autodiff/WellMultiSegment.hpp
+++ b/opm/autodiff/WellMultiSegment.hpp
@@ -73,6 +73,7 @@ namespace Opm
         const std::vector<std::vector<int>>& inletSegments() const;
         const std::vector<double>& segmentLength() const;
         const std::vector<double>& segmentDepth() const;
+        const std::vector<double>& segmentDiameter() const;
         const std::vector<double>& segmentCrossArea() const;
         const std::vector<double>& segmentRoughness() const;
         const std::vector<double>& segmentVolume() const;

--- a/opm/autodiff/WellMultiSegment.hpp
+++ b/opm/autodiff/WellMultiSegment.hpp
@@ -57,6 +57,7 @@ namespace Opm
         bool isMultiSegmented() const;
         int numberOfPerforations() const;
         int numberOfSegments() const;
+        std::string compPressureDrop() const;
 
         const WellControls* wellControls() const;
         const std::vector<double>& compFrac() const;

--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -32,7 +32,6 @@
 #include <map>
 #include <algorithm>
 #include <array>
-#include <iostream>
 
 namespace Opm
 {

--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -168,42 +168,6 @@ namespace Opm
                     }
                 }
             }
-#if 0
-            // Debugging output.
-            std::cout << " output all the well state informations after initialization " << std::endl;
-            const int nperf_total = nperf;
-
-            std::cout << " number of phase : " << np << " nubmer of perforations " << nperf_total << std::endl;
-
-            std::cout << " bhps : " << std::endl;
-            for (int i = 0; i < nw; ++i) {
-                std::cout << bhp()[i] << std::endl;
-            }
-
-            std::cout << " thps : " << std::endl;
-
-            for (int i = 0; i < nw; ++i) {
-                std::cout << thp()[i] << std::endl;
-            }
-
-            std::cout << " well rates " << std::endl;
-            for (int i = 0; i < nw; ++i) {
-                std::cout << i;
-                for (int p = 0; p < np; ++p) {
-                    std::cout << " " << wellRates()[np * i + p];
-                }
-                std::cout << std::endl;
-            }
-
-            std::cout << " perf pressures and pref phase rates : " << std::endl;
-            for (int i = 0; i < nperf_total; ++i) {
-                std::cout << i << " " << perfPress()[i];
-                for (int p = 0; p < np; ++p) {
-                    std::cout << " " << perfPhaseRates()[np * i + p];
-                }
-                std::cout << std::endl;
-            }
-#endif
         }
 
         /// One rate per phase and well connection.

--- a/opm/autodiff/WellStateMultiSegment.hpp
+++ b/opm/autodiff/WellStateMultiSegment.hpp
@@ -351,11 +351,6 @@ namespace Opm
         std::vector<double> segpress_;
         // phase rates for the segments
         std::vector<double> segphaserates_;
-        // TODO: MIGHT NOT USE THE FOLLOWING VARIABLES AT THE
-        // fractions for each segments (W, O, G)
-        std::vector<double> segphasefrac_;
-        // total flow rates for each segments, G_T
-        std::vector<double> segtotalrate_;
 
         // the location of the top segments within the whole segment list
         // it is better in the Wells class if we have a class instead of

--- a/opm/autodiff/WellStateMultiSegment.hpp
+++ b/opm/autodiff/WellStateMultiSegment.hpp
@@ -47,7 +47,6 @@ namespace Opm
     public:
 
         typedef WellStateFullyImplicitBlackoil Base;
-        typedef WellMultiSegment::V V;
 
         typedef struct {
             int well_number;

--- a/opm/autodiff/WellStateMultiSegment.hpp
+++ b/opm/autodiff/WellStateMultiSegment.hpp
@@ -68,29 +68,27 @@ namespace Opm
         void init(const std::vector<WellMultiSegmentConstPtr>& wells, const ReservoirState& state, const PrevWellState& prevState)
         {
             const int nw = wells.size();
+            nseg_ = 0;
+            nperf_ = 0;
             if (nw == 0) {
+                perfPhaseRates().clear();
+                perfPress().clear();
+                segphaserates_.clear();
+                segpress_.clear();
                 return;
             }
 
             const int np = wells[0]->numberOfPhases(); // number of the phases
 
-            int nperf = 0; // the number of the perforations
-            int nseg = 0; // the nubmer of the segments
-
             for (int iw = 0; iw < nw; ++iw) {
-                nperf += wells[iw]->numberOfPerforations();
-                nseg += wells[iw]->numberOfSegments();
+                nperf_ += wells[iw]->numberOfPerforations();
+                nseg_ += wells[iw]->numberOfSegments();
             }
 
             bhp().resize(nw);
             thp().resize(nw);
             top_segment_loc_.resize(nw);
             temperature().resize(nw, 273.15 + 20); // standard temperature for now
-
-            // deciding to add the following variables temporarily
-            // TODO: making it better later
-            nseg_ = nseg;
-            nperf_ = nperf;
 
             wellRates().resize(nw * np, 0.0);
 
@@ -106,17 +104,10 @@ namespace Opm
             int start_segment = 0;
             int start_perforation = 0;
 
-            perfPhaseRates().clear();
-            perfPhaseRates().resize(nperf * np, 0.0);
-
-            perfPress().clear();
-            perfPress().resize(nperf, -1.0e100);
-
-            segphaserates_.clear();
-            segphaserates_.resize(nseg * np, 0.0);
-
-            segpress_.clear();
-            segpress_.resize(nseg, -1.0e100);
+            perfPhaseRates().resize(nperf_ * np, 0.0);
+            perfPress().resize(nperf_, -1.0e100);
+            segphaserates_.resize(nseg_ * np, 0.0);
+            segpress_.resize(nseg_, -1.0e100);
 
 
             for (int w = 0; w < nw; ++w) {


### PR DESCRIPTION
This PR adds a new derived model that supports multi-segment wells.

It is a very large PR, so it will be demanding to review. In the interest of saving time and effort we have tried to explain some choices we have made here, as well as provide some guidance as to what we think should be looked at.

The PR makes only limited changes to the existing `BlackoilModelBase` class, the new functionality is accessed through the new `BlackoilMultiSegmentModel` class.  A new main program, `flow_multisegment.cpp`, has been added that uses the new model. This has been done to minimise disruption to the regular version of flow. The only difference in the main programs is the simulator class used, so later refactoring of this should be trivial.

In the longer term we may want to refactor the whole well subsystem. The current effort may provide a starting point to such a refactoring, in that it uses the `Wells` C-struct (and thereby also the `WellsManager`) only in a minimal way. We do not consider the present proposal the end of the discussion of well APIs however!

There are some known limitations of this PR:
 - We have not yet made sure the new model will work in a parallel setting. This should be part of the discussion later however, when we refactor the well subsystem.
 - The VFP handling is disabled for the new model class.

In reviewing this, the most critical part is how existing classes are changed,
since that bears the risk of breaking existing functionality. The `BlackoilModelBase` model has
changed as follows:
 - The `WellOps` helper class now contain a vector `well_cells`. This simplifies code by eliminating repeated creation of this object in various functions.
 - The `assemble()` function has been simplified, and the extraction of the perforation cell properties has been moved to its own function, `extractWellPerfProperties()`.
 - Made a few functions `const` that should have been from the start.
 - Added a method `numWellVars()`, used in `updateState()`, enabling the derived model to use the base implementation of `updateState()`.
 - Made many method calls use asImpl(), to support subclass usage of base class implementations.
 - The `convergenceReduction()` method no longer requires the argument containing the number of wells.

The new classes are:
 - `WellStateMultiSegment`
 - `WellMultiSegment`
 - `SimulatorFullyImplicitBlackoilMultiSegment`
 - `BlackoilMultiSegmentModel`

`WellStateMultiSegment`: this class extends the existing well state class used by the base model with
data for the segments (pressures, fluxes) as well as a new well map to preserve segment information
across timesteps (since segments can be added to a well for example), the existing well map would
be insufficient for this. There is some duplication of functionality in the `init()` method here, however
designing one's way around that is better done later in my opinion, when we decide to remove the
`Wells` C struct from these codes completely, since the reason for duplication is precisely that the
method does not use that struct as input.

`WellMultiSegment`: this class provides an API for accessing all needed information for a multi-segment or regular well (regular wells can be thought of as having a single segment). It is (mostly) initialized from an opm-parser `Well` object, and for the most part does simple data storage. However it also contain some discrete operators (stored as sparse matrices) to map for example segment -> perforations or vice versa (for that single well).

`SimulatorFullyImplicitBlackoilMultiSegment`: the main difference from the plain `SimulatorBase` class is that the model requires a vector of (shared pointers to) `WellMultiSegment` well objects instead of the `Wells` struct. This means that it must implement its own version of `run()`, which mostly duplicates that of `SimulatorBase`. Again, this is a change that may foreshadow a well refactoring, and getting rid of this duplication is not worth it at this time in my opinion.

`BlackoilMultiSegmentModel`: this class implements the multi-segment well model. It is derived from
`BlackoilModelBase`, and makes the following modifications:
 - Add various data members for segment densities, depth differences etc.
 - Add a `std::vector<WellMultiSegment>`, replaces usage of `Wells`.
 - Add an instance of (new, private class) `MultiSegmentWellOps`, that is a richer set of discrete well operations than that of the base class.
 - Override the following methods with significant changes: constructor, `prepareStep()`, `numWellVars()`, `variableWellStateInitials()`, `variableStateExtractWellsVars()`, `computeWellConnectionPressures()`, `computeWellFlux()`, `updatePerfPhaseRatesAndPressures()`, `addWellFluxEq()`, `updateWellControls()`, `addWellControlEq()`, `updateWellState()`.
 - Override the following methods with small changes (usually calling the base class implementation): `makeConstantState()`, `assemble()`, `solveWellEq()`.
 - New important methods: `computeSegmentFluidProperties()`, `computeSegmentPressuresDelta()`
Some of the methods listed with significant changes do not add features, but essentially reimplement the base feature without using the Wells struct since we have to do without it here. This applies to for example `updateWellControls()`.
Basically, the new class modifies everything that has anything to do with wells, and leaves the rest unchanged.