### PR TITLE
implement abililty to change the geology during the simulation run

### DIFF
--- a/examples/flow.cpp
+++ b/examples/flow.cpp
@@ -434,7 +434,7 @@ try
                       << std::flush;
         }
 
-        SimulatorReport fullReport = simulator.run(simtimer, state);
+        SimulatorReport fullReport = simulator.run(eclipseState, simtimer, state);
 
         if( output_cout )
         {

--- a/examples/flow_solvent.cpp
+++ b/examples/flow_solvent.cpp
@@ -407,7 +407,7 @@ try
                       << std::flush;
         }
 
-        SimulatorReport fullReport = simulator.run(simtimer, state);
+        SimulatorReport fullReport = simulator.run(eclipseState, simtimer, state);
 
         if( output_cout )
         {

--- a/opm/autodiff/GeoProps.hpp
+++ b/opm/autodiff/GeoProps.hpp
@@ -69,6 +69,17 @@ namespace Opm
             , trans_(Opm::AutoDiffGrid::numFaces(grid))
             , gpot_ (Vector::Zero(Opm::AutoDiffGrid::cell2Faces(grid).noEntries(), 1))
             , z_(Opm::AutoDiffGrid::numCells(grid))
+            , use_local_perm_(use_local_perm)
+        {
+            update(grid, props, eclState, grav);
+        }
+
+        /// compute the all geological properties at a given report step
+        template <class Props, class Grid>
+        void update(const Grid&              grid,
+                    const Props&             props ,
+                    Opm::EclipseStateConstPtr eclState,
+                    const double*            grav)
         {
             int numCells = AutoDiffGrid::numCells(grid);
             int numFaces = AutoDiffGrid::numFaces(grid);
@@ -121,7 +132,7 @@ namespace Opm
             Vector htrans(AutoDiffGrid::numCellFaces(grid));
             Grid* ug = const_cast<Grid*>(& grid);
 
-            if (! use_local_perm) {
+            if (! use_local_perm_) {
                 tpfa_htrans_compute(ug, props.permeability(), htrans.data());
             }
             else {
@@ -204,9 +215,7 @@ namespace Opm
         Vector gpot_ ;
         Vector z_;
         double gravity_[3]; // Size 3 even if grid is 2-dim.
-
-
-
+        bool use_local_perm_;
 
     };
 

--- a/opm/autodiff/SimulatorBase.hpp
+++ b/opm/autodiff/SimulatorBase.hpp
@@ -120,7 +120,7 @@ namespace Opm
         /// \param[in] threshold_pressures_by_face   if nonempty, threshold pressures that inhibit flow
         SimulatorBase(const parameter::ParameterGroup& param,
                       const Grid& grid,
-                      const DerivedGeology& geo,
+                      DerivedGeology& geo,
                       BlackoilPropsAdInterface& props,
                       const RockCompressibility* rock_comp_props,
                       NewtonIterationBlackoilInterface& linsolver,
@@ -134,11 +134,13 @@ namespace Opm
         /// Run the simulation.
         /// This will run succesive timesteps until timer.done() is true. It will
         /// modify the reservoir and well states.
+        /// \param[in] eclState        the object which represents an internalized ECL deck
         /// \param[in,out] timer       governs the requested reporting timesteps
         /// \param[in,out] state       state of reservoir: pressure, fluxes
         /// \param[in,out] well_state  state of wells: bhp, perforation rates
         /// \return                    simulation report, with timing data
-        SimulatorReport run(SimulatorTimer& timer,
+        SimulatorReport run(EclipseStateConstPtr eclState,
+                            SimulatorTimer& timer,
                             ReservoirState& state);
 
     protected:
@@ -176,7 +178,7 @@ namespace Opm
         const RockCompressibility* rock_comp_props_;
         const double* gravity_;
         // Solvers
-        const DerivedGeology& geo_;
+        DerivedGeology& geo_;
         NewtonIterationBlackoilInterface& solver_;
         // Misc. data
         std::vector<int> allcells_;

--- a/opm/autodiff/SimulatorFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoil.hpp
@@ -50,7 +50,7 @@ public:
     // forward the constructor to the base class
     SimulatorFullyImplicitBlackoil(const parameter::ParameterGroup& param,
                                    const typename Base::Grid& grid,
-                                   const DerivedGeology& geo,
+                                   DerivedGeology& geo,
                                    BlackoilPropsAdInterface& props,
                                    const RockCompressibility* rock_comp_props,
                                    NewtonIterationBlackoilInterface& linsolver,

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilSolvent.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilSolvent.hpp
@@ -106,7 +106,7 @@ namespace Opm
     public:
         SimulatorFullyImplicitBlackoilSolvent(const parameter::ParameterGroup& param,
                                               const GridT& grid,
-                                              const DerivedGeology& geo,
+                                              DerivedGeology& geo,
                                               BlackoilPropsAdInterface& props,
                                               const SolventPropsAdFromDeck& solvent_props,
                                               const RockCompressibility* rock_comp_props,

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilSolvent_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilSolvent_impl.hpp
@@ -26,7 +26,7 @@ namespace Opm
     SimulatorFullyImplicitBlackoilSolvent<GridT>::
     SimulatorFullyImplicitBlackoilSolvent(const parameter::ParameterGroup& param,
                                           const GridT& grid,
-                                          const DerivedGeology& geo,
+                                          DerivedGeology& geo,
                                           BlackoilPropsAdInterface& props,
                                           const SolventPropsAdFromDeck& solvent_props,
                                           const RockCompressibility* rock_comp_props,


### PR DESCRIPTION
i.e. it now supports stuff like MULTFLT in the schedule
section. Possibly, the MPI-parallel code paths need some fixes. (but
if the geology is not changed during the simulation, the parallel code
will do the same as before.)

the most fundamental change of this patch is that the
reference/pointer to the DerivedGeology object is made non-constant. IMO
that's okay, though, because the geology can no longer assumed to be
constant over the whole simulation run.