### PR TITLE
Use cell centers based on cell corners

### DIFF
--- a/opm/autodiff/GeoProps.hpp
+++ b/opm/autodiff/GeoProps.hpp
@@ -125,7 +125,7 @@ namespace Opm
                 tpfa_htrans_compute(ug, props.permeability(), htrans.data());
             }
             else {
-                tpfa_loc_trans_compute_(grid,props.permeability(),htrans);
+                tpfa_loc_trans_compute_(grid,eclgrid, props.permeability(),htrans);
             }
 
             std::vector<double> mult;
@@ -191,6 +191,7 @@ namespace Opm
 
         template <class Grid>
         void tpfa_loc_trans_compute_(const Grid &grid,
+                                     Opm::EclipseGridConstPtr eclGrid,
                                      const double* perm,
                                      Vector &hTrans);
 
@@ -338,6 +339,7 @@ namespace Opm
 
     template <class GridType>
     inline void DerivedGeology::tpfa_loc_trans_compute_(const GridType& grid,
+                                                        Opm::EclipseGridConstPtr eclGrid,
                                                         const double* perm,
                                                         Vector& hTrans){
 
@@ -358,6 +360,7 @@ namespace Opm
             for(auto cellFaceIter = cellFacesRange.begin(), cellFaceEnd = cellFacesRange.end();
                 cellFaceIter != cellFaceEnd; ++cellFaceIter, ++cellFaceIdx)
             {
+
                 // The index of the face in the compressed grid
                 const int faceIdx = *cellFaceIter;
 
@@ -388,11 +391,26 @@ namespace Opm
                 const double* scaledFaceNormal = faceNormal;
 #endif
 
+                int cartesianCellIdx = AutoDiffGrid::globalCell(grid)[cellIdx];
+                auto cellCentroid = eclGrid->getCellCenter(cartesianCellIdx);
+
                 for (int indx = 0; indx < dim; ++indx) {
-                    const double Ci = Opm::UgGridHelpers::faceCentroid(grid, faceIdx)[indx] -
-                        Opm::UgGridHelpers::cellCentroidCoordinate(grid, cellIdx, indx);
+
+                    double Ci = Opm::UgGridHelpers::faceCentroid(grid, faceIdx)[indx];
+                    switch (indx) {
+                    case 0:
+                        Ci -= std::get<0>(cellCentroid);
+                        break;
+                    case 1:
+                        Ci -= std::get<1>(cellCentroid);
+                        break;
+                    case 2:
+                        Ci -= std::get<2>(cellCentroid);
+                        break;
+
+                    }
                     dist += Ci*Ci;
-                    cn += sgn * Ci * scaledFaceNormal[ indx ]; //Opm::UgGridHelpers::faceNormal(grid, faceIdx)[indx];
+                    cn += sgn * Ci * scaledFaceNormal[ indx ];
                 }
 
                 if (cn < 0){

--- a/opm/autodiff/GeoProps.hpp
+++ b/opm/autodiff/GeoProps.hpp
@@ -143,7 +143,7 @@ namespace Opm
 
             // Compute z coordinates
             for (int c = 0; c<numCells; ++c){
-                z_[c] = Opm::UgGridHelpers::cellCentroidCoordinate(grid, c, 2);
+                z_[c] = Opm::UgGridHelpers::cellCenterDepth(grid, c);
             }
 
 

--- a/opm/autodiff/GeoProps.hpp
+++ b/opm/autodiff/GeoProps.hpp
@@ -392,23 +392,11 @@ namespace Opm
 #endif
 
                 int cartesianCellIdx = AutoDiffGrid::globalCell(grid)[cellIdx];
-                auto cellCentroid = eclGrid->getCellCenter(cartesianCellIdx);
+                auto cellCenter = eclGrid->getCellCenter(cartesianCellIdx);
 
                 for (int indx = 0; indx < dim; ++indx) {
 
-                    double Ci = Opm::UgGridHelpers::faceCentroid(grid, faceIdx)[indx];
-                    switch (indx) {
-                    case 0:
-                        Ci -= std::get<0>(cellCentroid);
-                        break;
-                    case 1:
-                        Ci -= std::get<1>(cellCentroid);
-                        break;
-                    case 2:
-                        Ci -= std::get<2>(cellCentroid);
-                        break;
-
-                    }
+                    const double Ci = Opm::UgGridHelpers::faceCentroid(grid, faceIdx)[indx] - cellCenter[indx];
                     dist += Ci*Ci;
                     cn += sgn * Ci * scaledFaceNormal[ indx ];
                 }


### PR DESCRIPTION
Cell centers and depths based on the cell corners is used instead of the cell centroids. 

This PR improves the match with Eclipse on the new model and norne. 

