### PR TITLE
Parallel overlapping ILU0

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -130,6 +130,7 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/autodiff/NonlinearSolver_impl.hpp
 	opm/autodiff/LinearisedBlackoilResidual.hpp
 	opm/autodiff/ParallelDebugOutput.hpp
+	opm/autodiff/ParallelOverlappingILU0.hpp
 	opm/autodiff/ParallelRestrictedAdditiveSchwarz.hpp
 	opm/autodiff/RateConverter.hpp
 	opm/autodiff/RedistributeDataHandles.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -130,6 +130,7 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/autodiff/NonlinearSolver_impl.hpp
 	opm/autodiff/LinearisedBlackoilResidual.hpp
 	opm/autodiff/ParallelDebugOutput.hpp
+	opm/autodiff/ParallelRestrictedAdditiveSchwarz.hpp
 	opm/autodiff/RateConverter.hpp
 	opm/autodiff/RedistributeDataHandles.hpp
 	opm/autodiff/SimulatorBase.hpp

--- a/opm/autodiff/CPRPreconditioner.hpp
+++ b/opm/autodiff/CPRPreconditioner.hpp
@@ -264,8 +264,7 @@ createEllipticPreconditionerPointer(const M& Ae, double relax,
     //Dune::SeqILU0<M,X,X>* ilu=new Dune::SeqILU0<M,X,X>(Ae, relax);
     typedef typename CPRSelector<M,X,X,Dune::OwnerOverlapCopyCommunication<I1,I2> >
         ::EllipticPreconditionerPointer EllipticPreconditionerPointer;
-    return EllipticPreconditionerPointer(new ParallelPreconditioner(Ae, comm, relax));//,
-    //                                         createParallelDeleter(*ilu, comm));
+    return EllipticPreconditionerPointer(new ParallelPreconditioner(Ae, comm, relax));
 }
 #endif
 } // end namespace

--- a/opm/autodiff/CPRPreconditioner.hpp
+++ b/opm/autodiff/CPRPreconditioner.hpp
@@ -49,6 +49,7 @@
 
 #include <opm/autodiff/AdditionalObjectDeleter.hpp>
 #include <opm/autodiff/ParallelRestrictedAdditiveSchwarz.hpp>
+#include <opm/autodiff/ParallelOverlappingILU0.hpp>
 namespace Opm
 {
 namespace

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
@@ -143,50 +143,15 @@ namespace Opm
 
 #if HAVE_MPI
         typedef Dune::OwnerOverlapCopyCommunication<int, int> Comm;
-        //typedef Dune::BlockPreconditioner<Vector, Vector, Comm, SeqPreconditioner> ParPreconditioner;
         typedef ParallelOverlappingILU0<Mat,Vector,Vector,Comm> ParPreconditioner;
         template <class Operator>
-        std::unique_ptr<ParPreconditioner /*,
-                                            AdditionalObjectDeleter<SeqPreconditioner> */
-                        >
+        std::unique_ptr<ParPreconditioner>
         constructPrecond(Operator& opA, const Comm& comm) const
         {
-            typedef AdditionalObjectDeleter<SeqPreconditioner> Deleter;
-            //typedef std::unique_ptr<ParPreconditioner, Deleter> Pointer;
             typedef std::unique_ptr<ParPreconditioner> Pointer;
             const double relax = 1.0;
             return Pointer(new ParPreconditioner(opA.getmat(), comm, relax));
-            /*
-
-            int ilu_setup_successful = 1;
-            std::string message;
-            const double relax = 1.0;
-            SeqPreconditioner* seq_precond = nullptr;
-            try {
-                seq_precond = new SeqPreconditioner(opA.getmat(), relax);
-            }
-            catch ( Dune::MatrixBlockError error )
-            {
-                message = error.what();
-                std::cerr<<"Exception occured on process " <<
-                    comm.communicator().rank() << " during " <<
-                    "setup of ILU0 preconditioner with message: " <<
-                    message<<std::endl;
-                ilu_setup_successful = 0;
-            }
-            // Check whether there was a problem on some process
-            if ( comm.communicator().min(ilu_setup_successful) == 0 )
-            {
-                if ( seq_precond ) // not null if constructor succeeded
-                {
-                    // prevent memory leak
-                    delete seq_precond;
-                    throw Dune::MatrixBlockError();
-                }
-            }
-            return Pointer(new ParPreconditioner(*seq_precond, comm),
-                                  Deleter(*seq_precond));
-            */
+            
         }
 #endif
 

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
@@ -27,6 +27,8 @@
 #include <opm/autodiff/AdditionalObjectDeleter.hpp>
 #include <opm/autodiff/NewtonIterationBlackoilInterleaved.hpp>
 #include <opm/autodiff/NewtonIterationUtilities.hpp>
+#include <opm/autodiff/ParallelRestrictedAdditiveSchwarz.hpp>
+#include <opm/autodiff/ParallelOverlappingILU0.hpp>
 #include <opm/autodiff/AutoDiffHelpers.hpp>
 #include <opm/common/Exceptions.hpp>
 #include <opm/core/linalg/ParallelIstlInformation.hpp>

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
@@ -141,15 +141,21 @@ namespace Opm
 
 #if HAVE_MPI
         typedef Dune::OwnerOverlapCopyCommunication<int, int> Comm;
-        typedef Dune::BlockPreconditioner<Vector, Vector, Comm, SeqPreconditioner> ParPreconditioner;
-
+        //typedef Dune::BlockPreconditioner<Vector, Vector, Comm, SeqPreconditioner> ParPreconditioner;
+        typedef ParallelOverlappingILU0<Mat,Vector,Vector,Comm> ParPreconditioner;
         template <class Operator>
-        std::unique_ptr<ParPreconditioner,
-                        AdditionalObjectDeleter<SeqPreconditioner> >
+        std::unique_ptr<ParPreconditioner /*,
+                                            AdditionalObjectDeleter<SeqPreconditioner> */
+                        >
         constructPrecond(Operator& opA, const Comm& comm) const
         {
             typedef AdditionalObjectDeleter<SeqPreconditioner> Deleter;
-            typedef std::unique_ptr<ParPreconditioner, Deleter> Pointer;
+            //typedef std::unique_ptr<ParPreconditioner, Deleter> Pointer;
+            typedef std::unique_ptr<ParPreconditioner> Pointer;
+            const double relax = 1.0;
+            return Pointer(new ParPreconditioner(opA.getmat(), comm, relax));
+            /*
+
             int ilu_setup_successful = 1;
             std::string message;
             const double relax = 1.0;
@@ -178,6 +184,7 @@ namespace Opm
             }
             return Pointer(new ParPreconditioner(*seq_precond, comm),
                                   Deleter(*seq_precond));
+            */
         }
 #endif
 

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -25,7 +25,7 @@
 #ifndef OPM_NEWTONITERATIONBLACKOILINTERLEAVED_HEADER_INCLUDED
 #define OPM_NEWTONITERATIONBLACKOILINTERLEAVED_HEADER_INCLUDED
 
-
+#include <opm/autodiff/ParallelRestrictedAdditiveSchwarz.hpp>
 #include <opm/autodiff/NewtonIterationBlackoilInterface.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -26,6 +26,7 @@
 #define OPM_NEWTONITERATIONBLACKOILINTERLEAVED_HEADER_INCLUDED
 
 #include <opm/autodiff/ParallelRestrictedAdditiveSchwarz.hpp>
+#include <opm/autodiff/ParallelOverlappingILU0.hpp>
 #include <opm/autodiff/NewtonIterationBlackoilInterface.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -25,8 +25,6 @@
 #ifndef OPM_NEWTONITERATIONBLACKOILINTERLEAVED_HEADER_INCLUDED
 #define OPM_NEWTONITERATIONBLACKOILINTERLEAVED_HEADER_INCLUDED
 
-#include <opm/autodiff/ParallelRestrictedAdditiveSchwarz.hpp>
-#include <opm/autodiff/ParallelOverlappingILU0.hpp>
 #include <opm/autodiff/NewtonIterationBlackoilInterface.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 

--- a/opm/autodiff/ParallelOverlappingILU0.hpp
+++ b/opm/autodiff/ParallelOverlappingILU0.hpp
@@ -173,7 +173,9 @@ public:
             auto rhs(v[row.index()]);
             auto col = row->beforeEnd();
             for( ; col.index() > row.index(); --col)
+            {
                 col->mmv(v[col.index()], rhs);
+            }
             v[row.index()] = 0;
             col->umv(rhs, v[row.index()]);
         }

--- a/opm/autodiff/ParallelOverlappingILU0.hpp
+++ b/opm/autodiff/ParallelOverlappingILU0.hpp
@@ -77,7 +77,7 @@ namespace Opm
 /// During apply we make sure that the current residual is consistent (i.e.
 /// each process knows the same value for each index. The we solve
 /// Ly= d for y and make y consistent again. Last we solve Ux = y and
-/// make sure that x is consistent consistent.
+/// make sure that x is consistent.
 /// In contrast for ParallelRestrictedOverlappingSchwarz we solve (LU)x = d for x
 /// without forcing consistency between the two steps.
 /// \tparam Matrix The type of the Matrix.

--- a/opm/autodiff/ParallelOverlappingILU0.hpp
+++ b/opm/autodiff/ParallelOverlappingILU0.hpp
@@ -55,13 +55,8 @@ struct ConstructionTraits<Opm::ParallelOverlappingILU0<M,X,Y,C> >
         delete bp;
     }
 
-};/*
-    template<class X, class Y, class C>
-    struct SmootherTraits<Opm::ParallelOverlappingILU0<X,Y,C> >
-    {
-    typedef DefaultSmootherArgs<typename T::matrix_type::field_type> Arguments;
+};
 
-    };*/
 } // end namespace Amg
 
 } // end namespace Dune

--- a/opm/autodiff/ParallelOverlappingILU0.hpp
+++ b/opm/autodiff/ParallelOverlappingILU0.hpp
@@ -1,0 +1,180 @@
+/*
+  Copyright 2015 Dr. Blatt - HPC-Simulation-Software & Services
+  Copyright 2015 Statoil AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_PARALLELOVERLAPPINGILU0_HEADER_INCLUDED
+#define OPM_PARALLELOVERLAPPINGILU0_HEADER_INCLUDED
+
+#include <dune/istl/preconditioner.hh>
+#include <dune/istl/paamg/smoother.hh>
+
+namespace Opm
+{
+template<class M, class X, class Y, class C>
+class ParallelOverlappingILU0;
+}
+namespace Dune
+{
+namespace Amg
+{
+
+template<class M, class X, class Y, class C>
+struct ConstructionTraits<Opm::ParallelOverlappingILU0<M,X,Y,C> >
+{
+    typedef Dune::SeqILU0<M,X,Y> T;
+    typedef DefaultParallelConstructionArgs<T,C> Arguments;
+    typedef ConstructionTraits<T> SeqConstructionTraits;
+    static inline Opm::ParallelOverlappingILU0<M,X,Y,C>* construct(Arguments& args)
+    {
+        return new Opm::ParallelOverlappingILU0<M,X,Y,C>(args.getMatrix(),
+                                                         args.getComm(),
+                                                         args.getArgs().relaxationFactor);
+    }
+
+    static inline void deconstruct(Opm::ParallelOverlappingILU0<M,X,Y,C>* bp)
+    {
+        delete bp;
+    }
+
+};/*
+    template<class X, class Y, class C>
+    struct SmootherTraits<Opm::ParallelOverlappingILU0<X,Y,C> >
+    {
+    typedef DefaultSmootherArgs<typename T::matrix_type::field_type> Arguments;
+
+    };*/
+} // end namespace Amg
+} // end namespace Dune
+namespace Opm
+{
+
+template<class M, class X, class Y, typename C>
+class ParallelOverlappingILU0 : public Dune::Preconditioner<X,Y> {
+public:
+    //! \brief The matrix type the preconditioner is for.
+    typedef typename Dune::remove_const<M>::type matrix_type;
+    //! \brief The domain type of the preconditioner.
+    typedef X domain_type;
+    //! \brief The range type of the preconditioner.
+    typedef Y range_type;
+    //! \brief The field type of the preconditioner.
+    typedef typename X::field_type field_type;
+
+    // define the category
+    enum {
+        //! \brief The category the preconditioner is part of.
+        category=Dune::SolverCategory::overlapping
+    };
+
+    /*! \brief Constructor.
+
+      Constructor gets all parameters to operate the prec.
+      \param A The matrix to operate on.
+      \param w The relaxation factor.
+    */
+    ParallelOverlappingILU0 (const M& A, const C& comm, field_type w)
+        : ilu_(A), comm_(comm), w_(w)
+    {
+        int ilu_setup_successful = 1;
+        std::string message;
+        try
+        {
+            bilu0_decomposition(ilu_);
+        }
+        catch ( Dune::MatrixBlockError error )
+        {
+            message = error.what();
+            std::cerr<<"Exception occured on process " <<
+                comm.communicator().rank() << " during " <<
+                "setup of ILU0 preconditioner with message: " <<
+                message<<std::endl;
+            ilu_setup_successful = 0;
+        }
+        // Check whether there was a problem on some process
+        if ( comm.communicator().min(ilu_setup_successful) == 0 )
+        {
+            throw Dune::MatrixBlockError();
+        }
+    }
+
+    /*!
+      \brief Prepare the preconditioner.
+
+      \copydoc Preconditioner::pre(X&,Y&)
+    */
+    virtual void pre (X& x, Y& b)
+    {
+        DUNE_UNUSED_PARAMETER(x);
+        DUNE_UNUSED_PARAMETER(b);
+    }
+
+    /*!
+      \brief Apply the preconditoner.
+
+      \copydoc Preconditioner::apply(X&,const Y&)
+    */
+    virtual void apply (X& v, const Y& d)
+    {
+        Y& md = const_cast<Y&>(d);
+        comm_.copyOwnerToAll(md,md);
+        auto endrow=ilu_.end();
+        for ( auto row = ilu_.begin(); row != endrow; ++row )
+        {
+            auto rhs(d[row.index()]);
+            for ( auto col = row->begin(); col.index() < row.index(); ++col )
+            {
+                col->mmv(v[col.index()],rhs);
+            }
+            v[row.index()] = rhs;
+        }
+        comm_.copyOwnerToAll(v, v);
+        auto rendrow = ilu_.beforeBegin();
+        for( auto row = ilu_.beforeEnd(); row != rendrow; --row)
+        {
+            auto rhs(v[row.index()]);
+            auto col = row->beforeEnd();
+            for( ; col.index() > row.index(); --col)
+                col->mmv(v[col.index()], rhs);
+            v[row.index()] = 0;
+            col->umv(rhs, v[row.index()]);
+        }
+        comm_.copyOwnerToAll(v, v);
+        v *= w_;
+    }
+
+    /*!
+      \brief Clean up.
+
+      \copydoc Preconditioner::post(X&)
+    */
+    virtual void post (X& x)
+    {
+        DUNE_UNUSED_PARAMETER(x);
+    }
+
+private:
+    //! \brief The ILU0 decomposition of the matrix.
+    matrix_type ilu_;
+    const C& comm_;
+    //! \brief The relaxation factor to use.
+    field_type w_;
+
+};
+
+} // end namespace Opm
+#endif

--- a/opm/autodiff/ParallelOverlappingILU0.hpp
+++ b/opm/autodiff/ParallelOverlappingILU0.hpp
@@ -25,11 +25,15 @@
 
 namespace Opm
 {
+
 template<class M, class X, class Y, class C>
 class ParallelOverlappingILU0;
-}
+
+} // end namespace Opm
+
 namespace Dune
 {
+
 namespace Amg
 {
 
@@ -59,7 +63,9 @@ struct ConstructionTraits<Opm::ParallelOverlappingILU0<M,X,Y,C> >
 
     };*/
 } // end namespace Amg
+
 } // end namespace Dune
+
 namespace Opm
 {
 

--- a/opm/autodiff/ParallelRestrictedAdditiveSchwarz.hpp
+++ b/opm/autodiff/ParallelRestrictedAdditiveSchwarz.hpp
@@ -22,13 +22,18 @@
 
 #include <dune/istl/preconditioner.hh>
 #include <dune/istl/paamg/smoother.hh>
+
 namespace Opm
 {
+
 template<class X, class Y, class C, class T>
 class ParallelRestrictedOverlappingSchwarz;
-}
+
+} // end namespace Opm
+
 namespace Dune
 {
+
 namespace Amg
 {
 template<class X, class Y, class C, class T>
@@ -57,6 +62,7 @@ struct SmootherTraits<Opm::ParallelRestrictedOverlappingSchwarz<X,Y,C,T> >
 };
 
 } // end namespace Amg
+
 } // end namespace Dune
 
 namespace Opm{

--- a/opm/autodiff/ParallelRestrictedAdditiveSchwarz.hpp
+++ b/opm/autodiff/ParallelRestrictedAdditiveSchwarz.hpp
@@ -26,8 +26,6 @@ namespace Opm
 {
 template<class X, class Y, class C, class T>
 class ParallelRestrictedOverlappingSchwarz;
-template<class M, class X, class Y, class C>
-class ParallelOverlappingILU0;
 }
 namespace Dune
 {
@@ -58,36 +56,11 @@ struct SmootherTraits<Opm::ParallelRestrictedOverlappingSchwarz<X,Y,C,T> >
 
 };
 
-template<class M, class X, class Y, class C>
-struct ConstructionTraits<Opm::ParallelOverlappingILU0<M,X,Y,C> >
-{
-    typedef Dune::SeqILU0<M,X,Y> T;
-    typedef DefaultParallelConstructionArgs<T,C> Arguments;
-    typedef ConstructionTraits<T> SeqConstructionTraits;
-    static inline Opm::ParallelOverlappingILU0<M,X,Y,C>* construct(Arguments& args)
-    {
-        return new Opm::ParallelOverlappingILU0<M,X,Y,C>(args.getMatrix(),
-                                                         args.getComm(),
-                                                         args.getArgs().relaxationFactor);
-    }
-
-    static inline void deconstruct(Opm::ParallelOverlappingILU0<M,X,Y,C>* bp)
-    {
-        delete bp;
-    }
-
-};/*
-    template<class X, class Y, class C>
-    struct SmootherTraits<Opm::ParallelOverlappingILU0<X,Y,C> >
-    {
-    typedef DefaultSmootherArgs<typename T::matrix_type::field_type> Arguments;
-
-    };*/
-
-}
-}
+} // end namespace Amg
+} // end namespace Dune
 
 namespace Opm{
+
 /**
  * @brief Block parallel preconditioner.
  *
@@ -179,118 +152,6 @@ private:
     const communication_type& communication;
 };
 
-template<class M, class X, class Y, typename C>
-class ParallelOverlappingILU0 : public Dune::Preconditioner<X,Y> {
-public:
-    //! \brief The matrix type the preconditioner is for.
-    typedef typename Dune::remove_const<M>::type matrix_type;
-    //! \brief The domain type of the preconditioner.
-    typedef X domain_type;
-    //! \brief The range type of the preconditioner.
-    typedef Y range_type;
-    //! \brief The field type of the preconditioner.
-    typedef typename X::field_type field_type;
-
-    // define the category
-    enum {
-        //! \brief The category the preconditioner is part of.
-        category=Dune::SolverCategory::overlapping
-    };
-
-    /*! \brief Constructor.
-
-      Constructor gets all parameters to operate the prec.
-      \param A The matrix to operate on.
-      \param w The relaxation factor.
-    */
-    ParallelOverlappingILU0 (const M& A, const C& comm, field_type w)
-        : ilu_(A), comm_(comm), w_(w)
-    {
-        int ilu_setup_successful = 1;
-        std::string message;
-        try
-        {
-            bilu0_decomposition(ilu_);
-        }
-        catch ( Dune::MatrixBlockError error )
-        {
-            message = error.what();
-            std::cerr<<"Exception occured on process " <<
-                comm.communicator().rank() << " during " <<
-                "setup of ILU0 preconditioner with message: " <<
-                message<<std::endl;
-            ilu_setup_successful = 0;
-        }
-        // Check whether there was a problem on some process
-        if ( comm.communicator().min(ilu_setup_successful) == 0 )
-        {
-            throw Dune::MatrixBlockError();
-        }
-    }
-
-    /*!
-      \brief Prepare the preconditioner.
-
-      \copydoc Preconditioner::pre(X&,Y&)
-    */
-    virtual void pre (X& x, Y& b)
-    {
-        DUNE_UNUSED_PARAMETER(x);
-        DUNE_UNUSED_PARAMETER(b);
-    }
-
-    /*!
-      \brief Apply the preconditoner.
-
-      \copydoc Preconditioner::apply(X&,const Y&)
-    */
-    virtual void apply (X& v, const Y& d)
-    {
-        Y& md = const_cast<Y&>(d);
-        comm_.copyOwnerToAll(md,md);
-        auto endrow=ilu_.end();
-        for ( auto row = ilu_.begin(); row != endrow; ++row )
-        {
-            auto rhs(d[row.index()]);
-            for ( auto col = row->begin(); col.index() < row.index(); ++col )
-            {
-                col->mmv(v[col.index()],rhs);
-            }
-            v[row.index()] = rhs;
-        }
-        comm_.copyOwnerToAll(v, v);
-        auto rendrow = ilu_.beforeBegin();
-        for( auto row = ilu_.beforeEnd(); row != rendrow; --row)
-        {
-            auto rhs(v[row.index()]);
-            auto col = row->beforeEnd();
-            for( ; col.index() > row.index(); --col)
-                col->mmv(v[col.index()], rhs);
-            v[row.index()] = 0;
-            col->umv(rhs, v[row.index()]);
-        }
-        comm_.copyOwnerToAll(v, v);
-        v *= w_;
-    }
-
-    /*!
-      \brief Clean up.
-
-      \copydoc Preconditioner::post(X&)
-    */
-    virtual void post (X& x)
-    {
-        DUNE_UNUSED_PARAMETER(x);
-    }
-
-private:
-    //! \brief The ILU0 decomposition of the matrix.
-    matrix_type ilu_;
-    const C& comm_;
-    //! \brief The relaxation factor to use.
-    field_type w_;
-
-};
 
 } // end namespace OPM
 #endif

--- a/opm/autodiff/ParallelRestrictedAdditiveSchwarz.hpp
+++ b/opm/autodiff/ParallelRestrictedAdditiveSchwarz.hpp
@@ -1,0 +1,296 @@
+/*
+  Copyright 2015 Dr. Blatt - HPC-Simulation-Software & Services
+  Copyright 2015 Statoil AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_PARALLELRESTRICTEDADDITIVESCHWARZ_HEADER_INCLUDED
+#define OPM_PARALLELRESTRICTEDADDITIVESCHWARZ_HEADER_INCLUDED
+
+#include <dune/istl/preconditioner.hh>
+#include <dune/istl/paamg/smoother.hh>
+namespace Opm
+{
+template<class X, class Y, class C, class T>
+class ParallelRestrictedOverlappingSchwarz;
+template<class M, class X, class Y, class C>
+class ParallelOverlappingILU0;
+}
+namespace Dune
+{
+namespace Amg
+{
+template<class X, class Y, class C, class T>
+struct ConstructionTraits<Opm::ParallelRestrictedOverlappingSchwarz<X,Y,C,T> >
+{
+    typedef DefaultParallelConstructionArgs<T,C> Arguments;
+    typedef ConstructionTraits<T> SeqConstructionTraits;
+    static inline Opm::ParallelRestrictedOverlappingSchwarz<X,Y,C,T>* construct(Arguments& args)
+    {
+        return new Opm::ParallelRestrictedOverlappingSchwarz<X,Y,C,T>(*SeqConstructionTraits::construct(args),
+                                                                      args.getComm());
+    }
+
+    static inline void deconstruct(Opm::ParallelRestrictedOverlappingSchwarz<X,Y,C,T>* bp)
+    {
+        SeqConstructionTraits::deconstruct(static_cast<T*>(&bp->preconditioner));
+        delete bp;
+    }
+
+};
+template<class X, class Y, class C, class T>
+struct SmootherTraits<Opm::ParallelRestrictedOverlappingSchwarz<X,Y,C,T> >
+{
+    typedef DefaultSmootherArgs<typename T::matrix_type::field_type> Arguments;
+
+};
+
+template<class M, class X, class Y, class C>
+struct ConstructionTraits<Opm::ParallelOverlappingILU0<M,X,Y,C> >
+{
+    typedef Dune::SeqILU0<M,X,Y> T;
+    typedef DefaultParallelConstructionArgs<T,C> Arguments;
+    typedef ConstructionTraits<T> SeqConstructionTraits;
+    static inline Opm::ParallelOverlappingILU0<M,X,Y,C>* construct(Arguments& args)
+    {
+        return new Opm::ParallelOverlappingILU0<M,X,Y,C>(args.getMatrix(),
+                                                         args.getComm(),
+                                                         args.getArgs().relaxationFactor);
+    }
+
+    static inline void deconstruct(Opm::ParallelOverlappingILU0<M,X,Y,C>* bp)
+    {
+        delete bp;
+    }
+
+};/*
+    template<class X, class Y, class C>
+    struct SmootherTraits<Opm::ParallelOverlappingILU0<X,Y,C> >
+    {
+    typedef DefaultSmootherArgs<typename T::matrix_type::field_type> Arguments;
+
+    };*/
+
+}
+}
+
+namespace Opm{
+/**
+ * @brief Block parallel preconditioner.
+ *
+ * This is essentially a wrapper that takes a sequential
+ * preconditioner. In each step the sequential preconditioner
+ * is applied and then all owner data points are updated on
+ * all other processes.
+ */
+template<class X, class Y, class C, class T=Dune::Preconditioner<X,Y> >
+class ParallelRestrictedOverlappingSchwarz : public Dune::Preconditioner<X,Y> {
+    friend class Dune::Amg::ConstructionTraits<ParallelRestrictedOverlappingSchwarz<X,Y,C,T> >;
+public:
+    //! \brief The domain type of the preconditioner.
+    typedef X domain_type;
+    //! \brief The range type of the preconditioner.
+    typedef Y range_type;
+    //! \brief The field type of the preconditioner.
+    typedef typename X::field_type field_type;
+    //! \brief The type of the communication object.
+    typedef C communication_type;
+
+    // define the category
+    enum {
+        //! \brief The category the precondtioner is part of.
+        category=Dune::SolverCategory::overlapping
+    };
+
+    /*! \brief Constructor.
+
+      constructor gets all parameters to operate the prec.
+      \param p The sequential preconditioner.
+      \param c The communication object for syncing overlap and copy
+      data points. (E.~g. OwnerOverlapCommunication )
+    */
+    ParallelRestrictedOverlappingSchwarz (T& p, const communication_type& c)
+        : preconditioner(p), communication(c)
+    {   }
+
+    /*!
+      \brief Prepare the preconditioner.
+
+      \copydoc Preconditioner::pre(X&,Y&)
+    */
+    virtual void pre (X& x, Y& b)
+    {
+        communication.copyOwnerToAll(x,x);     // make dirichlet values consistent
+        preconditioner.pre(x,b);
+    }
+
+    /*!
+      \brief Apply the preconditioner
+
+      \copydoc Preconditioner::apply(X&,const Y&)
+    */
+    virtual void apply (X& v, const Y& d)
+    {
+        Y& md = const_cast<Y&>(d);
+        communication.copyOwnerToAll(md,md);
+        preconditioner.apply(v,d);
+        communication.copyOwnerToAll(v,v);
+        communication.project(md);
+    }
+
+    template<bool forward>
+    void apply (X& v, const Y& d)
+    {
+        Y& md = const_cast<Y&>(d);
+        communication.copyOwnerToAll(md,md);
+        preconditioner.template apply<forward>(v,d);
+        communication.copyOwnerToAll(v,v);
+        communication.project(md);
+    }
+
+    /*!
+      \brief Clean up.
+
+      \copydoc Preconditioner::post(X&)
+    */
+    virtual void post (X& x)
+    {
+        preconditioner.post(x);
+    }
+
+private:
+    //! \brief a sequential preconditioner
+    T& preconditioner;
+
+    //! \brief the communication object
+    const communication_type& communication;
+};
+
+template<class M, class X, class Y, typename C>
+class ParallelOverlappingILU0 : public Dune::Preconditioner<X,Y> {
+public:
+    //! \brief The matrix type the preconditioner is for.
+    typedef typename Dune::remove_const<M>::type matrix_type;
+    //! \brief The domain type of the preconditioner.
+    typedef X domain_type;
+    //! \brief The range type of the preconditioner.
+    typedef Y range_type;
+    //! \brief The field type of the preconditioner.
+    typedef typename X::field_type field_type;
+
+    // define the category
+    enum {
+        //! \brief The category the preconditioner is part of.
+        category=Dune::SolverCategory::overlapping
+    };
+
+    /*! \brief Constructor.
+
+      Constructor gets all parameters to operate the prec.
+      \param A The matrix to operate on.
+      \param w The relaxation factor.
+    */
+    ParallelOverlappingILU0 (const M& A, const C& comm, field_type w)
+        : ilu_(A), comm_(comm), w_(w)
+    {
+        int ilu_setup_successful = 1;
+        std::string message;
+        try
+        {
+            bilu0_decomposition(ilu_);
+        }
+        catch ( Dune::MatrixBlockError error )
+        {
+            message = error.what();
+            std::cerr<<"Exception occured on process " <<
+                comm.communicator().rank() << " during " <<
+                "setup of ILU0 preconditioner with message: " <<
+                message<<std::endl;
+            ilu_setup_successful = 0;
+        }
+        // Check whether there was a problem on some process
+        if ( comm.communicator().min(ilu_setup_successful) == 0 )
+        {
+            throw Dune::MatrixBlockError();
+        }
+    }
+
+    /*!
+      \brief Prepare the preconditioner.
+
+      \copydoc Preconditioner::pre(X&,Y&)
+    */
+    virtual void pre (X& x, Y& b)
+    {
+        DUNE_UNUSED_PARAMETER(x);
+        DUNE_UNUSED_PARAMETER(b);
+    }
+
+    /*!
+      \brief Apply the preconditoner.
+
+      \copydoc Preconditioner::apply(X&,const Y&)
+    */
+    virtual void apply (X& v, const Y& d)
+    {
+        Y& md = const_cast<Y&>(d);
+        comm_.copyOwnerToAll(md,md);
+        auto endrow=ilu_.end();
+        for ( auto row = ilu_.begin(); row != endrow; ++row )
+        {
+            auto rhs(d[row.index()]);
+            for ( auto col = row->begin(); col.index() < row.index(); ++col )
+            {
+                col->mmv(v[col.index()],rhs);
+            }
+            v[row.index()] = rhs;
+        }
+        comm_.copyOwnerToAll(v, v);
+        auto rendrow = ilu_.beforeBegin();
+        for( auto row = ilu_.beforeEnd(); row != rendrow; --row)
+        {
+            auto rhs(v[row.index()]);
+            auto col = row->beforeEnd();
+            for( ; col.index() > row.index(); --col)
+                col->mmv(v[col.index()], rhs);
+            v[row.index()] = 0;
+            col->umv(rhs, v[row.index()]);
+        }
+        comm_.copyOwnerToAll(v, v);
+        v *= w_;
+    }
+
+    /*!
+      \brief Clean up.
+
+      \copydoc Preconditioner::post(X&)
+    */
+    virtual void post (X& x)
+    {
+        DUNE_UNUSED_PARAMETER(x);
+    }
+
+private:
+    //! \brief The ILU0 decomposition of the matrix.
+    matrix_type ilu_;
+    const C& comm_;
+    //! \brief The relaxation factor to use.
+    field_type w_;
+
+};
+
+} // end namespace OPM
+#endif

--- a/opm/autodiff/RedistributeDataHandles.hpp
+++ b/opm/autodiff/RedistributeDataHandles.hpp
@@ -344,7 +344,7 @@ void distributeGridAndData( Dune::CpGrid& grid,
     global_grid.switchToGlobalView();
 
     // distribute the grid and switch to the distributed view
-    grid.loadBalance(eclipseState);
+    grid.loadBalance(eclipseState, geology.transmissibility().data());
     grid.switchToDistributedView();
     std::vector<int> compressedToCartesianIdx;
     Opm::createGlobalCellArray(grid, compressedToCartesianIdx);


### PR DESCRIPTION
This PR needs OPM/dune-cornerpoint#195

With this PR I am able to run Norne in parallel with the interleaved version of flow_mpi and actually get a speedup. There is still the problem that the linear iterations increase a bit to much.  The current picture is

Test run on a workstation with two Intel(R) Xeon(R) CPU E5-2620 v3 @ 2.40GHz. Each with 6 cores that can handle two threads.

Run using my branch this PR  and OPM/dune-cornerpoint#195 for the transmissibilities during loadbalancing. I used default arguments for the run. Processes are evenly distributed between the cpus (using `bysocket --report-bindings --bind-to-core` options for `mpirun` of OpenMPI)

 procs |   total |  solver | n_lin | n_nonlin |   speedup 
-------|---------|---------|-------|----------|-----------
     1 | 2104.59 | 2100.55 | 24572 |     1626 |        1. 
     2 | 1516.28 | 1433.69 | 29096 |     1710 | 1.3879956 
     4 |  977.21 |  886.21 | 27208 |     1673 | 2.1536722 
     8 |  869.97 |  760.97 | 32145 |     1704 | 2.4191524

Note that we are memory bandwidth limited here. One needs to install PT-Scotch and Zoltan for loadbalancing.

I hoped to improve the number of linear iterations by today, but the current implementation of better parallel ILU0 at https://github.com/blattms/opm-autodiff/tree/parallel-ilu-with-schedule still has some serious problems that require more bug fixing and testing.

Note that this PR does not change the bahaviour of a sequential run. Therefore it safe to merge at your disgression.
 
If you do not merge,  I will leave it open for information purposes/testing until my other branch is ready.