### PR TITLE
Remove unneeded function parameter for SimulatorBase::run(), fix warnings.

### DIFF
--- a/examples/flow.cpp
+++ b/examples/flow.cpp
@@ -434,7 +434,7 @@ try
                       << std::flush;
         }
 
-        SimulatorReport fullReport = simulator.run(eclipseState, simtimer, state);
+        SimulatorReport fullReport = simulator.run(simtimer, state);
 
         if( output_cout )
         {

--- a/examples/flow_polymer.cpp
+++ b/examples/flow_polymer.cpp
@@ -315,7 +315,7 @@ try
         std::cout << "\n\n================ Starting main simulation loop ===============\n"
                   << std::flush;
 
-        SimulatorReport fullReport = simulator.run(eclipseState, simtimer, state);
+        SimulatorReport fullReport = simulator.run(simtimer, state);
 
         std::cout << "\n\n================    End of simulation     ===============\n\n";
         fullReport.report(std::cout);

--- a/examples/flow_solvent.cpp
+++ b/examples/flow_solvent.cpp
@@ -407,7 +407,7 @@ try
                       << std::flush;
         }
 
-        SimulatorReport fullReport = simulator.run(eclipseState, simtimer, state);
+        SimulatorReport fullReport = simulator.run(simtimer, state);
 
         if( output_cout )
         {

--- a/examples/sim_poly_fi2p_comp_ad.cpp
+++ b/examples/sim_poly_fi2p_comp_ad.cpp
@@ -254,7 +254,7 @@ try
                   deck,
                   *fis_solver,
                   grav);
-    fullReport= simulator.run(eclipseState, simtimer, state);
+    fullReport= simulator.run(simtimer, state);
 
     std::cout << "\n\n================    End of simulation     ===============\n\n";
     fullReport.report(std::cout);

--- a/opm/autodiff/ParallelRestrictedAdditiveSchwarz.hpp
+++ b/opm/autodiff/ParallelRestrictedAdditiveSchwarz.hpp
@@ -20,8 +20,10 @@
 #ifndef OPM_PARALLELRESTRICTEDADDITIVESCHWARZ_HEADER_INCLUDED
 #define OPM_PARALLELRESTRICTEDADDITIVESCHWARZ_HEADER_INCLUDED
 
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <dune/istl/preconditioner.hh>
 #include <dune/istl/paamg/smoother.hh>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 namespace Opm
 {

--- a/opm/autodiff/SimulatorBase.hpp
+++ b/opm/autodiff/SimulatorBase.hpp
@@ -115,7 +115,7 @@ namespace Opm
         /// \param[in] gravity       if non-null, gravity vector
         /// \param[in] disgas        true for dissolved gas option
         /// \param[in] vapoil        true for vaporized oil option
-        /// \param[in] eclipse_state
+        /// \param[in] eclipse_state the object which represents an internalized ECL deck
         /// \param[in] output_writer
         /// \param[in] threshold_pressures_by_face   if nonempty, threshold pressures that inhibit flow
         SimulatorBase(const parameter::ParameterGroup& param,
@@ -134,13 +134,10 @@ namespace Opm
         /// Run the simulation.
         /// This will run succesive timesteps until timer.done() is true. It will
         /// modify the reservoir and well states.
-        /// \param[in] eclState        the object which represents an internalized ECL deck
         /// \param[in,out] timer       governs the requested reporting timesteps
         /// \param[in,out] state       state of reservoir: pressure, fluxes
-        /// \param[in,out] well_state  state of wells: bhp, perforation rates
         /// \return                    simulation report, with timing data
-        SimulatorReport run(EclipseStateConstPtr eclState,
-                            SimulatorTimer& timer,
+        SimulatorReport run(SimulatorTimer& timer,
                             ReservoirState& state);
 
     protected:

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -74,8 +74,7 @@ namespace Opm
     }
 
     template <class Implementation>
-    SimulatorReport SimulatorBase<Implementation>::run(EclipseStateConstPtr eclState,
-                                                       SimulatorTimer& timer,
+    SimulatorReport SimulatorBase<Implementation>::run(SimulatorTimer& timer,
                                                        ReservoirState& state)
     {
         WellState prev_well_state;
@@ -89,7 +88,7 @@ namespace Opm
         std::string tstep_filename = output_writer_.outputDirectory() + "/step_timing.txt";
         std::ofstream tstep_os(tstep_filename.c_str());
 
-        const auto& schedule = eclState->getSchedule();
+        const auto& schedule = eclipse_state_->getSchedule();
         const auto& events = schedule->getEvents();
 
         // adaptive time stepping
@@ -177,7 +176,6 @@ namespace Opm
                 // section
                 //
                 // TODO (?): handle the parallel case (maybe this works out of the box)
-                ScheduleConstPtr schedule = eclipse_state_->getSchedule();
                 DeckConstPtr miniDeck = schedule->getModifierDeck(nextTimeStepIdx);
                 eclipse_state_->applyModifierDeck(miniDeck);
                 geo_.update(grid_, props_, eclipse_state_, gravity_);


### PR DESCRIPTION
Since the EclipseState was added as a data member, it is no longer necessary to pass it as an argument. This also fixes the situation that there were two `schedule` variables in run(), causing a warning.

We also add warning suppression header includes to ParallelRestrictedAdditiveSchwarz.hpp.