### PR TITLE
NNC and threshold pressure

### DIFF
--- a/examples/flow.cpp
+++ b/examples/flow.cpp
@@ -413,7 +413,8 @@ try
     std::map<std::pair<int, int>, double> maxDp;
     computeMaxDp(maxDp, deck, eclipseState, grid, state, props, gravity[2]);
     std::vector<double> threshold_pressures = thresholdPressures(deck, eclipseState, grid, maxDp);
-
+    std::vector<double> threshold_pressures_nnc = thresholdPressuresNNC(eclipseState, geoprops.nnc(), maxDp);
+    threshold_pressures.insert(threshold_pressures.begin(), threshold_pressures_nnc.begin(), threshold_pressures_nnc.end());
     SimulatorFullyImplicitBlackoil< Grid >  simulator(param,
                                                       grid,
                                                       geoprops,

--- a/examples/flow_multisegment.cpp
+++ b/examples/flow_multisegment.cpp
@@ -413,6 +413,8 @@ try
     std::map<std::pair<int, int>, double> maxDp;
     computeMaxDp(maxDp, deck, eclipseState, grid, state, props, gravity[2]);
     std::vector<double> threshold_pressures = thresholdPressures(deck, eclipseState, grid, maxDp);
+    std::vector<double> threshold_pressures_nnc = thresholdPressuresNNC(eclipseState, geoprops.nnc(), maxDp);
+    threshold_pressures.insert(threshold_pressures.begin(), threshold_pressures_nnc.begin(), threshold_pressures_nnc.end());
 
     SimulatorFullyImplicitBlackoilMultiSegment< Grid >  simulator(param,
                                                       grid,

--- a/examples/flow_polymer.cpp
+++ b/examples/flow_polymer.cpp
@@ -287,6 +287,8 @@ try
     std::map<std::pair<int, int>, double> maxDp;
     computeMaxDp(maxDp, deck, eclipseState, *grid->c_grid(), state, *props, gravity[2]);
     std::vector<double> threshold_pressures = thresholdPressures(deck, eclipseState, *grid->c_grid(), maxDp);
+    std::vector<double> threshold_pressures_nnc = thresholdPressuresNNC(eclipseState, geology.nnc(), maxDp);
+    threshold_pressures.insert(threshold_pressures.begin(), threshold_pressures_nnc.begin(), threshold_pressures_nnc.end());
 
     Opm::BlackoilOutputWriter
         outputWriter(cGrid, param, eclipseState, pu,

--- a/examples/flow_solvent.cpp
+++ b/examples/flow_solvent.cpp
@@ -383,6 +383,8 @@ try
     std::map<std::pair<int, int>, double> maxDp;
     computeMaxDp(maxDp, deck, eclipseState, grid, state, props, gravity[2]);
     std::vector<double> threshold_pressures = thresholdPressures(deck, eclipseState, grid, maxDp);
+    std::vector<double> threshold_pressures_nnc = thresholdPressuresNNC(eclipseState, geoprops.nnc(), maxDp);
+    threshold_pressures.insert(threshold_pressures.begin(), threshold_pressures_nnc.begin(), threshold_pressures_nnc.end());
 
     SimulatorFullyImplicitBlackoilSolvent< Grid >  simulator(param,
                                                       grid,

--- a/opm/autodiff/AutoDiffHelpers.hpp
+++ b/opm/autodiff/AutoDiffHelpers.hpp
@@ -23,7 +23,11 @@
 
 #include <opm/autodiff/AutoDiffBlock.hpp>
 #include <opm/autodiff/GridHelpers.hpp>
+#include <opm/autodiff/GeoProps.hpp>
 #include <opm/core/grid.h>
+#include <opm/core/grid/PinchProcessor.hpp>
+#include <opm/core/props/rock/RockFromDeck.hpp>
+
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
@@ -69,7 +73,7 @@ struct HelperOps
 
     /// Constructs all helper vectors and matrices.
     template<class Grid>
-    HelperOps(const Grid& grid, Opm::EclipseStateConstPtr eclState = EclipseStateConstPtr () )
+    HelperOps(const Grid& grid, const NNC& nnc = NNC())
     {
         using namespace AutoDiffGrid;
         const int nc = numCells(grid);
@@ -78,39 +82,33 @@ struct HelperOps
 
         TwoColInt nbi;
         extractInternalFaces(grid, internal_faces, nbi);
-        int num_internal = internal_faces.size();
-        // num_connections may also include non-neighboring connections
-        int num_connections = num_internal;
-        int numNNC = 0;
+        const int num_internal = internal_faces.size();
 
         // handle non-neighboring connections
-        std::shared_ptr<const NNC> nnc = eclState ? eclState->getNNC()
-            : std::shared_ptr<const Opm::NNC>();
-        const bool has_nnc = nnc && nnc->hasNNC();
+        const bool has_nnc = nnc.hasNNC();
+        size_t numNNC = nnc.numNNC();
+
+        // num_connections may also include non-neighboring connections
+        const int num_connections = num_internal + numNNC;
         if (has_nnc) {
-            numNNC = nnc->numNNC();
-            num_connections += numNNC;
-            //std::cout << "Added " << numNNC << " NNC" <<std::endl;
-            nbi.resize(num_internal, 2);
+            const int *cartDims = AutoDiffGrid::cartDims(grid);
+            const int numCartesianCells = cartDims[0] * cartDims[1] * cartDims[2];
 
             // the nnc's acts on global indicies and must be mapped to cell indicies
-            size_t cartesianSize = eclState->getEclipseGrid()->getCartesianSize();
-            std::vector<int> global2localIdx(cartesianSize,0);
+            std::vector<int> global2localIdx(numCartesianCells,0);
             for (int i = 0; i< nc; ++i) {
                 global2localIdx[ globalCell( grid )[i] ] = i;
             }
-            const std::vector<size_t>& NNC1 = nnc->nnc1();
-            const std::vector<size_t>& NNC2 = nnc->nnc2();
+            const std::vector<size_t>& NNC1 = nnc.nnc1();
+            const std::vector<size_t>& NNC2 = nnc.nnc2();
             nnc_cells.resize(numNNC,2);
+            nnc_trans.resize(numNNC);
             for (int i = 0; i < numNNC; ++i) {
                 nnc_cells(i,0) = global2localIdx[NNC1[i]];
                 nnc_cells(i,1) = global2localIdx[NNC2[i]];
+                // store the nnc transmissibilities for later usage.
+                nnc_trans(i) = nnc.trans()[i];
             }
-            // store the nnc transmissibilities for later usage.
-            nnc_trans = Eigen::Map<const V>(nnc->trans().data(), numNNC);
-        } else {
-            nnc_trans.resize(0);
-            nnc_cells.resize(0, 2); // Required to have two columns.
         }
 
 
@@ -166,7 +164,6 @@ struct HelperOps
         fulldiv = fullngrad.transpose();
     }
 };
-
 // -------------------- upwinding helper class --------------------
 
 

--- a/opm/autodiff/AutoDiffHelpers.hpp
+++ b/opm/autodiff/AutoDiffHelpers.hpp
@@ -99,15 +99,13 @@ struct HelperOps
             for (int i = 0; i< nc; ++i) {
                 global2localIdx[ globalCell( grid )[i] ] = i;
             }
-            const std::vector<size_t>& NNC1 = nnc.nnc1();
-            const std::vector<size_t>& NNC2 = nnc.nnc2();
             nnc_cells.resize(numNNC,2);
             nnc_trans.resize(numNNC);
             for (int i = 0; i < numNNC; ++i) {
-                nnc_cells(i,0) = global2localIdx[NNC1[i]];
-                nnc_cells(i,1) = global2localIdx[NNC2[i]];
+                nnc_cells(i,0) = global2localIdx[nnc.nncdata()[i].cell1];
+                nnc_cells(i,1) = global2localIdx[nnc.nncdata()[i].cell2];
                 // store the nnc transmissibilities for later usage.
-                nnc_trans(i) = nnc.trans()[i];
+                nnc_trans(i) = nnc.nncdata()[i].trans;
             }
         }
 

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -298,7 +298,7 @@ namespace Opm {
         ModelParameters                 param_;
         bool use_threshold_pressure_;
         bool wells_active_;
-        V threshold_pressures_by_interior_face_;
+        V threshold_pressures_by_connection_;
 
         std::vector<ReservoirResidualQuant> rq_;
         std::vector<PhasePresence> phaseCondition_;

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -163,7 +163,7 @@ namespace detail {
         , active_(detail::activePhases(fluid.phaseUsage()))
         , canph_ (detail::active2Canonical(fluid.phaseUsage()))
         , cells_ (detail::buildAllCells(Opm::AutoDiffGrid::numCells(grid)))
-        , ops_   (grid, eclState)
+        , ops_   (grid, geo.nnc())
         , wops_  (wells_)
         , has_disgas_(has_disgas)
         , has_vapoil_(has_vapoil)

--- a/opm/autodiff/BlackoilSolventModel.hpp
+++ b/opm/autodiff/BlackoilSolventModel.hpp
@@ -123,7 +123,7 @@ namespace Opm {
         using Base::has_vapoil_;
         using Base::param_;
         using Base::use_threshold_pressure_;
-        using Base::threshold_pressures_by_interior_face_;
+        using Base::threshold_pressures_by_connection_;
         using Base::rq_;
         using Base::phaseCondition_;
         using Base::well_perforation_pressure_diffs_;

--- a/opm/autodiff/GeoProps.hpp
+++ b/opm/autodiff/GeoProps.hpp
@@ -28,6 +28,7 @@
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <Eigen/Eigen>
@@ -101,10 +102,9 @@ namespace Opm
                 ntg = eclState->getDoubleGridProperty("NTG")->getData();
             }
 
-            // get grid from parser.
-
-            // Get original grid cell volume.
+            // Get grid from parser.
             EclipseGridConstPtr eclgrid = eclState->getEclipseGrid();
+
             // Pore volume.
             // New keywords MINPVF will add some PV due to OPM cpgrid process algorithm.
             // But the default behavior is to get the comparable pore volume with ECLIPSE.
@@ -141,6 +141,12 @@ namespace Opm
 
             std::vector<double> mult;
             multiplyHalfIntersections_(grid, eclState, ntg, htrans, mult);
+
+            // Handle NNCs
+            std::shared_ptr<const NNC> nnc_deck = eclState ? eclState->getNNC()
+                             : std::shared_ptr<const Opm::NNC>();
+            NNC nnc (*nnc_deck);
+            nnc_ = nnc;
 
             // combine the half-face transmissibilites into the final face
             // transmissibilites.
@@ -191,6 +197,7 @@ namespace Opm
         const double* gravity()          const { return gravity_;}
         Vector&       poreVolume()             { return pvol_   ;}
         Vector&       transmissibility()       { return trans_  ;}
+        const NNC& nnc() const { return nnc_;}
 
     private:
         template <class Grid>
@@ -217,6 +224,13 @@ namespace Opm
         Vector z_;
         double gravity_[3]; // Size 3 even if grid is 2-dim.
         bool use_local_perm_;
+
+
+        /// Non-neighboring connections
+        NNC nnc_;
+
+
+
 
     };
 
@@ -369,7 +383,6 @@ namespace Opm
             for(auto cellFaceIter = cellFacesRange.begin(), cellFaceEnd = cellFacesRange.end();
                 cellFaceIter != cellFaceEnd; ++cellFaceIter, ++cellFaceIdx)
             {
-
                 // The index of the face in the compressed grid
                 const int faceIdx = *cellFaceIter;
 
@@ -402,9 +415,7 @@ namespace Opm
 
                 int cartesianCellIdx = AutoDiffGrid::globalCell(grid)[cellIdx];
                 auto cellCenter = eclGrid->getCellCenter(cartesianCellIdx);
-
                 for (int indx = 0; indx < dim; ++indx) {
-
                     const double Ci = Opm::UgGridHelpers::faceCentroid(grid, faceIdx)[indx] - cellCenter[indx];
                     dist += Ci*Ci;
                     cn += sgn * Ci * scaledFaceNormal[ indx ];

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
@@ -169,7 +169,7 @@ namespace Opm {
         using Base::has_vapoil_;
         using Base::param_;
         using Base::use_threshold_pressure_;
-        using Base::threshold_pressures_by_interior_face_;
+        using Base::threshold_pressures_by_connection_;
         using Base::rq_;
         using Base::phaseCondition_;
         using Base::well_perforation_pressure_diffs_;


### PR DESCRIPTION
This PR changes the following
1) NNCs in the deck a read and stored in geoprops instead of in autodiff helpers
2) Threshold pressures are calculated and appended to the threshold pressure vector 

Depends on OPM/opm-parser#635, OPM/opm-core#928 and OPM/dune-cornerpoint#193

This PR supersedes #539. The difference between this PR and #539 is that this PR does not use the pinchProcessor to generate the pinch connections.  