### PR TITLE
Fast sparse sum

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -68,6 +68,7 @@ list (APPEND TEST_SOURCE_FILES
 	tests/test_autodiffmatrix.cpp
 	tests/test_block.cpp
 	tests/test_boprops_ad.cpp
+	tests/test_fastsparsesum.cpp
 	tests/test_rateconverter.cpp
 	tests/test_span.cpp
 	tests/test_syntax.cpp
@@ -139,6 +140,7 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/autodiff/BlackoilMultiSegmentModel.hpp
 	opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
 	opm/autodiff/fastSparseProduct.hpp
+	opm/autodiff/fastSparseSum.hpp
 	opm/autodiff/DuneMatrix.hpp
 	opm/autodiff/ExtractParallelGridInformationToISTL.hpp
 	opm/autodiff/FlowMain.hpp

--- a/opm/autodiff/AutoDiffMatrix.hpp
+++ b/opm/autodiff/AutoDiffMatrix.hpp
@@ -29,11 +29,13 @@
 
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/autodiff/fastSparseProduct.hpp>
+#include <opm/autodiff/fastSparseSum.hpp>
 #include <vector>
 
 
 namespace Opm
 {
+
 
     /**
      * AutoDiffMatrix is a wrapper class that optimizes matrix operations.
@@ -459,8 +461,11 @@ namespace Opm
         {
             assert(lhs.type_ == Sparse);
             assert(rhs.type_ == Sparse);
-            AutoDiffMatrix retval = lhs;
-            retval.sparse_ += rhs.sparse_;
+            AutoDiffMatrix retval;
+            retval.type_ = Sparse;
+            retval.rows_ = lhs.rows_;
+            retval.cols_ = lhs.cols_;
+            fastSparseSum(lhs.sparse_, rhs.sparse_, retval.sparse_);
             return retval;
         }
 
@@ -717,6 +722,7 @@ namespace Opm
         fastSparseProduct(lhs, rhs, retval);
         return retval;
     }
+
 
 } // namespace Opm
 

--- a/opm/autodiff/fastSparseSum.hpp
+++ b/opm/autodiff/fastSparseSum.hpp
@@ -1,0 +1,107 @@
+/*
+  Copyright 2015 SINTEF ICT, Applied Mathematics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_FASTSPARSESUM_HEADER_INCLUDED
+#define OPM_FASTSPARSESUM_HEADER_INCLUDED
+
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+
+#include <Eigen/Eigen>
+#include <Eigen/Sparse>
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+
+namespace Opm
+{
+
+    /// Add Eigen sparse matrices.
+    /// This function is faster than Eigen's own operator+ for these matrices,
+    /// but no attempt has been made to make it generic (in terms of matrix
+    /// ordering etc). Is is intended for use by the AutoDiffMatrix class.
+    inline void fastSparseSum(const Eigen::SparseMatrix<double>& lhs,
+                              const Eigen::SparseMatrix<double>& rhs,
+                              Eigen::SparseMatrix<double>& sum)
+    {
+        typedef Eigen::SparseMatrix<double> Mat;
+        typedef Mat::Scalar Scalar;
+        typedef Mat::Index Index;
+
+        sum = Mat(lhs.rows(), lhs.cols());
+        if (lhs.nonZeros() == 0) {
+            sum = rhs;
+            return;
+        }
+        if (rhs.nonZeros() == 0) {
+            sum = lhs;
+            return;
+        }
+        sum.setZero();
+        sum.reserve(lhs.nonZeros() + rhs.nonZeros());
+
+        // we compute each column of the result, one after the other
+        const Index cols = lhs.cols();
+        using ColEntry = std::pair<int, double>; // Row index and value.
+        std::vector<ColEntry> col_entries;
+        for (Index col = 0; col < cols; ++col) {
+            col_entries.clear();
+            Mat::InnerIterator lhs_it(lhs, col);
+            Mat::InnerIterator rhs_it(rhs, col);
+            while (true) {
+                if (!lhs_it) {
+                    for (; rhs_it; ++rhs_it) {
+                        col_entries.emplace_back(rhs_it.index(), rhs_it.value());
+                    }
+                    break;
+                } else if (!rhs_it) {
+                    for (; lhs_it; ++lhs_it) {
+                        col_entries.emplace_back(lhs_it.index(), lhs_it.value());
+                    }
+                    break;
+                }
+                // Assumes both iterators are valid at this point.
+                if (lhs_it.index() == rhs_it.index()) {
+                    col_entries.emplace_back(lhs_it.index(), lhs_it.value() + rhs_it.value());
+                    ++lhs_it;
+                    ++rhs_it;
+                } else if (lhs_it.index() < rhs_it.index()) {
+                    col_entries.emplace_back(lhs_it.index(), lhs_it.value());
+                    ++lhs_it;
+                } else {
+                    assert(lhs_it.index() > rhs_it.index());
+                    col_entries.emplace_back(rhs_it.index(), rhs_it.value());
+                    ++rhs_it;
+                }
+            }
+            sum.startVec(col);
+            for (const ColEntry& ce : col_entries) {
+                sum.insertBackByOuterInnerUnordered(col, ce.first) = ce.second;
+            }
+        }
+        sum.finalize();
+        sum.makeCompressed();
+        // Mat sumx = lhs + rhs;
+        // assert(sum == sumx);
+    }
+
+} // namespace Opm
+
+
+
+#endif // OPM_FASTSPARSESUM_HEADER_INCLUDED

--- a/tests/test_fastsparsesum.cpp
+++ b/tests/test_fastsparsesum.cpp
@@ -1,0 +1,172 @@
+/*
+  Copyright 2015 SINTEF ICT, Applied Mathematics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <config.h>
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#define BOOST_TEST_MODULE fastSparseSumTest
+
+#include <opm/autodiff/fastSparseSum.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+typedef Eigen::SparseMatrix<double> Sp;
+using namespace Opm;
+
+
+bool
+operator ==(const Eigen::SparseMatrix<double>& A,
+            const Eigen::SparseMatrix<double>& B)
+{
+    // Two SparseMatrices are equal if
+    //   0) They have the same ordering (enforced by equal types)
+    //   1) They have the same outer and inner dimensions
+    //   2) They have the same number of non-zero elements
+    //   3) They have the same sparsity structure
+    //   4) The non-zero elements are equal
+
+    // 1) Outer and inner dimensions
+    bool eq =       (A.outerSize() == B.outerSize());
+    eq      = eq && (A.innerSize() == B.innerSize());
+
+    // 2) Equal number of non-zero elements
+    eq      = eq && (A.nonZeros() == B.nonZeros());
+
+    for (typename Eigen::SparseMatrix<double>::Index
+             k0 = 0, kend = A.outerSize(); eq && (k0 < kend); ++k0) {
+        for (typename Eigen::SparseMatrix<double>::InnerIterator
+                 iA(A, k0), iB(B, k0); eq && (iA && iB); ++iA, ++iB) {
+            // 3) Sparsity structure
+            eq = (iA.row() == iB.row()) && (iA.col() == iB.col());
+
+            // 4) Equal non-zero elements
+            eq = eq && (iA.value() == iB.value());
+        }
+    }
+
+    return eq;
+
+    // Note: Investigate implementing this operator as
+    // return A.cwiseNotEqual(B).count() == 0;
+}
+
+
+BOOST_AUTO_TEST_CASE(function_fastSparseSum)
+{
+    // s1 has last entry.
+    {
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> s1(6, 1);
+        s1 << 1, 2, 0, 4, 0, 6;
+        Sp ss1(s1.sparseView());
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> s2(6, 1);
+        s2 << 0, 2, 3, 4, 0, 0;
+        Sp ss2(s2.sparseView());
+
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> r(6, 1);
+        r << 1, 4, 3, 8, 0, 6;
+        Sp reference(r.sparseView());
+
+        Sp sum;
+        Opm::fastSparseSum(ss1, ss2, sum);
+        for (int row = 0; row < sum.rows(); ++row) {
+            BOOST_CHECK_EQUAL(sum.coeff(row, 0), reference.coeff(row, 0));
+        }
+    }
+    // s2 has last entry.
+    {
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> s1(6, 1);
+        s1 << 1, 2, 0, 4, 0, 0;
+        Sp ss1(s1.sparseView());
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> s2(6, 1);
+        s2 << 0, 2, 3, 4, 0, 6;
+        Sp ss2(s2.sparseView());
+
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> r(6, 1);
+        r << 1, 4, 3, 8, 0, 6;
+        Sp reference(r.sparseView());
+
+        Sp sum;
+        Opm::fastSparseSum(ss1, ss2, sum);
+        for (int row = 0; row < sum.rows(); ++row) {
+            BOOST_CHECK_EQUAL(sum.coeff(row, 0), reference.coeff(row, 0));
+        }
+    }
+    // Both have last entry.
+    {
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> s1(6, 1);
+        s1 << 1, 2, 0, 4, 5, 0;
+        Sp ss1(s1.sparseView());
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> s2(6, 1);
+        s2 << 0, 2, 3, 4, 5, 0;
+        Sp ss2(s2.sparseView());
+
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> r(6, 1);
+        r << 1, 4, 3, 8, 10, 0;
+        Sp reference(r.sparseView());
+
+        Sp sum;
+        Opm::fastSparseSum(ss1, ss2, sum);
+        for (int row = 0; row < sum.rows(); ++row) {
+            BOOST_CHECK_EQUAL(sum.coeff(row, 0), reference.coeff(row, 0));
+        }
+    }
+    // Random structures.
+    {
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> s1(2, 3);
+        s1 << 1, 2, 0, 4, 5, 0;
+        Sp ss1(s1.sparseView());
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> s2(2, 3);
+        s2 << 0, 2, 3, 4, 5, 0;
+        Sp ss2(s2.sparseView());
+
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> r(2, 3);
+        r << 1, 4, 3, 8, 10, 0;
+        Sp reference(r.sparseView());
+
+        Sp sum;
+        Opm::fastSparseSum(ss1, ss2, sum);
+        for (int row = 0; row < sum.rows(); ++row) {
+            BOOST_CHECK(sum == ss1 + ss2);
+        }
+    }
+    // With a zero column.
+    {
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> s1(2, 3);
+        s1 << 1, 2, 0, 4, 5, 0;
+        Sp ss1(s1.sparseView());
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> s2(2, 3);
+        s2 << 0, 2, 3, 4, 0, 0;
+        Sp ss2(s2.sparseView());
+
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> r(2, 3);
+        r << 1, 4, 3, 8, 5, 0;
+        Sp reference(r.sparseView());
+
+        Sp sum;
+        Opm::fastSparseSum(ss1, ss2, sum);
+        for (int row = 0; row < sum.rows(); ++row) {
+            BOOST_CHECK(sum == ss1 + ss2);
+        }
+    }
+}
+


### PR DESCRIPTION
This implements an alternative addition function fastSparseSum() for Eigen::SparseMatrix, similar to the alternative multiplication function provided by fastSparseProduct().

Speed improvement approx 0.5 sec for an SPE9 runtime of ~21 sec (approx. 2.5%), should carry fully over to other cases.

Testing with Norne in progress, will report here.