### PR TITLE
Start Flow from restart file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,5 +124,24 @@ endif (NOT EIGEN3_FOUND)
 
 
 if (HAVE_OPM_DATA)
-   add_test( NAME flow_SPE1 COMMAND flow ${OPM_DATA_ROOT}/spe1/SPE1CASE1.DATA )
+    add_test( NAME flow_SPE1 COMMAND flow ${OPM_DATA_ROOT}/spe1/SPE1CASE1.DATA )
+
+    add_test( NAME flow_SPE1CASE2 COMMAND flow ${OPM_DATA_ROOT}/spe1/SPE1CASE2.DATA )
+    add_test( NAME flow_SPE1CASE2_restart COMMAND flow ${OPM_DATA_ROOT}/spe1/SPE1CASE2_RESTART.DATA )
+
+    set_tests_properties(flow_SPE1CASE2_restart PROPERTIES DEPENDS flow_SPE1CASE2) # Dependes on the restart file from test flow_SPE1CASE2
+
+    add_executable( test_restart tests/test_restart.cpp )
+    target_link_libraries( test_restart opmautodiff ${Boost_LIBRARIES})
+
+    add_test( compare_restart_files
+            ${CMAKE_BINARY_DIR}/bin/test_restart
+             SPE1CASE2.UNRST
+             SPE1CASE2_RESTART.UNRST # Restart from step 60
+             120
+            )
+
+    set_tests_properties(compare_restart_files PROPERTIES DEPENDS flow_SPE1CASE2_restart) # Compares the restart files from tests flow_SPE1CASE2_restart and flow_SPE1CASE2
+
+
 endif()

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -79,6 +79,7 @@
 #include <opm/parser/eclipse/EclipseState/checkDeck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
 
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string.hpp>
@@ -583,7 +584,8 @@ namespace Opm
             SimulatorTimer simtimer;
 
             // initialize variables
-            simtimer.init(timeMap);
+            const auto initConfig = eclipse_state_->getInitConfig();
+            simtimer.init(timeMap, initConfig->getRestartInitiated(), (size_t)initConfig->getRestartStep());
 
 
 

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -81,6 +81,12 @@ namespace Opm
     {
         WellState prev_well_state;
 
+
+		if (output_writer_.isRestart()) {
+			// This is a restart, populate WellState and ReservoirState state objects from restart file
+			output_writer_.initFromRestartFile(props_.phaseUsage(), props_.permeability(), grid_, state, prev_well_state);
+		}
+
         // Create timers and file for writing timing info.
         Opm::time::StopWatch solver_timer;
         double stime = 0.0;
@@ -143,6 +149,7 @@ namespace Opm
 
             // write simulation state at the report stage
             output_writer_.writeTimeStep( timer, state, well_state );
+
 
             // Max oil saturation (for VPPARS), hysteresis update.
             props_.updateSatOilMax(state.saturation());

--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -169,6 +169,13 @@ namespace Opm
             }
         }
 
+        template <class State>
+        void resize(const Wells* wells, const State& state) {
+            const WellStateFullyImplicitBlackoil dummy_state; //Init with an empty previous state only resizes
+            init(wells, state, dummy_state) ;
+        }
+
+
         /// One rate per phase and well connection.
         std::vector<double>& perfPhaseRates() { return perfphaserates_; }
         const std::vector<double>& perfPhaseRates() const { return perfphaserates_; }

--- a/tests/test_restart.cpp
+++ b/tests/test_restart.cpp
@@ -1,0 +1,73 @@
+/*
+  Copyright 2014 SINTEF ICT, Applied Mathematics.
+  Copyright 2015 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#define BOOST_TEST_MODULE RestartTests
+
+#include <iostream>
+#include <map>
+
+#include <ert/ecl/ecl_rst_file.h>
+#include <ert/ecl/ecl_kw.h>
+
+#include <boost/test/unit_test.hpp>
+
+
+BOOST_AUTO_TEST_CASE(CompareRestartFileResults)
+{
+    const std::string& filename1 = boost::unit_test::framework::master_test_suite().argv[1];
+    const std::string& filename2 = boost::unit_test::framework::master_test_suite().argv[2];
+    int last_report_step = std::atoi(boost::unit_test::framework::master_test_suite().argv[3]);
+
+    std::map<std::string, double> relative_diffs;
+    relative_diffs["SWAT"]     = 0.000200;  //0.02 %
+    relative_diffs["SGAS"]     = 0.000200;
+
+    relative_diffs["RS"]       = 0.000010;  //0.001 %
+    relative_diffs["RV"]       = 0.000010;
+    relative_diffs["PRESSURE"] = 0.000010;
+
+    ecl_file_type*  file1 =  ecl_file_open_rstblock_report_step( filename1.c_str() , last_report_step, 1);
+    ecl_file_type*  file2 =  ecl_file_open_rstblock_report_step( filename2.c_str() , last_report_step, 1);
+
+    for (auto key : {"PRESSURE", "SWAT", "SGAS", "RS", "RV"}) {
+        ecl_kw_type * kw_1 =  ecl_file_iget_named_kw( file1 , key, 0);
+        ecl_kw_type * kw_2 =  ecl_file_iget_named_kw( file2 , key, 0);
+
+        bool numeric_equal = ecl_kw_numeric_equal(kw_1, kw_2, relative_diffs[key]);
+        if (numeric_equal) {
+            std::cout << " Restart results for " << key << " compared ok" << std::endl;
+        } else {
+            std::cout << " Restart results for " << key << " not ok, failing test " << std::endl;
+        }
+
+        BOOST_CHECK_EQUAL(numeric_equal, true);
+    }
+
+    ecl_file_close(file1);
+    ecl_file_close(file2);
+}
+
+


### PR DESCRIPTION
@dr-robertk : Now the code is moved to the BlackoilOutputWriter class to have IO in one place. The names of the new methods (initFromRestartFile, isRestart..) does not go well with the "Writer" part of the classname, but this code is soon to be refactored i guess (IO will be moved to parser) so I think the names are good for now. 


This PR includes the following:

- If a restart have been initiated with the keywords RESTART and SKIPREST, 
  WellState and ReservoirState are initialized with OPM_XWEL and SOLUTION data from the restart file,   respectively. 
For now the following data is read from restart file:
Solution data:   pressure, temperature, saturation, RS and RV
XWEL data:   temperature, bhp, perfpress, perfrates, wellrates

- The current time of the simulator timer are set to the start of the report step to be restarted from

- Due to the use of a OPM proprietary kewyword OPM_XWEL; restart of Flow is only supported for restart files written by Flow itself, and not by Eclipse. 

The restart have been tested on SPE1CASE2.DATA (added restart keywords).
A restart vs regular run gives the same results for restarting from report steps ca 50-121 for this case, for restarts from steps before this the results starts to diverge with decreasing restart step. 

It has not been paid any attention to the MPI functionality when implementing this.


