### PR TITLE
OPM-163: Changed signature for method extractPvtTableIndex

### DIFF
--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -158,7 +158,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
 
         // retrieve the cell specific PVT table index from the deck
         // and using the grid...
-        extractPvtTableIndex(cellPvtRegionIdx_, deck, number_of_cells, global_cell);
+        extractPvtTableIndex(cellPvtRegionIdx_, eclState, number_of_cells, global_cell);
 
         if (init_rock){
             rock_.init(eclState, number_of_cells, global_cell, cart_dims);


### PR DESCRIPTION
Change due to change in method signature for method extractPvtTableIndex() in opm-core. 
Must be merged together with 
https://github.com/OPM/opm-core/pull/940
