### PR TITLE
Fix change in signature of extractPvtTableIndex() in solvent props.

### DIFF
--- a/opm/autodiff/SolventPropsAdFromDeck.cpp
+++ b/opm/autodiff/SolventPropsAdFromDeck.cpp
@@ -39,7 +39,7 @@ SolventPropsAdFromDeck::SolventPropsAdFromDeck(DeckConstPtr deck,
     if (deck->hasKeyword("SOLVENT")) {
         // retrieve the cell specific PVT table index from the deck
         // and using the grid...
-        extractPvtTableIndex(cellPvtRegionIdx_, deck, number_of_cells, global_cell);
+        extractPvtTableIndex(cellPvtRegionIdx_, eclState, number_of_cells, global_cell);
 
         // surface densities
         if (deck->hasKeyword("SDENSITY")) {


### PR DESCRIPTION
This change was missing for some reason in #569.

Will self-merge as this is a small but critical fix.

I wonder how this could happen, though?