### PR TITLE
Fixes includes wrt opm-parser PR-656

### DIFF
--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -78,6 +78,7 @@
 #include <opm/parser/eclipse/Parser/ParseMode.hpp>
 #include <opm/parser/eclipse/EclipseState/checkDeck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string.hpp>

--- a/opm/autodiff/GeoProps.hpp
+++ b/opm/autodiff/GeoProps.hpp
@@ -28,6 +28,7 @@
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
 #include <opm/core/grid/PinchProcessor.hpp>
 #include <opm/common/utility/platform_dependent/disable_warnings.h>

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -21,6 +21,8 @@
 
 #include <algorithm>
 
+#include <opm/parser/eclipse/EclipseState/Schedule/Events.hpp>
+
 namespace Opm
 {
 

--- a/opm/autodiff/SolventPropsAdFromDeck.cpp
+++ b/opm/autodiff/SolventPropsAdFromDeck.cpp
@@ -21,6 +21,9 @@
 #include <opm/autodiff/SolventPropsAdFromDeck.hpp>
 #include <opm/autodiff/AutoDiffHelpers.hpp>
 
+#include <opm/parser/eclipse/EclipseState/Tables/PvdsTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/SsfnTable.hpp>
+
 
 namespace Opm
 {

--- a/opm/autodiff/WellMultiSegment.cpp
+++ b/opm/autodiff/WellMultiSegment.cpp
@@ -19,6 +19,8 @@
 */
 
 #include <opm/autodiff/WellMultiSegment.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/CompletionSet.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
 
 
 namespace Opm

--- a/opm/polymer/PolymerProperties.hpp
+++ b/opm/polymer/PolymerProperties.hpp
@@ -22,6 +22,14 @@
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PlyadsTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PlymaxTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PlyrockTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PlyviscTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
+
 
 #include <cmath>
 #include <vector>

--- a/tests/test_vfpproperties.cpp
+++ b/tests/test_vfpproperties.cpp
@@ -43,6 +43,7 @@
 #include <opm/parser/eclipse/EclipseState/checkDeck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/VFPProdTable.hpp>
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
 #include <opm/autodiff/VFPProperties.hpp>
 #include <opm/autodiff/VFPProdProperties.hpp>


### PR DESCRIPTION
Several files stopped compiling due to relying on opm-parser headers doing
includes. From opm-parser PR-656 https://github.com/OPM/opm-parser/pull/656
this assumption is no longer valid.