### PR TITLE
use the blackoil PVT classes from opm-material instead of the opm-core ones

### DIFF
--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -431,11 +431,11 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
 
         LadEval pLad = 0.0;
         LadEval TLad = 0.0;
-        LadEval RsLad = 0.0;
+        LadEval RvLad = 0.0;
         LadEval muLad;
 
         pLad.derivatives[0] = 1.0;
-        RsLad.derivatives[1] = 1.0;
+        RvLad.derivatives[1] = 1.0;
 
         for (int i = 0; i < n; ++i) {
             unsigned pvtRegionIdx = cellPvtRegionIdx_[cells[i]];
@@ -446,8 +446,8 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
                 muLad = gasPvt_->saturatedViscosity(pvtRegionIdx, TLad, pLad);
             }
             else {
-                RsLad.value = rv.value()[i];
-                muLad = gasPvt_->viscosity(pvtRegionIdx, TLad, pLad, RsLad);
+                RvLad.value = rv.value()[i];
+                muLad = gasPvt_->viscosity(pvtRegionIdx, TLad, pLad, RvLad);
             }
 
             mu[i] = muLad.value;
@@ -482,7 +482,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
                                       const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Water]) {
-            OPM_THROW(std::runtime_error, "Cannot call muWat(): water phase not active.");
+            OPM_THROW(std::runtime_error, "Cannot call bWat(): water phase not active.");
         }
         const int n = cells.size();
         assert(pw.size() == n);
@@ -532,7 +532,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
                                       const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Oil]) {
-            OPM_THROW(std::runtime_error, "Cannot call muOil(): oil phase not active.");
+            OPM_THROW(std::runtime_error, "Cannot call bOil(): oil phase not active.");
         }
         const int n = cells.size();
         assert(po.size() == n);
@@ -597,7 +597,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
                                       const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Gas]) {
-            OPM_THROW(std::runtime_error, "Cannot call muGas(): gas phase not active.");
+            OPM_THROW(std::runtime_error, "Cannot call bGas(): gas phase not active.");
         }
         const int n = cells.size();
         assert(pg.size() == n);

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -29,6 +29,12 @@
 #include <opm/core/props/satfunc/SaturationPropsFromDeck.hpp>
 #include <opm/core/props/rock/RockFromDeck.hpp>
 
+#include <opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp>
+#include <opm/material/localad/Math.hpp>
+#include <opm/material/localad/Evaluation.hpp>
+
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 
@@ -59,6 +65,10 @@ namespace Opm
     {
         friend class BlackoilPropsDataHandle;
     public:
+        typedef Opm::GasPvtMultiplexer<double> GasPvt;
+        typedef Opm::OilPvtMultiplexer<double> OilPvt;
+        typedef Opm::WaterPvtMultiplexer<double> WaterPvt;
+
         typedef typename SaturationPropsFromDeck::MaterialLawManager MaterialLawManager;
 
         /// Constructor to create a blackoil properties from an ECL deck.
@@ -392,9 +402,6 @@ namespace Opm
                       const std::vector<int>& cells,
                       const double vap) const;
 
-        // Fills pvt_region_ with cellPvtRegionIdx_[cells].
-        void mapPvtRegions(const std::vector<int>& cells) const;
-
         RockFromDeck rock_;
 
         // This has to be a shared pointer as we must
@@ -409,15 +416,8 @@ namespace Opm
         // The PVT region which is to be used for each cell
         std::vector<int> cellPvtRegionIdx_;
 
-        // Used for storing the region-per-cell array computed in calls
-        // to pvt functions.
-        mutable std::vector<int> pvt_region_;
-
-        // The PVT properties. One object per active fluid phase.
-        std::vector<std::shared_ptr<Opm::PvtInterface> > props_;
-
         // Densities, one std::array per PVT region.
-        std::vector<std::array<double, BlackoilPhases::MaxNumPhases> > densities_;
+        std::vector<std::array<double, BlackoilPhases::MaxNumPhases> > surfaceDensity_;
 
         // VAPPARS
         double vap1_;
@@ -425,6 +425,9 @@ namespace Opm
         std::vector<double> satOilMax_;
         double vap_satmax_guard_;  //Threshold value to promote stability
 
+        std::shared_ptr<GasPvt> gasPvt_;
+        std::shared_ptr<OilPvt> oilPvt_;
+        std::shared_ptr<WaterPvt> waterPvt_;
     };
 } // namespace Opm
 


### PR DESCRIPTION
this PR replaces the PVT classes from opm-core by the ones provided by opm-material. to use it OPM/opm-material#114 is required.

Motivation
==

the main motivation for this change is the ability to properly handle temperature derivatives of the quantities. also, it is easier to add new features like "viscosibility" with the approach taken by the PVT classes of opm-material than it is to do this with the ones of opm-core. Finally, the computational performance seems to be slightly better with this (see below).

Performance
==

I mainly used the SPE9_CP dataset to compare performance. Each branch was run 10 times and the timing was measured (I also tried to configure my system in such a way that the measurement noise was reduced as much as possible: no turbo boost, no hyperthreading, fixed CPU freqencies, etc.). the results are:

- current master: 27.03 s average time (variance: ~1%)
- this PR: 26.50 s average time (variance: ~1.4%)
- comparison branch: 30.36  s average time (variance: ~2.8%)

using some vodoo math, this means that the opm-core PVT code uses about 3.86 seconds, while the opm-material one only needs about 3.33 seconds. This means that the opm-material PVT code is about 15% faster than the opm-core one.

while I have not done such extensive performance testing with the Norne deck (I only did a single run for each branch and also used my computer for something else during that time), the performance numbers seem to be consistent with the ones for SPE9. (2082.45, 2098.01 and 2138.99 for this PR, master and the comparison branch, respectively)

Correctness Testing Conducted
==

the branch https://github.com/andlaus/opm-autodiff/tree/PVT_compare is based on this PR and compares the value of _all_ PVT quantities with the ones computed by the opm-core PVT quantities for 9 decimal digits. with OPM/opm-core#947 applied, I made sure that the results are identical for the SPE1CASE2.DATA, SPE9_CP.DATA and NORNE_ATW2013.DATA from opm-data. I also ran it for a few report steps of "Model 2" until I ran out of patience. the number of linear and non-linear iterations was basically the same in all cases. (for some cases there were small differences, but these can be easily attributed to the numerical noise.)

TODO
==

- the opm-core PVT classes cannot yet be deleted as they are still used by the non-AD "intermediate layer" of opm-core. replacing them is my next item on the agenda.
- medium term, it would be beneficial for performance if the PVT quantities would be directly computed with derivatives in respect to the primary variables instead of using the chain rule. This would probably require rather extensive changes to how the AD objects are internally stored in opm-autodiff
- long term (i.e., probably "never" ;) the "medium" PVT layer, i.e. `Opm::BlackoilPropsAdFromDeck`, of opm-autodiff could be replaced by the fluid system of opm-material. this would definitely involve a lot of work do do performantly because currently there's no good way to create a fluid state based on the simulator state.