### PR TITLE
Add miscible effects to the solvent model 

### DIFF
--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -454,6 +454,8 @@ namespace Opm {
         computeMassFlux(const int               actph ,
                         const V&                transi,
                         const ADB&              kr    ,
+                        const ADB&              mu    ,
+                        const ADB&              rho    ,
                         const ADB&              p     ,
                         const SolutionState&    state );
 

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -925,7 +925,7 @@ namespace detail {
             // Compute initial accumulation contributions
             // and well connection pressures.
             asImpl().computeAccum(state0, 0);
-            asImpl().computeWellConnectionPressures(state0, well_state);        
+            asImpl().computeWellConnectionPressures(state0, well_state);
         }
 
         // OPM_AD_DISKVAL(state.pressure);

--- a/opm/autodiff/BlackoilSolventModel.hpp
+++ b/opm/autodiff/BlackoilSolventModel.hpp
@@ -237,7 +237,7 @@ namespace Opm {
         const std::vector<PhasePresence>
         phaseCondition() const {return this->phaseCondition_;}
 
-        void ToddLongstaffModel(std::vector<ADB> viscosity, std::vector<ADB> density, std::vector<ADB> saturations, const Opm::PhaseUsage pu);
+        void ToddLongstaffModel(std::vector<ADB>& viscosity, std::vector<ADB>& density, const std::vector<ADB>& saturations, const Opm::PhaseUsage pu);
 
 
 

--- a/opm/autodiff/BlackoilSolventModel.hpp
+++ b/opm/autodiff/BlackoilSolventModel.hpp
@@ -232,10 +232,10 @@ namespace Opm {
         phaseCondition() const {return this->phaseCondition_;}
 
         // compute effective viscosities (mu_eff_) and effective b factors (b_eff_)  using the ToddLongstaff model
-        void calculateEffectiveProperties(const SolutionState&  state);
+        void computeEffectiveProperties(const SolutionState&  state);
 
         // compute density and viscosity using the ToddLongstaff mixing model
-        void ToddLongstaffModel(std::vector<ADB>& viscosity, std::vector<ADB>& density, const std::vector<ADB>& saturations, const Opm::PhaseUsage pu);
+        void computeToddLongstaffMixing(std::vector<ADB>& viscosity, std::vector<ADB>& density, const std::vector<ADB>& saturations, const Opm::PhaseUsage pu);
 
     };
 

--- a/opm/autodiff/BlackoilSolventModel.hpp
+++ b/opm/autodiff/BlackoilSolventModel.hpp
@@ -63,6 +63,7 @@ namespace Opm {
         /// \param[in] has_vapoil          turn on vaporized oil feature
         /// \param[in] terminal_output     request output to cout/cerr
         /// \param[in] has_solvent         turn on solvent feature
+        /// \param[in] is_miscible         turn on miscible feature
         BlackoilSolventModel(const typename Base::ModelParameters&   param,
                              const Grid&                             grid,
                              const BlackoilPropsAdInterface&         fluid,
@@ -75,7 +76,8 @@ namespace Opm {
                              const bool                              has_disgas,
                              const bool                              has_vapoil,
                              const bool                              terminal_output,
-                             const bool                              has_solvent);
+                             const bool                              has_solvent,
+                             const bool                              is_miscible);
 
         /// Apply an update to the primary variables, chopped if appropriate.
         /// \param[in]      dx                updates to apply to primary variables
@@ -106,6 +108,8 @@ namespace Opm {
         const bool has_solvent_;
         const int solvent_pos_;
         const SolventPropsAdFromDeck& solvent_props_;
+        const bool is_miscible_;
+
 
         // Need to declare Base members we want to use here.
         using Base::grid_;

--- a/opm/autodiff/BlackoilSolventModel.hpp
+++ b/opm/autodiff/BlackoilSolventModel.hpp
@@ -147,9 +147,6 @@ namespace Opm {
         using Base::computePressures;
         using Base::computeGasPressure;
         using Base::applyThresholdPressures;
-        //using Base::fluidViscosity;
-        //using Base::fluidReciprocFVF;
-        //using Base::fluidDensity;
         using Base::fluidRsSat;
         using Base::fluidRvSat;
         using Base::poroMult;
@@ -167,9 +164,6 @@ namespace Opm {
 
         std::vector<ADB>
         computeRelPerm(const SolutionState& state) const;
-
-        void calculateEffectiveProperties(const SolutionState&  state);
-
 
         ADB
         fluidViscosity(const int               phase,
@@ -237,9 +231,11 @@ namespace Opm {
         const std::vector<PhasePresence>
         phaseCondition() const {return this->phaseCondition_;}
 
+        // compute effective viscosities (mu_eff_) and effective b factors (b_eff_)  using the ToddLongstaff model
+        void calculateEffectiveProperties(const SolutionState&  state);
+
+        // compute density and viscosity using the ToddLongstaff mixing model
         void ToddLongstaffModel(std::vector<ADB>& viscosity, std::vector<ADB>& density, const std::vector<ADB>& saturations, const Opm::PhaseUsage pu);
-
-
 
     };
 

--- a/opm/autodiff/BlackoilSolventModel.hpp
+++ b/opm/autodiff/BlackoilSolventModel.hpp
@@ -237,6 +237,9 @@ namespace Opm {
         const std::vector<PhasePresence>
         phaseCondition() const {return this->phaseCondition_;}
 
+        void ToddLongstaffModel(std::vector<ADB> viscosity, std::vector<ADB> density, std::vector<ADB> saturations, const Opm::PhaseUsage pu);
+
+
 
     };
 

--- a/opm/autodiff/BlackoilSolventModel.hpp
+++ b/opm/autodiff/BlackoilSolventModel.hpp
@@ -109,6 +109,8 @@ namespace Opm {
         const int solvent_pos_;
         const SolventPropsAdFromDeck& solvent_props_;
         const bool is_miscible_;
+        std::vector<ADB> mu_eff_;
+        std::vector<ADB> b_eff_;
 
 
         // Need to declare Base members we want to use here.
@@ -145,9 +147,9 @@ namespace Opm {
         using Base::computePressures;
         using Base::computeGasPressure;
         using Base::applyThresholdPressures;
-        using Base::fluidViscosity;
-        using Base::fluidReciprocFVF;
-        using Base::fluidDensity;
+        //using Base::fluidViscosity;
+        //using Base::fluidReciprocFVF;
+        //using Base::fluidDensity;
         using Base::fluidRsSat;
         using Base::fluidRvSat;
         using Base::poroMult;
@@ -165,6 +167,31 @@ namespace Opm {
 
         std::vector<ADB>
         computeRelPerm(const SolutionState& state) const;
+
+        void calculateEffectiveProperties(const SolutionState&  state);
+
+
+        ADB
+        fluidViscosity(const int               phase,
+                       const ADB&              p    ,
+                       const ADB&              temp ,
+                       const ADB&              rs   ,
+                       const ADB&              rv   ,
+                       const std::vector<PhasePresence>& cond) const;
+
+        ADB
+        fluidReciprocFVF(const int               phase,
+                         const ADB&              p    ,
+                         const ADB&              temp ,
+                         const ADB&              rs   ,
+                         const ADB&              rv   ,
+                         const std::vector<PhasePresence>& cond) const;
+
+        ADB
+        fluidDensity(const int  phase,
+                     const ADB& b,
+                     const ADB& rs,
+                     const ADB& rv) const;
 
         void
         makeConstantState(SolutionState& state) const;
@@ -202,6 +229,8 @@ namespace Opm {
         computeMassFlux(const int               actph ,
                         const V&                transi,
                         const ADB&              kr    ,
+                        const ADB&              mu    ,
+                        const ADB&              rho   ,
                         const ADB&              p     ,
                         const SolutionState&    state );
 

--- a/opm/autodiff/BlackoilSolventModel_impl.hpp
+++ b/opm/autodiff/BlackoilSolventModel_impl.hpp
@@ -712,7 +712,7 @@ namespace Opm {
 
     template <class Grid>
     void
-    BlackoilSolventModel<Grid>::calculateEffectiveProperties(const SolutionState&    state)
+    BlackoilSolventModel<Grid>::computeEffectiveProperties(const SolutionState&    state)
     {
         // Viscosity
         const Opm::PhaseUsage& pu = fluid_.phaseUsage();
@@ -767,7 +767,7 @@ namespace Opm {
         effective_saturations[solvent_pos_] = ss - sgcwmis;
 
         // Compute effective viscosities and densities
-        ToddLongstaffModel(viscosity, density, effective_saturations, pu);
+        computeToddLongstaffMixing(viscosity, density, effective_saturations, pu);
 
         // Store the computed volume factors and viscosities
         b_eff_[pu.phase_pos[ Water ]] = bw;
@@ -783,7 +783,7 @@ namespace Opm {
 
     template <class Grid>
     void
-    BlackoilSolventModel<Grid>::ToddLongstaffModel(std::vector<ADB>& viscosity, std::vector<ADB>& density, const std::vector<ADB>& saturations, const Opm::PhaseUsage pu)
+    BlackoilSolventModel<Grid>::computeToddLongstaffMixing(std::vector<ADB>& viscosity, std::vector<ADB>& density, const std::vector<ADB>& saturations, const Opm::PhaseUsage pu)
     {
         const int  nc = cells_.size();
         const V ones = V::Constant(nc, 1.0);
@@ -904,14 +904,14 @@ namespace Opm {
             // Compute initial accumulation contributions
             // and well connection pressures.
             if (is_miscible_) {
-                calculateEffectiveProperties(state0);
+                computeEffectiveProperties(state0);
             }
 
             computeAccum(state0, 0);
             computeWellConnectionPressures(state0, well_state);
         }
         if (is_miscible_) {
-            calculateEffectiveProperties(state);
+            computeEffectiveProperties(state);
         }
 
         // -------- Mass balance equations --------

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilSolvent.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilSolvent.hpp
@@ -131,6 +131,7 @@ namespace Opm
         bool has_solvent_;
         DeckConstPtr deck_;
         SolventPropsAdFromDeck solvent_props_;
+        bool is_miscible_;
 
     };
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilSolvent_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilSolvent_impl.hpp
@@ -54,9 +54,10 @@ namespace Opm
     , has_solvent_(has_solvent)
     , deck_(deck)
     , solvent_props_(solvent_props)
+    , is_miscible_(false)
     {
         if(deck->hasKeyword("MISCIBLE")) {
-            std::cerr << "MISICIBLE keyword is present. Mixing is not currently supported" << std::endl;
+            is_miscible_ = true;
         }
     }
 
@@ -80,7 +81,8 @@ namespace Opm
                                                       BaseType::has_disgas_,
                                                       BaseType::has_vapoil_,
                                                       BaseType::terminal_output_,
-                                                      has_solvent_));
+                                                      has_solvent_,
+                                                      is_miscible_));
 
         if (!BaseType::threshold_pressures_by_face_.empty()) {
             model->setThresholdPressures(BaseType::threshold_pressures_by_face_);

--- a/opm/autodiff/SolventPropsAdFromDeck.cpp
+++ b/opm/autodiff/SolventPropsAdFromDeck.cpp
@@ -300,34 +300,34 @@ ADB SolventPropsAdFromDeck::muSolvent(const ADB& pg,
 }
 
 ADB SolventPropsAdFromDeck::bSolvent(const ADB& pg,
-                                const Cells& cells) const
+                                     const Cells& cells) const
 {
     return SolventPropsAdFromDeck::makeADBfromTables(pg, cells, b_);
 
 }
 
 ADB SolventPropsAdFromDeck::gasRelPermMultiplier(const ADB& solventFraction,
-                                 const Cells& cells) const
+                                                 const Cells& cells) const
 {
     return SolventPropsAdFromDeck::makeADBfromTables(solventFraction, cells, krg_);
 
 }
 
 ADB SolventPropsAdFromDeck::solventRelPermMultiplier(const ADB& solventFraction,
-                                 const Cells& cells) const
+                                                     const Cells& cells) const
 {
     return SolventPropsAdFromDeck::makeADBfromTables(solventFraction, cells, krs_);
 }
 
 
 ADB SolventPropsAdFromDeck::misicibleHydrocarbonWaterRelPerm(const ADB& Sn,
-                                 const Cells& cells) const
+                                                             const Cells& cells) const
 {
     return SolventPropsAdFromDeck::makeADBfromTables(Sn, cells, krn_);
 }
 
 ADB SolventPropsAdFromDeck::miscibleSolventGasRelPermMultiplier(const ADB& Ssg,
-                                 const Cells& cells) const
+                                                                const Cells& cells) const
 {
     if (mkrsg_.size() > 0) {
         return SolventPropsAdFromDeck::makeADBfromTables(Ssg, cells, mkrsg_);
@@ -337,7 +337,7 @@ ADB SolventPropsAdFromDeck::miscibleSolventGasRelPermMultiplier(const ADB& Ssg,
 }
 
 ADB SolventPropsAdFromDeck::miscibleOilRelPermMultiplier(const ADB& So,
-                                 const Cells& cells) const
+                                                         const Cells& cells) const
 {
     if (mkro_.size() > 0) {
         return SolventPropsAdFromDeck::makeADBfromTables(So, cells, mkro_);
@@ -347,7 +347,7 @@ ADB SolventPropsAdFromDeck::miscibleOilRelPermMultiplier(const ADB& So,
 }
 
 ADB SolventPropsAdFromDeck::miscibilityFunction(const ADB& solventFraction,
-                                 const Cells& cells) const
+                                                const Cells& cells) const
 {
 
     return SolventPropsAdFromDeck::makeADBfromTables(solventFraction, cells, misc_);
@@ -355,7 +355,7 @@ ADB SolventPropsAdFromDeck::miscibilityFunction(const ADB& solventFraction,
 
 
 ADB SolventPropsAdFromDeck::miscibleCriticalGasSaturationFunction (const ADB& Sw,
-                                           const Cells& cells) const {
+                                                                   const Cells& cells) const {
     if (sgcwmis_.size()>0) {
         return SolventPropsAdFromDeck::makeADBfromTables(Sw, cells, sgcwmis_);
     }
@@ -365,7 +365,7 @@ ADB SolventPropsAdFromDeck::miscibleCriticalGasSaturationFunction (const ADB& Sw
 
 
 ADB SolventPropsAdFromDeck::miscibleResidualOilSaturationFunction (const ADB& Sw,
-                                           const Cells& cells) const {
+                                                                   const Cells& cells) const {
     if (sorwmis_.size()>0) {
         return SolventPropsAdFromDeck::makeADBfromTables(Sw, cells, sorwmis_);
     }
@@ -373,7 +373,9 @@ ADB SolventPropsAdFromDeck::miscibleResidualOilSaturationFunction (const ADB& Sw
     return ADB::constant(V::Zero(Sw.size()));
 }
 
-ADB SolventPropsAdFromDeck::makeADBfromTables(const ADB& X_AD, const Cells& cells, std::vector<NonuniformTableLinear<double>> table) const {
+ADB SolventPropsAdFromDeck::makeADBfromTables(const ADB& X_AD,
+                                              const Cells& cells,
+                                              const std::vector<NonuniformTableLinear<double>>& tables) const {
     const int n = cells.size();
     assert(X_AD.value().size() == n);
     V x(n);
@@ -381,8 +383,8 @@ ADB SolventPropsAdFromDeck::makeADBfromTables(const ADB& X_AD, const Cells& cell
     for (int i = 0; i < n; ++i) {
         const double& X_i = X_AD.value()[i];
         int regionIdx = 0; // TODO add mapping from cells to sat function table
-        x[i] = table[regionIdx](X_i);
-        dx[i] = table[regionIdx].derivative(X_i);
+        x[i] = tables[regionIdx](X_i);
+        dx[i] = tables[regionIdx].derivative(X_i);
     }
 
     ADB::M dx_diag(dx.matrix().asDiagonal());

--- a/opm/autodiff/SolventPropsAdFromDeck.cpp
+++ b/opm/autodiff/SolventPropsAdFromDeck.cpp
@@ -247,6 +247,31 @@ SolventPropsAdFromDeck::SolventPropsAdFromDeck(DeckConstPtr deck,
                 }
             }
 
+            if (deck->hasKeyword("TLMIXPAR")) {
+                const auto tlmixparRecord = deck->getKeyword("TLMIXPAR")->getRecord(0);
+                std::vector<double> mix_params_viscosity = tlmixparRecord->getItem("TL_VISCOSITY_PARAMETER")->getSIDoubleData();
+                const int numRegions = mix_params_viscosity.size();
+                if (numRegions > 1) {
+                    OPM_THROW(std::runtime_error, "Only singel miscibility region is supported for TLMIXPAR.");
+                }
+                mix_param_viscosity_ = mix_params_viscosity[0];
+
+                std::vector<double> mix_params_density = tlmixparRecord->getItem("TL_DENSITY_PARAMETER")->getSIDoubleData();
+                const int numDensityItems = mix_params_density.size();
+                if (numDensityItems == 0) {
+                    mix_param_density_ = mix_param_viscosity_;
+                } else if (numDensityItems == 1) {
+                    mix_param_density_ = mix_params_density[0];
+                } else {
+                    OPM_THROW(std::runtime_error, "Only singel miscibility region is supported for TLMIXPAR.");
+                }
+            } else {
+                mix_param_viscosity_ = 0.0;
+                mix_param_density_ = 0.0;
+            }
+
+
+
         }
     }
 
@@ -384,5 +409,14 @@ V SolventPropsAdFromDeck::solventSurfaceDensity(const Cells& cells) const {
     }
     return density;
 }
+
+double SolventPropsAdFromDeck::mixingParamterViscosity() const {
+    return mix_param_viscosity_;
+}
+
+double SolventPropsAdFromDeck::mixingParamterDensity() const {
+    return mix_param_density_;
+}
+
 
 } //namespace OPM

--- a/opm/autodiff/SolventPropsAdFromDeck.cpp
+++ b/opm/autodiff/SolventPropsAdFromDeck.cpp
@@ -23,6 +23,7 @@
 
 #include <opm/parser/eclipse/EclipseState/Tables/PvdsTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SsfnTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp>
 
 
 namespace Opm
@@ -138,8 +139,8 @@ SolventPropsAdFromDeck::SolventPropsAdFromDeck(DeckConstPtr deck,
 
                     // Copy data
                     // Sn = So + Sg + Ss;
-                    const std::vector<double>& sn = sof2Table.getSoColumn();
-                    const std::vector<double>& krn = sof2Table.getKroColumn();
+                    const auto& sn = sof2Table.getSoColumn();
+                    const auto& krn = sof2Table.getKroColumn();
 
                     for (size_t i = 0; i < sn.size(); ++i) {
                         std::cout << sn[i] << " " << krn[i] <<std::endl;
@@ -168,8 +169,8 @@ SolventPropsAdFromDeck::SolventPropsAdFromDeck(DeckConstPtr deck,
 
                     // Copy data
                     // solventFraction = Ss / (Ss + Sg);
-                    const std::vector<double>& solventFraction = miscTable.getSolventFractionColumn();
-                    const std::vector<double>& misc = miscTable.getMiscibilityColumn();
+                    const auto& solventFraction = miscTable.getSolventFractionColumn();
+                    const auto& misc = miscTable.getMiscibilityColumn();
 
                     misc_[regionIdx] = NonuniformTableLinear<double>(solventFraction, misc);
 
@@ -195,9 +196,9 @@ SolventPropsAdFromDeck::SolventPropsAdFromDeck(DeckConstPtr deck,
 
                     // Copy data
                     // Ssg = Ss + Sg;
-                    const std::vector<double>& Ssg = msfnTable.getGasPhaseFractionColumn();
-                    const std::vector<double>& krsg = msfnTable.getGasSolventRelpermMultiplierColumn();
-                    const std::vector<double>& kro = msfnTable.getOilRelpermMultiplierColumn();
+                    const auto& Ssg = msfnTable.getGasPhaseFractionColumn();
+                    const auto& krsg = msfnTable.getGasSolventRelpermMultiplierColumn();
+                    const auto& kro = msfnTable.getOilRelpermMultiplierColumn();
 
                     mkrsg_[regionIdx] = NonuniformTableLinear<double>(Ssg, krsg);
                     mkro_[regionIdx] = NonuniformTableLinear<double>(Ssg, kro);
@@ -219,8 +220,8 @@ SolventPropsAdFromDeck::SolventPropsAdFromDeck(DeckConstPtr deck,
                     const Opm::SorwmisTable& sorwmisTable = sorwmisTables.getTable<SorwmisTable>(regionIdx);
 
                     // Copy data
-                    const std::vector<double>& sw = sorwmisTable.getWaterSaturationColumn();
-                    const std::vector<double>& sorwmis = sorwmisTable.getMiscibleResidualOilColumn();
+                    const auto& sw = sorwmisTable.getWaterSaturationColumn();
+                    const auto& sorwmis = sorwmisTable.getMiscibleResidualOilColumn();
 
                     sorwmis_[regionIdx] = NonuniformTableLinear<double>(sw, sorwmis);
                 }
@@ -240,8 +241,8 @@ SolventPropsAdFromDeck::SolventPropsAdFromDeck(DeckConstPtr deck,
                     const Opm::SgcwmisTable& sgcwmisTable = sgcwmisTables.getTable<SgcwmisTable>(regionIdx);
 
                     // Copy data
-                    const std::vector<double>& sw = sgcwmisTable.getWaterSaturationColumn();
-                    const std::vector<double>& sgcwmis = sgcwmisTable.getMiscibleResidualGasColumn();
+                    const auto& sw = sgcwmisTable.getWaterSaturationColumn();
+                    const auto& sgcwmis = sgcwmisTable.getMiscibleResidualGasColumn();
 
                     sgcwmis_[regionIdx] = NonuniformTableLinear<double>(sw, sgcwmis);
                 }

--- a/opm/autodiff/SolventPropsAdFromDeck.cpp
+++ b/opm/autodiff/SolventPropsAdFromDeck.cpp
@@ -142,11 +142,6 @@ SolventPropsAdFromDeck::SolventPropsAdFromDeck(DeckConstPtr deck,
                     const auto& sn = sof2Table.getSoColumn();
                     const auto& krn = sof2Table.getKroColumn();
 
-                    for (size_t i = 0; i < sn.size(); ++i) {
-                        std::cout << sn[i] << " " << krn[i] <<std::endl;
-                    }
-
-
                     krn_[regionIdx] = NonuniformTableLinear<double>(sn, krn);
                 }
 
@@ -307,35 +302,35 @@ ADB SolventPropsAdFromDeck::muSolvent(const ADB& pg,
 ADB SolventPropsAdFromDeck::bSolvent(const ADB& pg,
                                 const Cells& cells) const
 {
-    return SolventPropsAdFromDeck::makeAD(pg, cells, b_);
+    return SolventPropsAdFromDeck::makeADBfromTables(pg, cells, b_);
 
 }
 
 ADB SolventPropsAdFromDeck::gasRelPermMultiplier(const ADB& solventFraction,
                                  const Cells& cells) const
 {
-    return SolventPropsAdFromDeck::makeAD(solventFraction, cells, krg_);
+    return SolventPropsAdFromDeck::makeADBfromTables(solventFraction, cells, krg_);
 
 }
 
 ADB SolventPropsAdFromDeck::solventRelPermMultiplier(const ADB& solventFraction,
                                  const Cells& cells) const
 {
-    return SolventPropsAdFromDeck::makeAD(solventFraction, cells, krs_);
+    return SolventPropsAdFromDeck::makeADBfromTables(solventFraction, cells, krs_);
 }
 
 
 ADB SolventPropsAdFromDeck::misicibleHydrocarbonWaterRelPerm(const ADB& Sn,
                                  const Cells& cells) const
 {
-    return SolventPropsAdFromDeck::makeAD(Sn, cells, krn_);
+    return SolventPropsAdFromDeck::makeADBfromTables(Sn, cells, krn_);
 }
 
 ADB SolventPropsAdFromDeck::miscibleSolventGasRelPermMultiplier(const ADB& Ssg,
                                  const Cells& cells) const
 {
     if (mkrsg_.size() > 0) {
-        return SolventPropsAdFromDeck::makeAD(Ssg, cells, mkrsg_);
+        return SolventPropsAdFromDeck::makeADBfromTables(Ssg, cells, mkrsg_);
     }
     // trivial function if not specified
     return Ssg;
@@ -345,7 +340,7 @@ ADB SolventPropsAdFromDeck::miscibleOilRelPermMultiplier(const ADB& So,
                                  const Cells& cells) const
 {
     if (mkro_.size() > 0) {
-        return SolventPropsAdFromDeck::makeAD(So, cells, mkro_);
+        return SolventPropsAdFromDeck::makeADBfromTables(So, cells, mkro_);
     }
     // trivial function if not specified
     return So;
@@ -355,14 +350,14 @@ ADB SolventPropsAdFromDeck::miscibilityFunction(const ADB& solventFraction,
                                  const Cells& cells) const
 {
 
-    return SolventPropsAdFromDeck::makeAD(solventFraction, cells, misc_);
+    return SolventPropsAdFromDeck::makeADBfromTables(solventFraction, cells, misc_);
 }
 
 
 ADB SolventPropsAdFromDeck::miscibleCriticalGasSaturationFunction (const ADB& Sw,
                                            const Cells& cells) const {
     if (sgcwmis_.size()>0) {
-        return SolventPropsAdFromDeck::makeAD(Sw, cells, sgcwmis_);
+        return SolventPropsAdFromDeck::makeADBfromTables(Sw, cells, sgcwmis_);
     }
     // return zeros if not specified
     return ADB::constant(V::Zero(Sw.size()));
@@ -372,15 +367,15 @@ ADB SolventPropsAdFromDeck::miscibleCriticalGasSaturationFunction (const ADB& Sw
 ADB SolventPropsAdFromDeck::miscibleResidualOilSaturationFunction (const ADB& Sw,
                                            const Cells& cells) const {
     if (sorwmis_.size()>0) {
-        return SolventPropsAdFromDeck::makeAD(Sw, cells, sorwmis_);
+        return SolventPropsAdFromDeck::makeADBfromTables(Sw, cells, sorwmis_);
     }
     // return zeros if not specified
     return ADB::constant(V::Zero(Sw.size()));
 }
 
-ADB SolventPropsAdFromDeck::makeAD(const ADB& X_AD, const Cells& cells, std::vector<NonuniformTableLinear<double>> table) const {
+ADB SolventPropsAdFromDeck::makeADBfromTables(const ADB& X_AD, const Cells& cells, std::vector<NonuniformTableLinear<double>> table) const {
     const int n = cells.size();
-    assert(Sn.value().size() == n);
+    assert(X_AD.value().size() == n);
     V x(n);
     V dx(n);
     for (int i = 0; i < n; ++i) {
@@ -411,11 +406,11 @@ V SolventPropsAdFromDeck::solventSurfaceDensity(const Cells& cells) const {
     return density;
 }
 
-double SolventPropsAdFromDeck::mixingParamterViscosity() const {
+double SolventPropsAdFromDeck::mixingParameterViscosity() const {
     return mix_param_viscosity_;
 }
 
-double SolventPropsAdFromDeck::mixingParamterDensity() const {
+double SolventPropsAdFromDeck::mixingParameterDensity() const {
     return mix_param_density_;
 }
 

--- a/opm/autodiff/SolventPropsAdFromDeck.hpp
+++ b/opm/autodiff/SolventPropsAdFromDeck.hpp
@@ -56,71 +56,71 @@ public:
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n formation volume factor values.
     ADB bSolvent(const ADB& pg,
-             const Cells& cells) const;
+                 const Cells& cells) const;
 
     /// Solvent viscosity.
     /// \param[in]  pg     Array of n gas pressure values.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n viscosity values.
     ADB muSolvent(const ADB& pg,
-              const Cells& cells) const;
+                  const Cells& cells) const;
 
     /// Gas relPerm multipliers
     /// \param[in]  gasFraction     Array of n gas fraction Sg / (sg + Ss) values.
     /// \param[in]  cells           Array of n cell indices to be associated with the fraction values.
     /// \return                     Array of n gas relPerm multiplier values.
     ADB gasRelPermMultiplier(const ADB& solventFraction,
-              const Cells& cells) const;
+                             const Cells& cells) const;
 
     /// Solvent relPerm multipliers
     /// \param[in]  solventFraction Array of n solvent fraction Ss / (Sg + Ss) values.
     /// \param[in]  cells           Array of n cell indices to be associated with the fraction values.
     /// \return                     Array of n solvent relPerm multiplier values.
     ADB solventRelPermMultiplier(const ADB& solventFraction,
-              const Cells& cells) const;
+                                 const Cells& cells) const;
 
     /// Miscible hydrocrabon relPerm wrt water
     /// \param[in]  Sn              Array of n total hyrdrocarbon saturation values.
     /// \param[in]  cells           Array of n cell indices to be associated with the fraction values.
     /// \return                     Array of n miscible hyrdrocabon wrt water relPerm values.
     ADB misicibleHydrocarbonWaterRelPerm(const ADB& Sn,
-              const Cells& cells) const;
+                                         const Cells& cells) const;
 
-    /// Miscible Solvent + Gas relPerm multipleier
+    /// Miscible Solvent + Gas relPerm multiplier
     /// \param[in]  Ssg             Array of n total gas fraction (Sgas + Ssolvent) / Sn values, where
     ///                             Sn = Sgas + Ssolvent + Soil.
     /// \param[in]  cells           Array of n cell indices to be associated with the fraction values.
     /// \return                     Array of n solvent gas relperm multiplier.
-    ADB miscibleSolventGasRelPermMultiplier (const ADB& Ssg,
-              const Cells& cells) const;
+    ADB miscibleSolventGasRelPermMultiplier(const ADB& Ssg,
+                                            const Cells& cells) const;
 
-    /// Miscible Oil relPerm multipleier
+    /// Miscible Oil relPerm multiplier
     /// \param[in]  So              Array of n oil fraction values. Soil / Sn values, where Sn = Sgas + Ssolvent + Soil.
     /// \param[in]  cells           Array of n cell indices to be associated with the fraction values.
     /// \return                     Array of n oil relperm multiplier.
-    ADB miscibleOilRelPermMultiplier (const ADB& So,
-              const Cells& cells) const;
+    ADB miscibleOilRelPermMultiplier(const ADB& So,
+                                     const Cells& cells) const;
 
     /// Miscible function
     /// \param[in]  solventFraction Array of n solvent fraction Ss / (Sg + Ss) values.
     /// \param[in]  cells           Array of n cell indices to be associated with the fraction values.
     /// \return                     Array of n miscibility values
-    ADB miscibilityFunction (const ADB& solventFraction,
-              const Cells& cells) const;
+    ADB miscibilityFunction(const ADB& solventFraction,
+                            const Cells& cells) const;
 
     /// Miscible critical gas saturation function
     /// \param[in]  Sw              Array of n water saturation values.
     /// \param[in]  cells           Array of n cell indices to be associated with the saturation values.
     /// \return                     Array of n miscible critical gas saturation values
-    ADB miscibleCriticalGasSaturationFunction (const ADB& Sw,
-                                               const Cells& cells) const;
+    ADB miscibleCriticalGasSaturationFunction(const ADB& Sw,
+                                              const Cells& cells) const;
 
     /// Miscible residual oil saturation function
     /// \param[in]  Sw              Array of n water saturation values.
     /// \param[in]  cells           Array of n cell indices to be associated with the saturation values.
     /// \return                     Array of n miscible residual oil saturation values
-    ADB miscibleResidualOilSaturationFunction (const ADB& Sw,
-                                               const Cells& cells) const;
+    ADB miscibleResidualOilSaturationFunction(const ADB& Sw,
+                                              const Cells& cells) const;
 
     /// Solvent surface density
     /// \param[in]  cells           Array of n cell indices to be associated with the fraction values.
@@ -137,7 +137,13 @@ public:
 private:
 
     /// Makes ADB from table values
-    ADB makeADBfromTables(const ADB& X, const Cells& cells,     std::vector<NonuniformTableLinear<double> > table) const;
+    /// \param[in]  X               Array of n table lookup values.
+    /// \param[in]  cells           Array of n cell indices to be associated with the fraction values.
+    /// \param[in]  tables           Vector of tables, one for each PVT region.
+    /// \return                     Array of n solvent density values.
+    ADB makeADBfromTables(const ADB& X,
+                          const Cells& cells,
+                          const std::vector<NonuniformTableLinear<double>>& tables) const;
 
     // The PVT region which is to be used for each cell
     std::vector<int> cellPvtRegionIdx_;

--- a/opm/autodiff/SolventPropsAdFromDeck.hpp
+++ b/opm/autodiff/SolventPropsAdFromDeck.hpp
@@ -101,6 +101,13 @@ public:
     ADB miscibleOilRelPermMultiplier (const ADB& So,
               const Cells& cells) const;
 
+    /// Miscible function
+    /// \param[in]  solventFraction Array of n solvent fraction Ss / (Sg + Ss) values.
+    /// \param[in]  cells           Array of n cell indices to be associated with the fraction values.
+    /// \return                     Array of n miscibility values
+    ADB miscibilityFunction (const ADB& solventFraction,
+              const Cells& cells) const;
+
     /// Solvent surface density
     /// \param[in]  cells           Array of n cell indices to be associated with the fraction values.
     /// \return                     Array of n solvent density values.
@@ -121,6 +128,7 @@ private:
     std::vector<NonuniformTableLinear<double> > krn_;
     std::vector<NonuniformTableLinear<double> > mkro_;
     std::vector<NonuniformTableLinear<double> > mkrsg_;
+    std::vector<NonuniformTableLinear<double> > misc_;
 };
 
 } // namespace OPM

--- a/opm/autodiff/SolventPropsAdFromDeck.hpp
+++ b/opm/autodiff/SolventPropsAdFromDeck.hpp
@@ -66,17 +66,39 @@ public:
               const Cells& cells) const;
 
     /// Gas relPerm multipliers
-    /// \param[in]  solventFraction Array of n solvent fraction values.
+    /// \param[in]  gasFraction     Array of n gas fraction Sg / (sg + Ss) values.
     /// \param[in]  cells           Array of n cell indices to be associated with the fraction values.
     /// \return                     Array of n gas relPerm multiplier values.
     ADB gasRelPermMultiplier(const ADB& solventFraction,
               const Cells& cells) const;
 
     /// Solvent relPerm multipliers
-    /// \param[in]  solventFraction Array of n solvent fraction values.
+    /// \param[in]  solventFraction Array of n solvent fraction Ss / (Sg + Ss) values.
     /// \param[in]  cells           Array of n cell indices to be associated with the fraction values.
     /// \return                     Array of n solvent relPerm multiplier values.
     ADB solventRelPermMultiplier(const ADB& solventFraction,
+              const Cells& cells) const;
+
+    /// Miscible hydrocrabon relPerm wrt water
+    /// \param[in]  Sn              Array of n total hyrdrocarbon saturation values.
+    /// \param[in]  cells           Array of n cell indices to be associated with the fraction values.
+    /// \return                     Array of n miscible hyrdrocabon wrt water relPerm values.
+    ADB misicibleHydrocarbonWaterRelPerm(const ADB& Sn,
+              const Cells& cells) const;
+
+    /// Miscible Solvent + Gas relPerm multipleier
+    /// \param[in]  Ssg             Array of n total gas fraction (Sgas + Ssolvent) / Sn values, where
+    ///                             Sn = Sgas + Ssolvent + Soil.
+    /// \param[in]  cells           Array of n cell indices to be associated with the fraction values.
+    /// \return                     Array of n solvent gas relperm multiplier.
+    ADB miscibleSolventGasRelPermMultiplier (const ADB& Ssg,
+              const Cells& cells) const;
+
+    /// Miscible Oil relPerm multipleier
+    /// \param[in]  So              Array of n oil fraction values. Soil / Sn values, where Sn = Sgas + Ssolvent + Soil.
+    /// \param[in]  cells           Array of n cell indices to be associated with the fraction values.
+    /// \return                     Array of n oil relperm multiplier.
+    ADB miscibleOilRelPermMultiplier (const ADB& So,
               const Cells& cells) const;
 
     /// Solvent surface density
@@ -85,6 +107,9 @@ public:
     V solventSurfaceDensity(const Cells& cells) const;
 
 private:
+
+    ADB makeAD(const ADB& X, const Cells& cells,     std::vector<NonuniformTableLinear<double> > table) const;
+
     // The PVT region which is to be used for each cell
     std::vector<int> cellPvtRegionIdx_;
     std::vector<NonuniformTableLinear<double> > b_;
@@ -93,6 +118,9 @@ private:
     std::vector<double> solvent_surface_densities_;
     std::vector<NonuniformTableLinear<double> > krg_;
     std::vector<NonuniformTableLinear<double> > krs_;
+    std::vector<NonuniformTableLinear<double> > krn_;
+    std::vector<NonuniformTableLinear<double> > mkro_;
+    std::vector<NonuniformTableLinear<double> > mkrsg_;
 };
 
 } // namespace OPM

--- a/opm/autodiff/SolventPropsAdFromDeck.hpp
+++ b/opm/autodiff/SolventPropsAdFromDeck.hpp
@@ -127,16 +127,17 @@ public:
     /// \return                     Array of n solvent density values.
     V solventSurfaceDensity(const Cells& cells) const;
 
-    /// Todd-Longstaff mixing paramter for viscosity calculation
-    double mixingParamterViscosity() const;
+    /// Todd-Longstaff mixing parameter for viscosity calculation
+    double mixingParameterViscosity() const;
 
-    /// Todd-Longstaff mixing paramter for density calculation
-    double mixingParamterDensity() const;
+    /// Todd-Longstaff mixing parameter for density calculation
+    double mixingParameterDensity() const;
 
 
 private:
 
-    ADB makeAD(const ADB& X, const Cells& cells,     std::vector<NonuniformTableLinear<double> > table) const;
+    /// Makes ADB from table values
+    ADB makeADBfromTables(const ADB& X, const Cells& cells,     std::vector<NonuniformTableLinear<double> > table) const;
 
     // The PVT region which is to be used for each cell
     std::vector<int> cellPvtRegionIdx_;

--- a/opm/autodiff/SolventPropsAdFromDeck.hpp
+++ b/opm/autodiff/SolventPropsAdFromDeck.hpp
@@ -108,6 +108,20 @@ public:
     ADB miscibilityFunction (const ADB& solventFraction,
               const Cells& cells) const;
 
+    /// Miscible critical gas saturation function
+    /// \param[in]  Sw              Array of n water saturation values.
+    /// \param[in]  cells           Array of n cell indices to be associated with the saturation values.
+    /// \return                     Array of n miscible critical gas saturation values
+    ADB miscibleCriticalGasSaturationFunction (const ADB& Sw,
+                                               const Cells& cells) const;
+
+    /// Miscible residual oil saturation function
+    /// \param[in]  Sw              Array of n water saturation values.
+    /// \param[in]  cells           Array of n cell indices to be associated with the saturation values.
+    /// \return                     Array of n miscible residual oil saturation values
+    ADB miscibleResidualOilSaturationFunction (const ADB& Sw,
+                                               const Cells& cells) const;
+
     /// Solvent surface density
     /// \param[in]  cells           Array of n cell indices to be associated with the fraction values.
     /// \return                     Array of n solvent density values.
@@ -129,6 +143,8 @@ private:
     std::vector<NonuniformTableLinear<double> > mkro_;
     std::vector<NonuniformTableLinear<double> > mkrsg_;
     std::vector<NonuniformTableLinear<double> > misc_;
+    std::vector<NonuniformTableLinear<double> > sorwmis_;
+    std::vector<NonuniformTableLinear<double> > sgcwmis_;
 };
 
 } // namespace OPM

--- a/opm/autodiff/SolventPropsAdFromDeck.hpp
+++ b/opm/autodiff/SolventPropsAdFromDeck.hpp
@@ -127,6 +127,13 @@ public:
     /// \return                     Array of n solvent density values.
     V solventSurfaceDensity(const Cells& cells) const;
 
+    /// Todd-Longstaff mixing paramter for viscosity calculation
+    double mixingParamterViscosity() const;
+
+    /// Todd-Longstaff mixing paramter for density calculation
+    double mixingParamterDensity() const;
+
+
 private:
 
     ADB makeAD(const ADB& X, const Cells& cells,     std::vector<NonuniformTableLinear<double> > table) const;
@@ -145,6 +152,8 @@ private:
     std::vector<NonuniformTableLinear<double> > misc_;
     std::vector<NonuniformTableLinear<double> > sorwmis_;
     std::vector<NonuniformTableLinear<double> > sgcwmis_;
+    double mix_param_viscosity_;
+    double mix_param_density_;
 };
 
 } // namespace OPM

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
@@ -238,6 +238,8 @@ namespace Opm {
         computeMassFlux(const int               actph ,
                         const V&                transi,
                         const ADB&              kr    ,
+                        const ADB&              mu    ,
+                        const ADB&              rho   ,
                         const ADB&              p     ,
                         const SolutionState&    state );
 

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
@@ -427,7 +427,6 @@ namespace Opm {
         const int canonicalPhaseIdx = canph_[ actph ];
         if (canonicalPhaseIdx == Water) {
             if (has_polymer_) {
-                const std::vector<PhasePresence>& cond = phaseCondition();
                 const ADB tr_mult = transMult(state.pressure);
                 const ADB cmax = ADB::constant(cmax_, state.concentration.blockPattern());
                 const ADB mc = computeMc(state);

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
@@ -300,7 +300,10 @@ namespace Opm {
         }
 
         for (int phaseIdx = 0; phaseIdx < fluid_.numPhases(); ++phaseIdx) {
-            computeMassFlux(phaseIdx, transi, kr[canph_[phaseIdx]], state.canonical_phase_pressures[canph_[phaseIdx]], state);
+            const std::vector<PhasePresence>& cond = phaseCondition();
+            const ADB mu = fluidViscosity(canph_[phaseIdx], state.canonical_phase_pressures[canph_[phaseIdx]], state.temperature, state.rs, state.rv, cond);
+            const ADB rho = fluidDensity(canph_[phaseIdx], rq_[phaseIdx].b, state.rs, state.rv);
+            computeMassFlux(phaseIdx, transi, kr[canph_[phaseIdx]], mu, rho, state.canonical_phase_pressures[canph_[phaseIdx]], state);
 
             residual_.material_balance_eq[ phaseIdx ] =
                 pvdt_ * (rq_[phaseIdx].accum[1] - rq_[phaseIdx].accum[0])
@@ -413,10 +416,12 @@ namespace Opm {
     BlackoilPolymerModel<Grid>::computeMassFlux(const int               actph ,
                                                 const V&                transi,
                                                 const ADB&              kr    ,
+                                                const ADB&              mu    ,
+                                                const ADB&              rho   ,
                                                 const ADB&              phasePressure,
                                                 const SolutionState&    state)
     {
-        Base::computeMassFlux(actph, transi, kr, phasePressure, state);
+        Base::computeMassFlux(actph, transi, kr, mu, rho, phasePressure, state);
 
         // Polymer treatment.
         const int canonicalPhaseIdx = canph_[ actph ];
@@ -424,7 +429,6 @@ namespace Opm {
             if (has_polymer_) {
                 const std::vector<PhasePresence>& cond = phaseCondition();
                 const ADB tr_mult = transMult(state.pressure);
-                const ADB mu = fluidViscosity(canonicalPhaseIdx, phasePressure, state.temperature, state.rs, state.rv, cond);
                 const ADB cmax = ADB::constant(cmax_, state.concentration.blockPattern());
                 const ADB mc = computeMc(state);
                 const ADB krw_eff = polymer_props_ad_.effectiveRelPerm(state.concentration, cmax, kr);


### PR DESCRIPTION
Miscibility effects are added to the solvent model and effective density and viscosity calculated using the Todd-Longstaff model. 

Tested using SPE1CASE2_SOLVENT_MISC_TL.DATA and SPE9_CP_SOLVENT_CO2_MISC_TL.DATA found in opm-data/solvent_test_suite

Note. Commit 69792d0 introduces changes to the BlackoilModel and the PolymerModel without effecting the results or the performance.  

