### PR TITLE
AMG for Interleaved solver and other goodies.

### DIFF
--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -250,7 +250,8 @@ namespace detail {
         const bool converged = asImpl().getConvergence(dt, iteration);
         const bool must_solve = (iteration < nonlinear_solver.minIter()) || (!converged);
         if (must_solve) {
-            residual_.singlePrecision = false ;
+            // enable single precision for solvers when dt is smaller then 20 days
+            residual_.singlePrecision = (unit::convert::to(dt, unit::day) < 20.) ;
 
             // Compute the nonlinear update.
             V dx = asImpl().solveJacobianSystem();

--- a/opm/autodiff/CPRPreconditioner.hpp
+++ b/opm/autodiff/CPRPreconditioner.hpp
@@ -52,7 +52,8 @@
 #include <opm/autodiff/ParallelOverlappingILU0.hpp>
 namespace Opm
 {
-namespace
+
+namespace ISTLUtility
 {
 ///
 /// \brief A traits class for selecting the types of the preconditioner.
@@ -85,6 +86,7 @@ struct CPRSelector
     {
         return new Operator(m);
     }
+
 };
 
 #if HAVE_MPI
@@ -266,8 +268,49 @@ createEllipticPreconditionerPointer(const M& Ae, double relax,
         ::EllipticPreconditionerPointer EllipticPreconditionerPointer;
     return EllipticPreconditionerPointer(new ParallelPreconditioner(Ae, comm, relax));
 }
-#endif
-} // end namespace
+
+#endif // #if HAVE_MPI
+
+/// \brief Creates the elliptic preconditioner (ILU0)
+/// \param opA     The operator representing the matrix of the system.
+/// \param relax   The relaxation parameter for ILU0.
+/// \param comm    The object describing the parallelization information and communication.
+//  \param amgPtr  The unique_ptr to be filled (return)
+template <class Op, class P, class AMG >
+inline void
+createAMGPreconditionerPointer( Op& opA, const double relax, const P& comm, std::unique_ptr< AMG >& amgPtr )
+{
+    // type of matrix
+    typedef typename Op::matrix_type  M;
+
+    // The coupling metric used in the AMG
+    typedef Dune::Amg::FirstDiagonal CouplingMetric;
+
+    // The coupling criterion used in the AMG
+    typedef Dune::Amg::SymmetricCriterion<M, CouplingMetric> CritBase;
+
+    // The coarsening criterion used in the AMG
+    typedef Dune::Amg::CoarsenCriterion<CritBase> Criterion;
+
+    // TODO: revise choice of parameters
+    int coarsenTarget=1200;
+    Criterion criterion(15,coarsenTarget);
+    criterion.setDebugLevel( 0 ); // no debug information, 1 for printing hierarchy information
+    criterion.setDefaultValuesIsotropic(2);
+    criterion.setNoPostSmoothSteps( 1 );
+    criterion.setNoPreSmoothSteps( 1 );
+
+    // for DUNE 2.2 we also need to pass the smoother args
+    typedef typename AMG::Smoother Smoother;
+    typedef typename Dune::Amg::SmootherTraits<Smoother>::Arguments  SmootherArgs;
+    SmootherArgs  smootherArgs;
+    smootherArgs.iterations = 1;
+    smootherArgs.relaxationFactor = relax;
+
+    amgPtr.reset( new AMG(opA, criterion, smootherArgs, comm ) );
+}
+
+} // end namespace ISTLUtility
 
     struct CPRParameter
     {
@@ -348,19 +391,21 @@ createEllipticPreconditionerPointer(const M& Ae, double relax,
             Dune::SolverCategory::sequential:Dune::SolverCategory::overlapping
         };
 
+        typedef ISTLUtility::CPRSelector<M,X,X,P>  CPRSelectorType ;
+
         //! \brief Elliptic Operator
-        typedef typename CPRSelector<M,X,X,P>::Operator Operator;
+        typedef typename CPRSelectorType::Operator Operator;
 
         //! \brief preconditioner for the whole system (here either ILU(0) or ILU(n)
         typedef Dune::Preconditioner<X,X> WholeSystemPreconditioner;
 
         //! \brief type of the unique pointer to the ilu-0 preconditioner
         //! used the for the elliptic system
-        typedef typename CPRSelector<M,X,X,P>::EllipticPreconditionerPointer
+        typedef typename CPRSelectorType::EllipticPreconditionerPointer
         EllipticPreconditionerPointer;
 
         //! \brief amg preconditioner for the elliptic system
-        typedef typename CPRSelector<M,X,X,P>::AMG  AMG;
+        typedef typename CPRSelectorType::AMG  AMG;
 
         /*! \brief Constructor.
 
@@ -382,7 +427,7 @@ createEllipticPreconditionerPointer(const M& Ae, double relax,
               de_( Ae_.N() ),
               ve_( Ae_.M() ),
               dmodified_( A_.N() ),
-              opAe_(CPRSelector<M,X,Y,P>::makeOperator(Ae_, commAe)),
+              opAe_(CPRSelectorType::makeOperator(Ae_, commAe)),
               precond_(), // ilu0 preconditioner for elliptic system
               amg_(),     // amg  preconditioner for elliptic system
               pre_(), // copy A will be made be the preconditioner
@@ -395,10 +440,10 @@ createEllipticPreconditionerPointer(const M& Ae, double relax,
 
             // create the preconditioner for the whole system.
             if( param_.cpr_ilu_n_ == 0 ) {
-                pre_ = createILU0Ptr<M,X>( A_, param_.cpr_relax_, comm_ );
+                pre_ = ISTLUtility::createILU0Ptr<M,X>( A_, param_.cpr_relax_, comm_ );
             }
             else {
-                pre_ = createILUnPtr<M,X>( A_, param_.cpr_ilu_n_, param_.cpr_relax_, comm_ );
+                pre_ = ISTLUtility::createILUnPtr<M,X>( A_, param_.cpr_ilu_n_, param_.cpr_relax_, comm_ );
             }
         }
 
@@ -552,35 +597,11 @@ createEllipticPreconditionerPointer(const M& Ae, double relax,
         {
             if( amg )
             {
-              // The coupling metric used in the AMG
-              typedef Dune::Amg::FirstDiagonal CouplingMetric;
-
-              // The coupling criterion used in the AMG
-              typedef Dune::Amg::SymmetricCriterion<M, CouplingMetric> CritBase;
-
-              // The coarsening criterion used in the AMG
-              typedef Dune::Amg::CoarsenCriterion<CritBase> Criterion;
-
-              // TODO: revise choice of parameters
-              int coarsenTarget=1200;
-              Criterion criterion(15,coarsenTarget);
-              criterion.setDebugLevel( 0 ); // no debug information, 1 for printing hierarchy information
-              criterion.setDefaultValuesIsotropic(2);
-              criterion.setNoPostSmoothSteps( 1 );
-              criterion.setNoPreSmoothSteps( 1 );
-
-              // for DUNE 2.2 we also need to pass the smoother args
-              typedef typename AMG::Smoother Smoother;
-              typedef typename Dune::Amg::SmootherTraits<Smoother>::Arguments  SmootherArgs;
-              SmootherArgs  smootherArgs;
-              smootherArgs.iterations = 1;
-              smootherArgs.relaxationFactor = param_.cpr_relax_;
-
-              amg_ = std::unique_ptr< AMG > (new AMG(*opAe_, criterion, smootherArgs, comm ));
+                ISTLUtility::createAMGPreconditionerPointer( *opAe_ , param_.cpr_relax_, comm, amg_ );
             }
             else
             {
-                precond_ = createEllipticPreconditionerPointer<M,X>( Ae_, param_.cpr_relax_, comm);
+                precond_ = ISTLUtility::createEllipticPreconditionerPointer<M,X>( Ae_, param_.cpr_relax_, comm);
             }
        }
     };

--- a/opm/autodiff/LinearisedBlackoilResidual.hpp
+++ b/opm/autodiff/LinearisedBlackoilResidual.hpp
@@ -65,6 +65,8 @@ namespace Opm
 
         std::vector<double> matbalscale;
 
+        bool singlePrecision ;
+
         /// The size of the non-linear system.
         int sizeNonLinear() const;
     };

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
@@ -541,15 +541,9 @@ namespace Opm
     {
         // get np and call appropriate template method
         const int np = residual.material_balance_eq.size();
-#if ! HAVE_UMFPACK
-        const bool singlePrecision = residual.singlePrecision ;
-        const NewtonIterationBlackoilInterface& newtonIncrement = singlePrecision ?
+        const NewtonIterationBlackoilInterface& newtonIncrement = residual.singlePrecision ?
             detail::NewtonIncrement< maxNumberEquations_, float  > :: get( newtonIncrementSinglePrecision_, parameters_, parallelInformation_, np ) :
             detail::NewtonIncrement< maxNumberEquations_, double > :: get( newtonIncrementDoublePrecision_, parameters_, parallelInformation_, np );
-#else
-        const NewtonIterationBlackoilInterface& newtonIncrement =
-            detail::NewtonIncrement< maxNumberEquations_, double > :: get( newtonIncrementDoublePrecision_, parameters_, parallelInformation_, np );
-#endif
 
         // compute newton increment
         SolutionVector dx = newtonIncrement.computeNewtonIncrement( residual );

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
@@ -214,7 +214,7 @@ namespace Opm
         template <class Operator>
         std::unique_ptr<SeqPreconditioner> constructPrecond(Operator& opA, const Dune::Amg::SequentialInformation&) const
         {
-            const double relax = 1.0;
+            const double relax = 0.9;
             std::unique_ptr<SeqPreconditioner> precond(new SeqPreconditioner(opA.getmat(), relax));
             return precond;
         }
@@ -227,7 +227,7 @@ namespace Opm
         constructPrecond(Operator& opA, const Comm& comm) const
         {
             typedef std::unique_ptr<ParPreconditioner> Pointer;
-            const double relax = 1.0;
+            const double relax = 0.9;
             return Pointer(new ParPreconditioner(opA.getmat(), comm, relax));
         }
 #endif
@@ -542,7 +542,7 @@ namespace Opm
         // get np and call appropriate template method
         const int np = residual.material_balance_eq.size();
 #if ! HAVE_UMFPACK
-        const bool singlePrecision = false ; // residual.singlePrecision ;
+        const bool singlePrecision = residual.singlePrecision ;
         const NewtonIterationBlackoilInterface& newtonIncrement = singlePrecision ?
             detail::NewtonIncrement< maxNumberEquations_, float  > :: get( newtonIncrementSinglePrecision_, parameters_, parallelInformation_, np ) :
             detail::NewtonIncrement< maxNumberEquations_, double > :: get( newtonIncrementDoublePrecision_, parameters_, parallelInformation_, np );

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
@@ -52,17 +52,41 @@
 
 namespace Dune
 {
-    namespace FMatrixHelp {
 
-    //! invert Matrix without changing the original matrix
-    //! return inverse matrix (specialization for n <= 3 in dune/common/fmatrix.hh)
-    template <typename K, int n>
-    static inline K invertMatrix (const FieldMatrix<K,n,n> &matrix, FieldMatrix<K,n,n> &inverse)
-    {
-        inverse.invert();
-        return K(0);
-    }
+namespace ISTLUtility {
+
+//! invert matrix by calling FMatrixHelp::invert
+template <typename K>
+static inline void invertMatrix (FieldMatrix<K,1,1> &matrix)
+{
+    FieldMatrix<K,1,1> A ( matrix );
+    FMatrixHelp::invertMatrix(A, matrix );
 }
+
+//! invert matrix by calling FMatrixHelp::invert
+template <typename K>
+static inline void invertMatrix (FieldMatrix<K,2,2> &matrix)
+{
+    FieldMatrix<K,2,2> A ( matrix );
+    FMatrixHelp::invertMatrix(A, matrix );
+}
+
+//! invert matrix by calling FMatrixHelp::invert
+template <typename K>
+static inline void invertMatrix (FieldMatrix<K,3,3> &matrix)
+{
+    FieldMatrix<K,3,3> A ( matrix );
+    FMatrixHelp::invertMatrix(A, matrix );
+}
+
+//! invert matrix by calling matrix.invert
+template <typename K, int n>
+static inline void invertMatrix (FieldMatrix<K,n,n> &matrix)
+{
+    matrix.invert();
+}
+
+} // end ISTLUtility
 
 template <class Scalar, int n, int m>
 class MatrixBlock : public Dune::FieldMatrix<Scalar, n, m>
@@ -76,8 +100,7 @@ public:
     explicit MatrixBlock( const Scalar scalar = 0 ) : BaseType( scalar ) {}
     void invert()
     {
-        MatrixBlock matrix( *this );
-        Dune::FMatrixHelp::invertMatrix(matrix, *this);
+        ISTLUtility::invertMatrix( *this );
     }
     const BaseType& asBase() const { return static_cast< const BaseType& > (*this); }
     BaseType& asBase() { return static_cast< BaseType& > (*this); }

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -62,7 +62,7 @@ namespace Opm
         {
             newton_use_gmres_        = false;
             linear_solver_reduction_ = 1e-2;
-            linear_solver_maxiter_   = 50;
+            linear_solver_maxiter_   = 75;
             linear_solver_restart_   = 40;
             linear_solver_verbosity_ = 0;
         }

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -100,7 +100,7 @@ namespace Opm
         // max number of equations supported, increase if necessary
         static const int maxNumberEquations_ = 6 ;
 
-        mutable std::array< std::unique_ptr< NewtonIterationBlackoilInterface >, maxNumberEquations_+1 > newtonIncrement_;
+        mutable std::array< std::unique_ptr< NewtonIterationBlackoilInterface >, maxNumberEquations_+1 > newtonIncrementDoublePrecision_;
         mutable std::array< std::unique_ptr< NewtonIterationBlackoilInterface >, maxNumberEquations_+1 > newtonIncrementSinglePrecision_;
         NewtonIterationBlackoilInterleavedParameters parameters_;
         boost::any parallelInformation_;

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -101,6 +101,7 @@ namespace Opm
         static const int maxNumberEquations_ = 6 ;
 
         mutable std::array< std::unique_ptr< NewtonIterationBlackoilInterface >, maxNumberEquations_+1 > newtonIncrement_;
+        mutable std::array< std::unique_ptr< NewtonIterationBlackoilInterface >, maxNumberEquations_+1 > newtonIncrementSinglePrecision_;
         NewtonIterationBlackoilInterleavedParameters parameters_;
         boost::any parallelInformation_;
         mutable int iterations_;

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -200,12 +200,14 @@ namespace Opm
             // Report timing.
             const double st = solver_timer.secsSinceStart();
 
+            // accumulate total time
+            stime += st;
+
             if ( terminal_output_ )
             {
-                std::cout << "Fully implicit solver took: " << st << " seconds." << std::endl;
+                std::cout << "Fully implicit solver took: " << st << " seconds. Total solver time taken: " << stime << " seconds." << std::endl;
             }
 
-            stime += st;
             if ( output_writer_.output() ) {
                 SimulatorReport step_report;
                 step_report.pressure_time = st;

--- a/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.cpp
+++ b/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.cpp
@@ -189,7 +189,8 @@ namespace {
         , residual_ ( { std::vector<ADB>(fluid.numPhases() + 1, ADB::null()),
                         ADB::null(),
                         ADB::null(),
-                        { 1.1169, 1.0031, 0.0031, 1.0 }} ) // default scaling
+                        { 1.1169, 1.0031, 0.0031, 1.0 },
+                        false } ) // default scaling
     {
     }
 
@@ -369,7 +370,7 @@ namespace {
         assert(not x.concentration().empty());
         const V c = Eigen::Map<const V>(&x.concentration()[0], nc);
         state.concentration = ADB::constant(c);
-        
+
         // Well rates.
         assert (not xw.wellRates().empty());
         // Need to reshuffle well rates, from ordered by wells, then phase,
@@ -400,7 +401,7 @@ namespace {
         const int np = x.numPhases();
 
         std::vector<V> vars0;
-   
+
         // Initial pressure.
         assert (not x.pressure().empty());
         const V p = Eigen::Map<const V>(& x.pressure()[0], nc, 1);
@@ -496,12 +497,12 @@ namespace {
         const double dead_pore_vol = polymer_props_ad_.deadPoreVol();
         rq_[2].accum[aix] = pv_mult * rq_[0].b * sat[0] * c * (1. - dead_pore_vol) + pv_mult *  rho_rock * (1. - phi) / phi * ads;
     }
-	
 
 
 
 
-    void 
+
+    void
     FullyImplicitCompressiblePolymerSolver::
     computeCmax(PolymerBlackoilState& state)
     {
@@ -654,7 +655,7 @@ namespace {
 		const V poly_mc_cell = subset(mc, well_cells).value();
 		const V poly_in_c = poly_in_perf;// * poly_mc_cell;
         const V poly_mc = producer.select(poly_mc_cell, poly_in_c);
-        
+
 		residual_.material_balance_eq[2] += superset(well_perf_rates[0] * poly_mc, well_cells, nc);
         // Set the well flux equation
         residual_.well_flux_eq = state.qs + well_rates_all;
@@ -960,7 +961,7 @@ namespace {
 
 
 
-    // here mc means m(c) * c. 
+    // here mc means m(c) * c.
     ADB
     FullyImplicitCompressiblePolymerSolver::computeMc(const SolutionState& state) const
     {
@@ -1028,7 +1029,7 @@ namespace {
     {
         const int nc = grid_.number_of_cells;
         const DataBlock s = Eigen::Map<const DataBlock>(& state.saturation()[0], nc, 2);
-        
+
         const V so = s.col(1);
         for (V::Index c = 0, e = so.size(); c != e; ++c) {
             phaseCondition_[c].setFreeWater();


### PR DESCRIPTION
This PR add the possibility to use the AMG preconditioner for the Interleaved solver (when UMFPACK is disabled) and other small changes: 

- Fix residual is too large output. 
- ILU0 with relaxation parameter 0.9 
- single precision solvers when dt < 20 days
- print total time after each report step (for performance comparison)