### PR TITLE
Change Deck access methods/types to references

### DIFF
--- a/examples/sim_poly_fi2p_comp_ad.cpp
+++ b/examples/sim_poly_fi2p_comp_ad.cpp
@@ -155,7 +155,7 @@ try
     std::shared_ptr<EclipseState> eclipseState;
     try {
         deck = parser->parseFile(deck_filename , parseMode);
-        Opm::checkDeck(deck);
+        Opm::checkDeck(deck, parser);
         eclipseState.reset(new Opm::EclipseState(deck , parseMode));
     }
     catch (const std::invalid_argument& e) {

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -177,31 +177,31 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         waterPvt_->initFromDeck(deck, eclState);
 
         // Surface densities. Accounting for different orders in eclipse and our code.
-        Opm::DeckKeywordConstPtr densityKeyword = deck->getKeyword("DENSITY");
-        int numRegions = densityKeyword->size();
+        const auto& densityKeyword = deck->getKeyword("DENSITY");
+        int numRegions = densityKeyword.size();
         auto tables = eclState->getTableManager();
 
         surfaceDensity_.resize(numRegions);
         for (int regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
             if (phase_usage_.phase_used[Liquid]) {
                 surfaceDensity_[regionIdx][phase_usage_.phase_pos[Liquid]]
-                    = densityKeyword->getRecord(regionIdx)->getItem("OIL")->getSIDouble(0);
+                    = densityKeyword.getRecord(regionIdx).getItem("OIL").getSIDouble(0);
             }
             if (phase_usage_.phase_used[Aqua]) {
                 surfaceDensity_[regionIdx][phase_usage_.phase_pos[Aqua]]
-                    = densityKeyword->getRecord(regionIdx)->getItem("WATER")->getSIDouble(0);
+                    = densityKeyword.getRecord(regionIdx).getItem("WATER").getSIDouble(0);
             }
             if (phase_usage_.phase_used[Vapour]) {
                 surfaceDensity_[regionIdx][phase_usage_.phase_pos[Vapour]]
-                    = densityKeyword->getRecord(regionIdx)->getItem("GAS")->getSIDouble(0);
+                    = densityKeyword.getRecord(regionIdx).getItem("GAS").getSIDouble(0);
             }
         }
 
         // Oil vaporization controls (kw VAPPARS)
         vap1_ = vap2_ = 0.0;
         if (deck->hasKeyword("VAPPARS") && deck->hasKeyword("VAPOIL") && deck->hasKeyword("DISGAS")) {
-            vap1_ = deck->getKeyword("VAPPARS")->getRecord(0)->getItem(0)->getRawDouble(0);
-            vap2_ = deck->getKeyword("VAPPARS")->getRecord(0)->getItem(1)->getRawDouble(0);
+            vap1_ = deck->getKeyword("VAPPARS").getRecord(0).getItem(0).get< double >(0);
+            vap2_ = deck->getKeyword("VAPPARS").getRecord(0).getItem(1).get< double >(0);
             satOilMax_.resize(number_of_cells, 0.0);
         } else if (deck->hasKeyword("VAPPARS")) {
             OPM_THROW(std::runtime_error, "Input has VAPPARS, but missing VAPOIL and/or DISGAS\n");

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -353,7 +353,7 @@ namespace Opm
                 std::string deck_filename = param_.get<std::string>("deck_filename");
                 ParseMode parseMode({{ ParseMode::PARSE_RANDOM_SLASH , InputError::IGNORE }});
                 deck_ = parser->parseFile(deck_filename, parseMode);
-                checkDeck(deck_);
+                checkDeck(deck_, parser);
                 eclipse_state_.reset(new EclipseState(deck_, parseMode));
             }
             catch (const std::invalid_argument& e) {

--- a/opm/autodiff/SolventPropsAdFromDeck.cpp
+++ b/opm/autodiff/SolventPropsAdFromDeck.cpp
@@ -48,12 +48,12 @@ SolventPropsAdFromDeck::SolventPropsAdFromDeck(DeckConstPtr deck,
 
         // surface densities
         if (deck->hasKeyword("SDENSITY")) {
-            Opm::DeckKeywordConstPtr densityKeyword = deck->getKeyword("SDENSITY");
-            int numRegions = densityKeyword->size();
+            const auto& densityKeyword = deck->getKeyword("SDENSITY");
+            int numRegions = densityKeyword.size();
             solvent_surface_densities_.resize(numRegions);
             for (int regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
                 solvent_surface_densities_[regionIdx]
-                        = densityKeyword->getRecord(regionIdx)->getItem("SOLVENT_DENSITY")->getSIDouble(0);
+                        = densityKeyword.getRecord(regionIdx).getItem("SOLVENT_DENSITY").getSIDouble(0);
             }
         } else {
             OPM_THROW(std::runtime_error, "SDENSITY must be specified in SOLVENT runs\n");
@@ -232,16 +232,16 @@ SolventPropsAdFromDeck::SolventPropsAdFromDeck(DeckConstPtr deck,
             }
 
             if (deck->hasKeyword("TLMIXPAR")) {
-                const int numRegions = deck->getKeyword("TLMIXPAR")->size();
+                const int numRegions = deck->getKeyword("TLMIXPAR").size();
 
                 // resize the attributes of the object
                 mix_param_viscosity_.resize(numRegions);
                 mix_param_density_.resize(numRegions);
                 for (int regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
-                    const auto& tlmixparRecord = deck->getKeyword("TLMIXPAR")->getRecord(regionIdx);
-                    const auto& mix_params_viscosity = tlmixparRecord->getItem("TL_VISCOSITY_PARAMETER")->getSIDoubleData();
+                    const auto& tlmixparRecord = deck->getKeyword("TLMIXPAR").getRecord(regionIdx);
+                    const auto& mix_params_viscosity = tlmixparRecord.getItem("TL_VISCOSITY_PARAMETER").getSIDoubleData();
                     mix_param_viscosity_[regionIdx] = mix_params_viscosity[0];
-                    const auto& mix_params_density = tlmixparRecord->getItem("TL_DENSITY_PARAMETER")->getSIDoubleData();
+                    const auto& mix_params_density = tlmixparRecord.getItem("TL_DENSITY_PARAMETER").getSIDoubleData();
                     const int numDensityItems = mix_params_density.size();
                     if (numDensityItems == 0) {
                         mix_param_density_[regionIdx] = mix_param_viscosity_[regionIdx];

--- a/opm/polymer/PolymerProperties.hpp
+++ b/opm/polymer/PolymerProperties.hpp
@@ -132,13 +132,13 @@ namespace Opm
             // We assume NTMISC=1
             auto tables = eclipseState->getTableManager();
             const auto& plymaxTable = tables->getPlymaxTables().getTable<PlymaxTable>(0);
-            const auto plmixparRecord = deck->getKeyword("PLMIXPAR")->getRecord(0);
+            const auto& plmixparRecord = deck->getKeyword("PLMIXPAR").getRecord(0);
 
             // We also assume that each table has exactly one row...
             assert(plymaxTable.numRows() == 1);
 
             c_max_ = plymaxTable.getPolymerConcentrationColumn()[0];
-            mix_param_ = plmixparRecord->getItem("TODD_LONGSTAFF")->getSIDouble(0);
+            mix_param_ = plmixparRecord.getItem("TODD_LONGSTAFF").getSIDouble(0);
 
             // We assume NTSFUN=1
             const auto& plyrockTable = tables->getPlyrockTables().getTable<PlyrockTable>(0);
@@ -176,12 +176,12 @@ namespace Opm
                 shear_vrf_vals_ = plyshlogTable.getShearMultiplierColumn().vectorCopy( );
 
                 // do the unit version here for the water_vel_vals_
-                Opm::UnitSystem unitSystem = *deck->getActiveUnitSystem();
+                Opm::UnitSystem unitSystem = deck->getActiveUnitSystem();
                 double siFactor;
                 if (has_shrate_) {
                     siFactor = unitSystem.parse("1/Time")->getSIScaling();
-                    DeckKeywordConstPtr shrateKeyword = deck->getKeyword("SHRATE");
-                    std::vector<double> shrate_readin = shrateKeyword->getSIDoubleData();
+                    const auto& shrateKeyword = deck->getKeyword("SHRATE");
+                    std::vector<double> shrate_readin = shrateKeyword.getSIDoubleData();
                     if (shrate_readin.size() == 1) {
                         shrate_ = shrate_readin[0];
                     } else if (shrate_readin.size() == 0) {

--- a/tests/test_restart.cpp
+++ b/tests/test_restart.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(CompareRestartFileResults)
     const std::string& filename1 = boost::unit_test::framework::master_test_suite().argv[1];
     const std::string& filename2 = boost::unit_test::framework::master_test_suite().argv[2];
     int last_report_step = std::atoi(boost::unit_test::framework::master_test_suite().argv[3]);
-    const double abs_diff = 1e-5;
+    const double abs_diff = 1e-3;
     std::map<std::string, double> relative_diffs;
     relative_diffs["SWAT"]     = 0.0005;  //0.05 %
     relative_diffs["SGAS"]     = 0.0005;

--- a/tests/test_vfpproperties.cpp
+++ b/tests/test_vfpproperties.cpp
@@ -1051,10 +1051,10 @@ VFPPROD \n\
     deck = parser->parseString(table_str, parse_mode);
 
     BOOST_REQUIRE(deck->hasKeyword("VFPPROD"));
-    BOOST_CHECK_EQUAL(deck->numKeywords("VFPPROD"), 1);
+    BOOST_CHECK_EQUAL(deck->count("VFPPROD"), 1);
 
     Opm::VFPProdTable table;
-    table.init(deck->getKeyword("VFPPROD", 0), units);
+    table.init(deck->getKeyword("VFPPROD", 0), *units);
 
     Opm::VFPProdProperties properties(&table);
 
@@ -1112,13 +1112,13 @@ BOOST_AUTO_TEST_CASE(ParseInterpolateRealisticVFPPROD)
     boost::filesystem::path file("VFPPROD2");
 
     deck = parser->parseFile(file.string(), parse_mode);
-    Opm::checkDeck(deck);
+    Opm::checkDeck(deck, parser);
 
     BOOST_REQUIRE(deck->hasKeyword("VFPPROD"));
-    BOOST_CHECK_EQUAL(deck->numKeywords("VFPPROD"), 1);
+    BOOST_CHECK_EQUAL(deck->count("VFPPROD"), 1);
 
     Opm::VFPProdTable table;
-    table.init(deck->getKeyword("VFPPROD", 0), units);
+    table.init(deck->getKeyword("VFPPROD", 0), *units);
 
     Opm::VFPProdProperties properties(&table);
 


### PR DESCRIPTION
OPM/opm-parser#677 changes the return types for the Deck family of classes.
This patch fixes all broken code from that patch set.

https://github.com/OPM/opm-parser/pull/677