### PR TITLE
Fix minor issue with const POD requirements.

### DIFF
--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -171,7 +171,7 @@ namespace Opm
 
         template <class State>
         void resize(const Wells* wells, const State& state) {
-            const WellStateFullyImplicitBlackoil dummy_state; //Init with an empty previous state only resizes
+            const WellStateFullyImplicitBlackoil dummy_state{}; // Init with an empty previous state only resizes
             init(wells, state, dummy_state) ;
         }
 


### PR DESCRIPTION
A user-defined default constructor is required in this situation unless explicitly using the empty-brace-init syntax.

See discussion here:
http://stackoverflow.com/questions/7411515/why-does-c-require-a-user-provided-default-constructor-to-default-construct-a

It is possible that gcc is less strict than clang here, anyway the minor change below restores complilation with clang on my system, and I will therefore self-merge.
