### PR TITLE
Fast sparse add.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -138,7 +138,7 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/autodiff/BlackoilSolventState.hpp
 	opm/autodiff/BlackoilMultiSegmentModel.hpp
 	opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
-	opm/autodiff/fastSparseProduct.hpp
+	opm/autodiff/fastSparseOperations.hpp
 	opm/autodiff/DuneMatrix.hpp
 	opm/autodiff/ExtractParallelGridInformationToISTL.hpp
 	opm/autodiff/FlowMain.hpp

--- a/opm/autodiff/AutoDiffBlock.hpp
+++ b/opm/autodiff/AutoDiffBlock.hpp
@@ -24,7 +24,7 @@
 
 #include <Eigen/Eigen>
 #include <Eigen/Sparse>
-#include <opm/autodiff/fastSparseProduct.hpp>
+#include <opm/autodiff/fastSparseOperations.hpp>
 
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 

--- a/opm/autodiff/AutoDiffBlock.hpp
+++ b/opm/autodiff/AutoDiffBlock.hpp
@@ -342,7 +342,9 @@ namespace Opm
                     jac[block] = D2*jac_[block];
                 }
                 else {
-                    jac[block] = D2*jac_[block] + D1*rhs.jac_[block];
+                    //jac[block] = D2*jac_[block] + D1*rhs.jac_[block];
+                    jac[block]  = D2*jac_[block];
+                    jac[block] += D1*rhs.jac_[block];
                 }
             }
             return function(val_ * rhs.val_, std::move(jac));
@@ -366,6 +368,8 @@ namespace Opm
             M D1(val_.matrix().asDiagonal());
             M D2(rhs.val_.matrix().asDiagonal());
             M D3((1.0/(rhs.val_*rhs.val_)).matrix().asDiagonal());
+            M D4;
+            M D5;
 #pragma omp parallel for schedule(dynamic)
             for (int block = 0; block < num_blocks; ++block) {
                 assert(jac_[block].rows() == rhs.jac_[block].rows());
@@ -374,14 +378,31 @@ namespace Opm
                     jac[block] = M( D3.rows(), jac_[block].cols() );
                 }
                 else if( jac_[block].nonZeros() == 0 ) {
-                    jac[block] =  D3 * ( D1*rhs.jac_[block]) * (-1.0);
+#pragma omp critical
+                    if( D4.rows() == 0 ) {
+                        D4 = D3 * D1 * (-1.0);
+                    }
+                    jac[block] = D4*rhs.jac_[block];
                 }
                 else if ( rhs.jac_[block].nonZeros() == 0 )
                 {
-                    jac[block] = D3 * (D2*jac_[block]);
+#pragma omp critical
+                    if( D5.rows() == 0 ) {
+                        D5 = D3 * D2 ;
+                    }
+                    jac[block] = D5*jac_[block];
                 }
                 else {
-                    jac[block] = D3 * (D2*jac_[block] + (D1*rhs.jac_[block]*(-1.0)));
+#pragma omp critical
+                    if( D4.rows() == 0 ) {
+                        D4 = D3 * D1 * (-1.0);
+                    }
+#pragma omp critical
+                    if( D5.rows() == 0 ) {
+                        D5 = D3 * D2 ;
+                    }
+                    jac[block]  = D5*jac_[block];
+                    jac[block] += D4*rhs.jac_[block];
                 }
             }
             return function(val_ / rhs.val_, std::move(jac));

--- a/opm/autodiff/AutoDiffMatrix.hpp
+++ b/opm/autodiff/AutoDiffMatrix.hpp
@@ -28,7 +28,7 @@
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/common/ErrorMacros.hpp>
-#include <opm/autodiff/fastSparseProduct.hpp>
+#include <opm/autodiff/fastSparseOperations.hpp>
 #include <vector>
 
 

--- a/opm/autodiff/AutoDiffMatrix.hpp
+++ b/opm/autodiff/AutoDiffMatrix.hpp
@@ -268,8 +268,9 @@ namespace Opm
             {
                 fastSparseAdd( sparse_, rhs.sparse_ );
             }
-            else
+            else {
                 *this = *this + rhs;
+            }
             return *this;
         }
 
@@ -284,8 +285,9 @@ namespace Opm
             {
                 fastSparseSubstract( sparse_, rhs.sparse_ );
             }
-            else
+            else {
                 *this = *this + (rhs * -1.0);
+            }
             return *this;
         }
 

--- a/opm/autodiff/AutoDiffMatrix.hpp
+++ b/opm/autodiff/AutoDiffMatrix.hpp
@@ -264,7 +264,12 @@ namespace Opm
 
         AutoDiffMatrix& operator+=(const AutoDiffMatrix& rhs)
         {
-            *this = *this + rhs;
+            if( type_ == Sparse && rhs.type_ == Sparse )
+            {
+                fastSparseAdd( sparse_, rhs.sparse_ );
+            }
+            else
+                *this = *this + rhs;
             return *this;
         }
 
@@ -275,7 +280,12 @@ namespace Opm
 
         AutoDiffMatrix& operator-=(const AutoDiffMatrix& rhs)
         {
-            *this = *this + (rhs * -1.0);
+            if( type_ == Sparse && rhs.type_ == Sparse )
+            {
+                fastSparseSubstract( sparse_, rhs.sparse_ );
+            }
+            else
+                *this = *this + (rhs * -1.0);
             return *this;
         }
 

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1244,11 +1244,11 @@ namespace detail {
 
             if (phase == Oil && active_[Gas]) {
                 const int gaspos = pu.phase_pos[Gas];
-                tmp = tmp - rv_perfcells * cmix_s[gaspos] / d;
+                tmp -= rv_perfcells * cmix_s[gaspos] / d;
             }
             if (phase == Gas && active_[Oil]) {
                 const int oilpos = pu.phase_pos[Oil];
-                tmp = tmp - rs_perfcells * cmix_s[oilpos] / d;
+                tmp -= rs_perfcells * cmix_s[oilpos] / d;
             }
             volumeRatio += tmp / b_perfcells[phase];
         }

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -98,7 +98,7 @@ namespace Opm
             }
         }
         materialLawManager->initFromDeck(deck, eclState, compressedToCartesianIdx);
-        init(deck, eclState, materialLawManager, grid.number_of_cells, grid.global_cell, grid.cartdims, 
+        init(deck, eclState, materialLawManager, grid.number_of_cells, grid.global_cell, grid.cartdims,
              init_rock);
     }
 
@@ -399,7 +399,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             fastSparseProduct(dmudp_diag, po.derivative()[block], jacs[block]);
             ADB::M temp;
             fastSparseProduct(dmudr_diag, rs.derivative()[block], temp);
-            jacs[block] = jacs[block] + temp;
+            jacs[block] += temp;
         }
         return ADB::function(std::move(mu), std::move(jacs));
     }
@@ -463,7 +463,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             fastSparseProduct(dmudp_diag, pg.derivative()[block], jacs[block]);
             ADB::M temp;
             fastSparseProduct(dmudr_diag, rv.derivative()[block], temp);
-            jacs[block] = jacs[block] + temp;
+            jacs[block] += temp;
         }
         return ADB::function(std::move(mu), std::move(jacs));
     }
@@ -578,7 +578,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             fastSparseProduct(dbdp_diag, po.derivative()[block], jacs[block]);
             ADB::M temp;
             fastSparseProduct(dbdr_diag, rs.derivative()[block], temp);
-            jacs[block] = jacs[block] + temp;
+            jacs[block] += temp;
         }
         return ADB::function(std::move(b), std::move(jacs));
     }
@@ -643,7 +643,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             fastSparseProduct(dbdp_diag, pg.derivative()[block], jacs[block]);
             ADB::M temp;
             fastSparseProduct(dbdr_diag, rv.derivative()[block], temp);
-            jacs[block] = jacs[block] + temp;
+            jacs[block] += temp;
         }
         return ADB::function(std::move(b), std::move(jacs));
     }
@@ -824,7 +824,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
                     for (int block = 0; block < num_blocks; ++block) {
                         ADB::M temp;
                         fastSparseProduct(dkr1_ds2_diag, s[phase2]->derivative()[block], temp);
-                        jacs[block] = jacs[block] + temp;
+                        jacs[block] += temp;
                     }
                 }
                 ADB::V val = kr.col(phase1_pos);
@@ -885,7 +885,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
                     for (int block = 0; block < nBlocks; ++block) {
                         ADB::M temp;
                         fastSparseProduct(dpc1_ds2_diag, s[phase2]->derivative()[block], temp);
-                        jacs[block] = jacs[block] + temp;
+                        jacs[block] += temp;
                     }
                 }
                 ADB::V val = pc.col(phase1_pos);

--- a/opm/autodiff/fastSparseOperations.hpp
+++ b/opm/autodiff/fastSparseOperations.hpp
@@ -188,60 +188,57 @@ equalSparsityPattern(const Lhs& lhs, const Rhs& rhs)
     if( equal )
     {
         typedef typename Eigen::internal::remove_all<Lhs>::type::Index Index;
-        const Index nnz = lhs.nonZeros();
-
-        // outer indices
-        const Index* rhsO = rhs.outerIndexPtr();
-        const Index* lhsO = lhs.outerIndexPtr();
-
-        // inner indices
-        const Index* rhsJ = rhs.innerIndexPtr();
-        const Index* lhsJ = lhs.innerIndexPtr();
-
         const Index outerSize = lhs.outerSize();
         if( outerSize != rhs.outerSize() )
         {
             return false;
         }
 
+        const Index nnz = lhs.nonZeros();
+
+        // outer indices
+        const Index* rhsOuter = rhs.outerIndexPtr();
+        const Index* lhsOuter = lhs.outerIndexPtr();
+
+        // inner indices
+        const Index* rhsInner = rhs.innerIndexPtr();
+        const Index* lhsInner = lhs.innerIndexPtr();
+
         bool equalOuter = true;
         bool equalInner = true;
         const Index size = std::min( outerSize+1, nnz );
         for( Index i=0; i<size; ++i)
         {
-            equalOuter &= (lhsO[ i ] == rhsO[ i ]);
-            equalInner &= (lhsJ[ i ] == rhsJ[ i ]);
+            equalOuter &= (lhsOuter[ i ] == rhsOuter[ i ]);
+            equalInner &= (lhsInner[ i ] == rhsInner[ i ]);
         }
 
-        if( ! equalOuter || ! equalInner ) return false ;
+        if( ! equalOuter || ! equalInner ) {
+            return false ;
+        }
 
         if( outerSize+1 < nnz )
         {
             for(Index i=outerSize+1; i<nnz; ++i)
             {
-                if( lhsJ[ i ] != rhsJ[ i ] ) return false;
+                if( lhsInner[ i ] != rhsInner[ i ] ) {
+                    return false;
+                }
             }
         }
         else if( outerSize+1 > nnz )
         {
             for(Index o=nnz; o<=outerSize; ++o )
             {
-                if( lhsO[ o ] != rhsO[ o ] )
+                if( lhsOuter[ o ] != rhsOuter[ o ] ) {
                     return false;
+                }
             }
         }
         else
         {
             return equalOuter && equalInner;
         }
-
-        /*
-        for(Index o=0; o<=outerSize; ++o )
-        {
-            if( lhsO[ o ] != rhsO[ o ] )
-                return false;
-        }
-        */
     }
 
     return equal;

--- a/opm/autodiff/fastSparseOperations.hpp
+++ b/opm/autodiff/fastSparseOperations.hpp
@@ -194,50 +194,26 @@ equalSparsityPattern(const Lhs& lhs, const Rhs& rhs)
             return false;
         }
 
-        const Index nnz = lhs.nonZeros();
-
         // outer indices
         const Index* rhsOuter = rhs.outerIndexPtr();
         const Index* lhsOuter = lhs.outerIndexPtr();
+        for(Index i=0; i<=outerSize; ++i )
+        {
+            if( lhsOuter[ i ] != rhsOuter[ i ] ) {
+                return false ;
+            }
+        }
 
         // inner indices
         const Index* rhsInner = rhs.innerIndexPtr();
         const Index* lhsInner = lhs.innerIndexPtr();
 
-        bool equalOuter = true;
-        bool equalInner = true;
-        const Index size = std::min( outerSize+1, nnz );
-        for( Index i=0; i<size; ++i)
+        const Index nnz = lhs.nonZeros();
+        for( Index i=0; i<nnz; ++i)
         {
-            equalOuter &= (lhsOuter[ i ] == rhsOuter[ i ]);
-            equalInner &= (lhsInner[ i ] == rhsInner[ i ]);
-        }
-
-        if( ! equalOuter || ! equalInner ) {
-            return false ;
-        }
-
-        if( outerSize+1 < nnz )
-        {
-            for(Index i=outerSize+1; i<nnz; ++i)
-            {
-                if( lhsInner[ i ] != rhsInner[ i ] ) {
-                    return false;
-                }
+            if( lhsInner[ i ] != rhsInner[ i ] ) {
+                return false;
             }
-        }
-        else if( outerSize+1 > nnz )
-        {
-            for(Index o=nnz; o<=outerSize; ++o )
-            {
-                if( lhsOuter[ o ] != rhsOuter[ o ] ) {
-                    return false;
-                }
-            }
-        }
-        else
-        {
-            return equalOuter && equalInner;
         }
     }
 

--- a/opm/autodiff/fastSparseOperations.hpp
+++ b/opm/autodiff/fastSparseOperations.hpp
@@ -181,8 +181,8 @@ template<typename Lhs, typename Rhs>
 inline bool
 equalSparsityPattern(const Lhs& lhs, const Rhs& rhs)
 {
-  // if non zeros don't match, matrices don't have the same sparsity pattern
-  bool equal = (lhs.nonZeros() == rhs.nonZeros());
+  // if both matrices have equal storage and non zeros match, we can check sparsity pattern
+  bool equal = (Lhs::IsRowMajor == Rhs::IsRowMajor) && (lhs.nonZeros() == rhs.nonZeros());
 
   // check complete sparsity pattern
   if( equal )
@@ -195,7 +195,6 @@ equalSparsityPattern(const Lhs& lhs, const Rhs& rhs)
 
     for(Index i=0; i<nnz; ++i )
     {
-        //equal &= ( lhsJ[ i ] == rhsJ[ i ] );
         if( lhsJ[ i ] != rhsJ[ i ] )
             return false;
     }
@@ -228,6 +227,7 @@ fastSparseAdd(Lhs& lhs, const Rhs& rhs)
     }
     else
     {
+        // default Eigen operator+=
         lhs += rhs;
     }
 }
@@ -256,6 +256,7 @@ fastSparseSubstract(Lhs& lhs, const Rhs& rhs)
     }
     else
     {
+        // default Eigen operator-=
         lhs -= rhs;
     }
 }

--- a/opm/autodiff/fastSparseProduct.hpp
+++ b/opm/autodiff/fastSparseProduct.hpp
@@ -177,98 +177,87 @@ inline void fastSparseDiagProduct(const Eigen::SparseMatrix<double>& lhs,
     }
 }
 
-
-namespace detail {
-
-    struct AddTo
-    {
-        template <class T>
-        inline void operator()( T& a, const T& b ) const
-        {
-            a += b;
-        }
-    };
-
-    struct SubstractFrom
-    {
-        template <class T>
-        inline void operator()( T& a, const T& b ) const
-        {
-            a -= b;
-        }
-    };
-
-} // end namespace detail
-
-
-// this function substracts two sparse matrices
-// if the sparsity pattern is the same a faster add/substract is performed
 template<typename Lhs, typename Rhs>
-void fastSparseBinaryOp(Lhs& lhs, const Rhs& rhs, const bool add )
+inline bool
+equalSparsityPattern(const Lhs& lhs, const Rhs& rhs)
 {
   // if non zeros don't match, matrices don't have the same sparsity pattern
-  bool equal = lhs.nonZeros() == rhs.nonZeros();
-
-  typedef typename Eigen::internal::remove_all<Lhs>::type::Scalar Scalar;
-  typedef typename Eigen::internal::remove_all<Lhs>::type::Index Index;
-
-  const Index nnz = lhs.nonZeros();
-
-  const Index*  rhsJ = rhs.innerIndexPtr();
-  const Index*  lhsJ = lhs.innerIndexPtr();
+  bool equal = (lhs.nonZeros() == rhs.nonZeros());
 
   // check complete sparsity pattern
   if( equal )
   {
+    typedef typename Eigen::internal::remove_all<Lhs>::type::Index Index;
+    const Index nnz = lhs.nonZeros();
+
+    const Index* rhsJ = rhs.innerIndexPtr();
+    const Index* lhsJ = lhs.innerIndexPtr();
+
     for(Index i=0; i<nnz; ++i )
     {
-      equal &= ( lhsJ[ i ] == rhsJ[ i ] );
+        //equal &= ( lhsJ[ i ] == rhsJ[ i ] );
+        if( lhsJ[ i ] != rhsJ[ i ] )
+            return false;
     }
   }
 
-  // if sparsity pattern does not match,
-  // fallback to default implementation
-  if( ! equal )
-  {
-      if( add ) {
-          lhs += rhs;
-      }
-      else {
-          lhs -= rhs;
-      }
-      return;
-  }
-
-  // fast add/substract using only the data pointers
-  const Scalar* rhsV = rhs.valuePtr();
-  Scalar* lhsV = lhs.valuePtr();
-
-  if( add )
-  {
-      for(Index i=0; i<nnz; ++i )
-      {
-          lhsV[ i ] += rhsV[ i ];
-      }
-  }
-  else
-  {
-      for(Index i=0; i<nnz; ++i )
-      {
-          lhsV[ i ] -= rhsV[ i ];
-      }
-  }
+  return equal;
 }
 
+// this function substracts two sparse matrices
+// if the sparsity pattern is the same a faster add/substract is performed
 template<typename Lhs, typename Rhs>
-void fastSparseAdd(Lhs& lhs, const Rhs& rhs )
+inline void
+fastSparseAdd(Lhs& lhs, const Rhs& rhs)
 {
-    fastSparseBinaryOp( lhs, rhs, true ); //detail::AddTo() );
+    if( equalSparsityPattern( lhs, rhs ) )
+    {
+        typedef typename Eigen::internal::remove_all<Lhs>::type::Scalar Scalar;
+        typedef typename Eigen::internal::remove_all<Lhs>::type::Index Index;
+
+        const Index nnz = lhs.nonZeros();
+
+        // fast add using only the data pointers
+        const Scalar* rhsV = rhs.valuePtr();
+        Scalar* lhsV = lhs.valuePtr();
+
+        for(Index i=0; i<nnz; ++i )
+        {
+            lhsV[ i ] += rhsV[ i ];
+        }
+    }
+    else
+    {
+        lhs += rhs;
+    }
 }
 
+// this function substracts two sparse matrices
+// if the sparsity pattern is the same a faster add/substract is performed
 template<typename Lhs, typename Rhs>
-void fastSparseSubstract(Lhs& lhs, const Rhs& rhs )
+inline void
+fastSparseSubstract(Lhs& lhs, const Rhs& rhs)
 {
-    fastSparseBinaryOp( lhs, rhs, false ); //detail::SubstractFrom() );
+    if( equalSparsityPattern( lhs, rhs ) )
+    {
+        typedef typename Eigen::internal::remove_all<Lhs>::type::Scalar Scalar;
+        typedef typename Eigen::internal::remove_all<Lhs>::type::Index Index;
+
+        const Index nnz = lhs.nonZeros();
+
+        // fast add using only the data pointers
+        const Scalar* rhsV = rhs.valuePtr();
+        Scalar* lhsV = lhs.valuePtr();
+
+        for(Index i=0; i<nnz; ++i )
+        {
+            lhsV[ i ] -= rhsV[ i ];
+        }
+    }
+    else
+    {
+        lhs -= rhs;
+    }
 }
 
 } // end namespace Opm

--- a/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.cpp
+++ b/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.cpp
@@ -99,7 +99,6 @@ namespace {
         }
 
         typedef AutoDiffBlock<double>::V V;
-        typedef AutoDiffBlock<double>::M M;
 
         const V& gpot  = geo.gravityPotential();
         const V& trans = geo.transmissibility();


### PR DESCRIPTION
This PR improves performance of flow by introducing an improved sparse add method for AutoDiffMatrix. When two SparseMatrix have the same sparsity pattern, we can simply add all matrix entries. Performance improvement of close to 10% has been discovered with SPE9 and Norne. 

This PR already includes #578. I will rebase once the other PR is merged. 