### PR TITLE
Account for variable change in 2.4.1

### DIFF
--- a/opm/autodiff/DuneMatrix.hpp
+++ b/opm/autodiff/DuneMatrix.hpp
@@ -80,7 +80,7 @@ namespace Opm
             this->m = cols;
 
             typedef Super::size_type size_type ;
-#if DUNE_VERSION_NEWER(DUNE_ISTL, 3, 0)
+#if DUNE_VERSION_NEWER_REV(DUNE_ISTL, 2, 4, 1)
             size_type& nnz = this->nnz_;
             std::shared_ptr<size_type>& j = this->j_;
 #else


### PR DESCRIPTION
Due to the upcomming release the name changes (`j`->`j_`, `nnz`->`nnz_`) already appear
in 2.4.1. This commit now checks for 2.4.1 and newer instead of 3.0 and newer.