### PR TITLE
fix the fallout of the removal of the opm-core black-oil PVT classes

### DIFF
--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -22,26 +22,19 @@
 #include <config.h>
 
 #include <opm/autodiff/BlackoilPropsAdFromDeck.hpp>
+#include <opm/autodiff/AutoDiffHelpers.hpp>
+
+#include <opm/core/props/BlackoilPropertiesInterface.hpp>
+#include <opm/core/props/BlackoilPhases.hpp>
+#include <opm/core/utility/Units.hpp>
+#include <opm/core/utility/extractPvtTableIndex.hpp>
 
 #include <opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp>
 
-#include <opm/autodiff/AutoDiffHelpers.hpp>
-#include <opm/core/props/BlackoilPropertiesInterface.hpp>
-#include <opm/core/props/BlackoilPhases.hpp>
-#include <opm/core/props/pvt/PvtInterface.hpp>
-#include <opm/core/props/pvt/PvtConstCompr.hpp>
-#include <opm/core/props/pvt/PvtDead.hpp>
-#include <opm/core/props/pvt/PvtDeadSpline.hpp>
-#include <opm/core/props/pvt/PvtLiveOil.hpp>
-#include <opm/core/props/pvt/PvtLiveGas.hpp>
-#include <opm/core/props/pvt/ThermalWaterPvtWrapper.hpp>
-#include <opm/core/props/pvt/ThermalOilPvtWrapper.hpp>
-#include <opm/core/props/pvt/ThermalGasPvtWrapper.hpp>
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/core/utility/Units.hpp>
-
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+
+#include <opm/common/ErrorMacros.hpp>
 
 namespace Opm
 {

--- a/opm/autodiff/SolventPropsAdFromDeck.cpp
+++ b/opm/autodiff/SolventPropsAdFromDeck.cpp
@@ -21,11 +21,12 @@
 #include <opm/autodiff/SolventPropsAdFromDeck.hpp>
 #include <opm/autodiff/AutoDiffHelpers.hpp>
 
+#include <opm/core/utility/extractPvtTableIndex.hpp>
+
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvdsTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SsfnTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp>
-
 
 namespace Opm
 {
@@ -381,7 +382,6 @@ ADB SolventPropsAdFromDeck::makeADBfromTables(const ADB& X_AD,
     }
     return ADB::function(std::move(x), std::move(jacs));
 }
-
 
 
 V SolventPropsAdFromDeck::solventSurfaceDensity(const Cells& cells) const {

--- a/opm/autodiff/SolventPropsAdFromDeck.hpp
+++ b/opm/autodiff/SolventPropsAdFromDeck.hpp
@@ -23,8 +23,7 @@
 #include <opm/autodiff/BlackoilPropsAdInterface.hpp>
 #include <opm/autodiff/AutoDiffBlock.hpp>
 
-#include <opm/core/props/pvt/PvtDead.hpp>
-#include <opm/core/props/pvt/PvtInterface.hpp>
+#include <opm/core/utility/NonuniformTableLinear.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
@@ -139,7 +138,6 @@ public:
 
 
 private:
-
     /// Makes ADB from table values
     /// \param[in]  X               Array of n table lookup values.
     /// \param[in]  cells           Array of n cell indices to be associated with the fraction values.


### PR DESCRIPTION
the changes are all pretty trivial: all of them remove of some header file `#include ` statements which do not exist anymore after the opm-core PVT classes have been removed and the addition of `#include ` statements for classes which where previously included via the old PVT headers (i.e., by transitivity).