### PR TITLE
Bugfix in backup/restore.

### DIFF
--- a/opm/autodiff/BackupRestore.hpp
+++ b/opm/autodiff/BackupRestore.hpp
@@ -106,7 +106,7 @@ namespace Opm {
         void readContainerImpl( std::istream& stream, Container& container, const bool adjustSize )
         {
             typedef typename Container :: value_type T;
-            size_t dataSize = 0;
+            unsigned int dataSize = 0;
             readValue( stream, dataSize );
             if( adjustSize && dataSize > 0 ) {
                 resizeContainer( container, dataSize/sizeof(T) );
@@ -115,7 +115,7 @@ namespace Opm {
             if( dataSize != container.size() * sizeof( T ) )
             {
                 OPM_THROW(std::logic_error,
-                        "Size of stored data and simulation data does not match"
+                        "Size of stored data and simulation data does not match "
                         << dataSize << " " << (container.size() * sizeof( T )) );
             }
             if( dataSize > 0 ) {

--- a/opm/autodiff/fastSparseOperations.hpp
+++ b/opm/autodiff/fastSparseOperations.hpp
@@ -245,7 +245,7 @@ fastSparseAdd(Lhs& lhs, const Rhs& rhs)
     else
     {
         // default Eigen operator+=
-        lhs = lhs + rhs;
+        lhs += rhs;
     }
 }
 
@@ -274,7 +274,7 @@ fastSparseSubstract(Lhs& lhs, const Rhs& rhs)
     else
     {
         // default Eigen operator-=
-        lhs = lhs - rhs;
+        lhs -= rhs;
     }
 }
 


### PR DESCRIPTION
This PR fixes a bug in the backup/restore due to a mix between size_t (64 bit) and unsigned int (32 bit).
It also includes a small change in fast sparse operations.