### PR TITLE
Fixes the exception for models with threshold pressures.

### DIFF
--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -511,8 +511,10 @@ namespace Opm
             // If there are more than one processors involved, we now repartition the grid
             // and initilialize new properties and states for it.
             if (must_distribute_) {
-                distributeGridAndData(grid_init_->grid(), deck_, eclipse_state_, state_, *fluidprops_, *geoprops_,
-                                      material_law_manager_, parallel_information_, use_local_perm_);
+                distributeGridAndData(grid_init_->grid(), deck_, eclipse_state_,
+                                      state_, *fluidprops_, *geoprops_,
+                                      material_law_manager_, threshold_pressures_,
+                                      parallel_information_, use_local_perm_);
             }
         }
 

--- a/opm/autodiff/RedistributeDataHandles.hpp
+++ b/opm/autodiff/RedistributeDataHandles.hpp
@@ -469,7 +469,7 @@ void distributeGridAndData( Dune::CpGrid& grid,
         {
             OPM_THROW(std::runtime_error, "NNCs not yet supported for parallel runs. "
                       << UgGridHelpers::numFaces(grid) << " faces but " <<
-                      threshold_pressures.size()<<" pressure values");
+                      threshold_pressures.size()<<" threshold pressure values");
         }
         distributed_pressures.resize(UgGridHelpers::numFaces(grid));
         ThresholdPressureDataHandle press_handle(global_grid, grid,


### PR DESCRIPTION
Since the support for threshold pressures running Norne with
flow_mpi aborted error messages like
```
Program threw an exception: [/home/mblatt/DUNE-test/opm-autodiff/opm/autodiff/BlackoilModelBase_impl.hpp:383] Illegal size of threshold_pressures input ( 153924 ), must be equal to number of faces + nncs ( 78316 + 0 ).
```
This commit now distributes the threshold pressures (if present) just like the rest
of the model properties and Norne does not abort here any more.

Please note:
1. If there are NNCs flow_mpi will abort with an error.
2. We might want to resort to reading and calculating the threshold pressure
  (and maybe other properties) on distributed grids instead of using communication.

Fixes #589 