### PR TITLE
BlackoilPropsAdFromDeck: allow the AutoDiffBlock which represents temperature to be empty

### DIFF
--- a/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.cpp
+++ b/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.cpp
@@ -440,6 +440,10 @@ namespace {
         int nextvar = 0;
         state.pressure = vars[ nextvar++ ];
 
+        // Temperature. (this is always a constant so far)
+        const V T = Eigen::Map<const V>(& x.temperature()[0], nc, 1);
+        state.temperature = ADB::constant(T);
+
         // Saturation.
         const std::vector<int>& bpat = vars[0].blockPattern();
         {


### PR DESCRIPTION
Since it came quite as a surprise to me that this can be the case, the
better fix is possibly to unconditionally create an ADB for
temperature.