### PR TITLE
PolymerState changes

### DIFF
--- a/opm/polymer/IncompTpfaPolymer.cpp
+++ b/opm/polymer/IncompTpfaPolymer.cpp
@@ -102,9 +102,9 @@ namespace Opm
         c_ = &state.concentration();
         cmax_ = &state.maxconcentration();
         if (rock_comp_props_ != 0 && rock_comp_props_->isActive()) {
-            solveRockComp(dt, state.twophaseState(), well_state);
+            solveRockComp(dt, state, well_state);
         } else {
-            solveIncomp(dt, state.twophaseState(), well_state);
+            solveIncomp(dt, state, well_state);
         }
     }
 
@@ -116,7 +116,7 @@ namespace Opm
 
     /// Compute per-solve dynamic properties.
     void IncompTpfaPolymer::computePerSolveDynamicData(const double /*dt*/,
-                                                       const TwophaseState& state,
+                                                       const PolymerState& state,
                                                        const WellState& /*well_state*/)
     {
         // Computed here:

--- a/opm/polymer/IncompTpfaPolymer.hpp
+++ b/opm/polymer/IncompTpfaPolymer.hpp
@@ -96,7 +96,7 @@ namespace Opm
 
     private:
         virtual void computePerSolveDynamicData(const double dt,
-                                                const TwophaseState& state,
+                                                const PolymerState& state,
                                                 const WellState& well_state);
     private:
         // ------ Data that will remain unmodified after construction. ------

--- a/opm/polymer/PolymerState.hpp
+++ b/opm/polymer/PolymerState.hpp
@@ -21,7 +21,7 @@
 #define OPM_POLYMERSTATE_HEADER_INCLUDED
 
 
-#include <opm/core/simulator/TwophaseState.hpp>
+#include <opm/core/simulator/SimulatorState.hpp>
 #include <opm/core/grid.h>
 #include <vector>
 
@@ -29,57 +29,34 @@ namespace Opm
 {
 
     /// Simulator state for a two-phase simulator with polymer.
-    class PolymerState
+    class PolymerState : public SimulatorState
     {
     public:
-        void init(const UnstructuredGrid& g, int num_phases)
-        {
-            this->init(g.number_of_cells, g.number_of_faces, num_phases);
-        }
 
         void init(int number_of_cells, int number_of_faces, int num_phases)
         {
-            state2p_.init(number_of_cells, number_of_faces, num_phases);
-            concentration_.resize(number_of_cells, 0.0);
-            cmax_.resize(number_of_cells, 0.0);
+            SimulatorState::init( number_of_cells , number_of_faces , num_phases );
+            registerCellData("CONCENTRATION" , 1 , 0 );
+            registerCellData("CMAX" , 1 , 0 );
         }
 
-        enum ExtremalSat { MinSat = TwophaseState::MinSat, MaxSat = TwophaseState::MaxSat };
-
-        void setFirstSat(const std::vector<int>& cells,
-                         const Opm::IncompPropertiesInterface& props,
-                         ExtremalSat es)
-        {
-            // A better solution for embedding TwophaseState::ExtremalSat could perhaps
-            // be found, to avoid the cast.
-            state2p_.setFirstSat(cells, props, static_cast<TwophaseState::ExtremalSat>(es));
+        const std::vector<double>& concentration() const {
+            return getCellData("CONCENTRATION");
         }
 
-        inline int numPhases() const
-        {
-            return state2p_.numPhases();
+        const std::vector<double>& maxconcentration() const {
+            return getCellData("CMAX");
         }
-        std::vector<double>& pressure    ()     { return state2p_.pressure(); }
-        std::vector<double>& facepressure()     { return state2p_.facepressure(); }
-        std::vector<double>& faceflux    ()     { return state2p_.faceflux(); }
-        std::vector<double>& saturation  ()     { return state2p_.saturation(); }
-        std::vector<double>& concentration()    { return concentration_; }
-        std::vector<double>& maxconcentration() { return cmax_; }
 
-        const std::vector<double>& pressure    () const     { return state2p_.pressure(); }
-        const std::vector<double>& facepressure() const     { return state2p_.facepressure(); }
-        const std::vector<double>& faceflux    () const     { return state2p_.faceflux(); }
-        const std::vector<double>& saturation  () const     { return state2p_.saturation(); }
-        const std::vector<double>& concentration() const    { return concentration_; }
-        const std::vector<double>& maxconcentration() const { return cmax_; }
 
-        TwophaseState& twophaseState() { return state2p_; }
-        const TwophaseState& twophaseState() const { return state2p_; }
-        
-    private:
-        TwophaseState state2p_;
-        std::vector<double> concentration_;
-        std::vector<double> cmax_;
+        std::vector<double>& concentration()  {
+            return getCellData("CONCENTRATION");
+        }
+
+        std::vector<double>& maxconcentration()  {
+            return getCellData("CMAX");
+        }
+
     };
 
 } // namespace Opm


### PR DESCRIPTION
 - The PolymerState class will derive from SimulatorState, instead of
   containing a TwoPhaseState instance.

 - The Polymer calculation methods take PolymerState& input argument
   instead of TwoPhaseState&

This is a followup to: https://github.com/OPM/opm-core/pull/954

OK: Have now run Norne successfully - in my opinion ready to be merged.