### PR TITLE
Adapt to removed init() parameter.

### DIFF
--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -587,7 +587,7 @@ namespace Opm
 
             // initialize variables
             const auto initConfig = eclipse_state_->getInitConfig();
-            simtimer.init(timeMap, initConfig->getRestartInitiated(), (size_t)initConfig->getRestartStep());
+            simtimer.init(timeMap, (size_t)initConfig->getRestartStep());
 
 
 


### PR DESCRIPTION
This is the follow-up to OPM/opm-core#965.