### PR TITLE
adding flag to wops_ms_ to indicate if MSW is involved.

### DIFF
--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -205,6 +205,7 @@ namespace Opm {
             AutoDiffMatrix eliminate_topseg;              // change the top segment related to be zero
             std::vector<int> well_cells;                  // the set of perforated cells
             V conn_trans_factors;                         // connection transmissibility factors
+            bool has_multisegment_wells;                  // flag indicating whether there is any muli-segment well
         };
 
         MultiSegmentWellOps wops_ms_;


### PR DESCRIPTION
to reduce some extra cost when multi-segment well is not involved.

The functions mainly affected are `addWellFlux`, `computeSegmentFluidProperties` and `computeWellConnectionPerssures`, which show relatively bigger performance degeneration due to handling usual wells as multi-segment well with one segment. 

The performance difference between flow_multisegment and flow is much smaller (1% or 2%, which is hard to test accurately due to the performance fluctuation of the computer itself.) now.

The results from flow_multisegment are not changed by this PR. 