### PR TITLE
enable relperm diagnostics for solvent model.

### DIFF
--- a/opm/autodiff/FlowMainSolvent.hpp
+++ b/opm/autodiff/FlowMainSolvent.hpp
@@ -107,18 +107,6 @@ namespace Opm
                                                  Base::deck_->hasKeyword("SOLVENT")));
         }
 
-        // run diagnostics
-        // Writes to:
-        //   logFile_
-        void runDiagnostics()
-        {
-            std::shared_ptr<Opm::StreamLog> streamLog = std::make_shared<Opm::StreamLog>(Base::logFile_, Opm::Log::DefaultMessageTypes);
-            const std::string msg = "Relperm diagnostic not implemented for the solvent model ";
-            std::cout << "\n" << msg << "\n" << std::endl;
-            streamLog->addMessage(Log::MessageType::Info, msg);
-        }
-
-
     };
 
 


### PR DESCRIPTION
This PR need https://github.com/OPM/opm-core/pull/972.
@totto82 I have test one of opm-data/solvent_test_suit, would you like to test more or the cases that have issues? 