### PR TITLE
Bugfix. Fix setting initial rates in updateWellControls

### DIFF
--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1621,14 +1621,18 @@ namespace detail {
                         }
                     }
                 } else if (well_type == PRODUCER) {
-                    // for single phase producers sum of distr should be 1.0
-                    double sumdistr = distr[0];
-                    for (int phase = 1; phase < np; ++phase) {
-                        sumdistr += distr[phase];
-                    }
-                    std::cout << sumdistr << std::endl;
+
+                    // only set target as initial rates for single phase
+                    // producers. (orat, grat and wrat, and not lrat)
+                    // lrat will result in numPhasesWithTargetsUnderThisControl == 2
+                    int numPhasesWithTargetsUnderThisControl = 0;
                     for (int phase = 0; phase < np; ++phase) {
-                        if (distr[phase] > 0.0 && sumdistr == 1.0 ) {
+                        if (distr[phase] > 0.0) {
+                            numPhasesWithTargetsUnderThisControl += 1;
+                        }
+                    }
+                    for (int phase = 0; phase < np; ++phase) {
+                        if (distr[phase] > 0.0 && numPhasesWithTargetsUnderThisControl < 2 ) {
                             xw.wellRates()[np*w + phase] = target * distr[phase];
                         }
                     }


### PR DESCRIPTION
- The initial rates are only set to target values for single phase
producers (orat, wrat, grat).
- For injectors compi is used to determine the initial target rates.

Tested on SPE1 and SPE9 where ORAT is substituted with LRAT. 