### PR TITLE
Refactor the solvent model 

### DIFF
--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -398,9 +398,9 @@ namespace Opm {
         assembleMassBalanceEq(const SolutionState& state);
 
         void
-        extractWellPerfProperties(std::vector<ADB>& mob_perfcells,
-                                  std::vector<ADB>& b_perfcells,
-                                  const SolutionState&) const;
+        extractWellPerfProperties(const SolutionState& state,
+                                  std::vector<ADB>& mob_perfcells,
+                                  std::vector<ADB>& b_perfcells) const;
 
         bool
         solveWellEq(const std::vector<ADB>& mob_perfcells,

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -392,7 +392,8 @@ namespace Opm {
 
         void
         extractWellPerfProperties(std::vector<ADB>& mob_perfcells,
-                                  std::vector<ADB>& b_perfcells) const;
+                                  std::vector<ADB>& b_perfcells,
+                                  const SolutionState&) const;
 
         bool
         solveWellEq(const std::vector<ADB>& mob_perfcells,

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -387,6 +387,13 @@ namespace Opm {
         void computeWellConnectionPressures(const SolutionState& state,
                                             const WellState& xw);
 
+        void computePropertiesForWellConnectionPressures(const SolutionState& state,
+                                                         const WellState& xw,
+                                                         std::vector<double>& b_perf,
+                                                         std::vector<double>& rsmax_perf,
+                                                         std::vector<double>& rvmax_perf,
+                                                         std::vector<double>& surf_dens_perf);
+
         void
         assembleMassBalanceEq(const SolutionState& state);
 

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -978,7 +978,7 @@ namespace detail {
 
         std::vector<ADB> mob_perfcells;
         std::vector<ADB> b_perfcells;
-        asImpl().extractWellPerfProperties(mob_perfcells, b_perfcells, state);
+        asImpl().extractWellPerfProperties(state, mob_perfcells, b_perfcells);
         if (param_.solve_welleq_initially_ && initial_assembly) {
             // solve the well equations as a pre-processing step
             asImpl().solveWellEq(mob_perfcells, b_perfcells, state, well_state);
@@ -1125,9 +1125,9 @@ namespace detail {
 
     template <class Grid, class Implementation>
     void
-    BlackoilModelBase<Grid, Implementation>::extractWellPerfProperties(std::vector<ADB>& mob_perfcells,
-                                                                       std::vector<ADB>& b_perfcells,
-                                                                       const SolutionState&) const
+    BlackoilModelBase<Grid, Implementation>::extractWellPerfProperties(const SolutionState&,
+                                                                       std::vector<ADB>& mob_perfcells,
+                                                                       std::vector<ADB>& b_perfcells) const
     {
         // If we have wells, extract the mobilities and b-factors for
         // the well-perforated cells.

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -871,9 +871,6 @@ namespace detail {
         surf_dens_perf.assign(rho.data(), rho.data() + nperf * pu.num_phases);
     }
 
-        // Gravity
-        double grav = detail::getGravity(geo_.gravity(), dimensions(grid_));
-
 
     template <class Grid, class Implementation>
     void BlackoilModelBase<Grid, Implementation>::computeWellConnectionPressures(const SolutionState& state,

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -954,7 +954,7 @@ namespace detail {
 
         std::vector<ADB> mob_perfcells;
         std::vector<ADB> b_perfcells;
-        asImpl().extractWellPerfProperties(mob_perfcells, b_perfcells);
+        asImpl().extractWellPerfProperties(mob_perfcells, b_perfcells, state);
         if (param_.solve_welleq_initially_ && initial_assembly) {
             // solve the well equations as a pre-processing step
             asImpl().solveWellEq(mob_perfcells, b_perfcells, state, well_state);
@@ -1102,7 +1102,8 @@ namespace detail {
     template <class Grid, class Implementation>
     void
     BlackoilModelBase<Grid, Implementation>::extractWellPerfProperties(std::vector<ADB>& mob_perfcells,
-                                                                       std::vector<ADB>& b_perfcells) const
+                                                                       std::vector<ADB>& b_perfcells,
+                                                                       const SolutionState&) const
     {
         // If we have wells, extract the mobilities and b-factors for
         // the well-perforated cells.

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -630,7 +630,7 @@ namespace Opm {
 
         std::vector<ADB> mob_perfcells;
         std::vector<ADB> b_perfcells;
-        asImpl().extractWellPerfProperties(mob_perfcells, b_perfcells);
+        asImpl().extractWellPerfProperties(state, mob_perfcells, b_perfcells);
         if (param_.solve_welleq_initially_ && initial_assembly) {
             // solve the well equations as a pre-processing step
             asImpl().solveWellEq(mob_perfcells, b_perfcells, state, well_state);

--- a/opm/autodiff/BlackoilSolventModel.hpp
+++ b/opm/autodiff/BlackoilSolventModel.hpp
@@ -151,6 +151,7 @@ namespace Opm {
         using Base::updateWellControls;
         using Base::computeWellConnectionPressures;
         using Base::addWellControlEq;
+        using Base::computePropertiesForWellConnectionPressures;
 
         std::vector<ADB>
         computeRelPerm(const SolutionState& state) const;
@@ -204,8 +205,12 @@ namespace Opm {
                                            const SolutionState& state,
                                            WellState& xw);
 
-        void computeWellConnectionPressures(const SolutionState& state,
-                                            const WellState& xw);
+        void computePropertiesForWellConnectionPressures(const SolutionState& state,
+                                                         const WellState& xw,
+                                                         std::vector<double>& b_perf,
+                                                         std::vector<double>& rsmax_perf,
+                                                         std::vector<double>& rvmax_perf,
+                                                         std::vector<double>& surf_dens_perf);
 
         void updateEquationsScaling();
 

--- a/opm/autodiff/BlackoilSolventModel.hpp
+++ b/opm/autodiff/BlackoilSolventModel.hpp
@@ -226,9 +226,9 @@ namespace Opm {
         const std::vector<PhasePresence>
         phaseCondition() const {return this->phaseCondition_;}
 
-        void extractWellPerfProperties(std::vector<ADB>& mob_perfcells,
-                                       std::vector<ADB>& b_perfcells,
-                                       const SolutionState& state);
+        void extractWellPerfProperties(const SolutionState& state,
+                                       std::vector<ADB>& mob_perfcells,
+                                       std::vector<ADB>& b_perfcells);
 
 
         // compute effective viscosities (mu_eff_) and effective b factors (b_eff_)  using the ToddLongstaff model

--- a/opm/autodiff/BlackoilSolventModel.hpp
+++ b/opm/autodiff/BlackoilSolventModel.hpp
@@ -87,14 +87,6 @@ namespace Opm {
                          ReservoirState& reservoir_state,
                          WellState& well_state);
 
-        /// Assemble the residual and Jacobian of the nonlinear system.
-        /// \param[in]      reservoir_state   reservoir state variables
-        /// \param[in, out] well_state        well state variables
-        /// \param[in]      initial_assembly  pass true if this is the first call to assemble() in this timestep
-        void assemble(const ReservoirState& reservoir_state,
-                      WellState& well_state,
-                      const bool initial_assembly);
-
 
     protected:
 
@@ -228,6 +220,11 @@ namespace Opm {
 
         const std::vector<PhasePresence>
         phaseCondition() const {return this->phaseCondition_;}
+
+        void extractWellPerfProperties(std::vector<ADB>& mob_perfcells,
+                                       std::vector<ADB>& b_perfcells,
+                                       const SolutionState& state);
+
 
         // compute effective viscosities (mu_eff_) and effective b factors (b_eff_)  using the ToddLongstaff model
         void computeEffectiveProperties(const SolutionState&  state);

--- a/opm/autodiff/BlackoilSolventModel_impl.hpp
+++ b/opm/autodiff/BlackoilSolventModel_impl.hpp
@@ -758,11 +758,11 @@ namespace Opm {
 
     template <class Grid>
     void
-    BlackoilSolventModel<Grid>::extractWellPerfProperties(std::vector<ADB>& mob_perfcells,
-                                                          std::vector<ADB>& b_perfcells,
-                                                          const SolutionState& state)
+    BlackoilSolventModel<Grid>::extractWellPerfProperties(const SolutionState& state,
+                                                          std::vector<ADB>& mob_perfcells,
+                                                          std::vector<ADB>& b_perfcells)
     {
-        Base::extractWellPerfProperties(mob_perfcells, b_perfcells, state);
+        Base::extractWellPerfProperties(state, mob_perfcells, b_perfcells);
         if (has_solvent_) {
             int gas_pos = fluid_.phaseUsage().phase_pos[Gas];
             const std::vector<int>& well_cells = wops_.well_cells;

--- a/opm/autodiff/BlackoilSolventModel_impl.hpp
+++ b/opm/autodiff/BlackoilSolventModel_impl.hpp
@@ -988,16 +988,19 @@ namespace Opm {
                      const ADB& ss) const
     {
         std::vector<ADB> pressures = Base::computePressures(po, sw, so, sg);
-        // The imiscible capillary pressure is evaluated using the total gas saturation (sg + ss)
-        std::vector<ADB> pressures_imisc = Base::computePressures(po, sw, so, sg + ss);
 
-        // Pressure effects on capillary pressure miscibility
-        const ADB pmisc = solvent_props_.pressureMiscibilityFunction(po, cells_);
-        // Only the pcog is effected by the miscibility. Since pg = po + pcog, changing pg is eqvivalent
-        // to changing the gas pressure directly.
-        const int  nc = cells_.size();
-        const V ones = V::Constant(nc, 1.0);
-        pressures[Gas] = ( pmisc * pressures[Gas] + ((ones - pmisc) * pressures_imisc[Gas]));
+        if (has_solvent_) {
+            // The imiscible capillary pressure is evaluated using the total gas saturation (sg + ss)
+            std::vector<ADB> pressures_imisc = Base::computePressures(po, sw, so, sg + ss);
+
+            // Pressure effects on capillary pressure miscibility
+            const ADB pmisc = solvent_props_.pressureMiscibilityFunction(po, cells_);
+            // Only the pcog is effected by the miscibility. Since pg = po + pcog, changing pg is eqvivalent
+            // to changing the gas pressure directly.
+            const int  nc = cells_.size();
+            const V ones = V::Constant(nc, 1.0);
+            pressures[Gas] = ( pmisc * pressures[Gas] + ((ones - pmisc) * pressures_imisc[Gas]));
+        }
         return pressures;
     }
 


### PR DESCRIPTION
Some refactoring to avoid code duplication. Mostly related to extracting data for the wells. 
- `ExtractWellPerfProperties()` is used to compute well perforation properties for the solvent model. This avoids duplication of assemble()
- `computePropertiesForWellConnectionPressures()` is added to the base model in order to tailor this for the solvent model. 
- The last commit fixes a bug that prohibited `flow_solvent` to run deck where solvent is not specified.

Tested on norne and the solvent tests