### PR TITLE
Asynchronous output.

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -307,9 +307,15 @@ namespace Opm
         // serial output is only done on I/O rank
         if( isIORank )
         {
-            // spawn write thread that calls eclWriter.writeTimeStepSerial
-            WriterCall call( *this, timer, state, wellState, substep );
-            std::async( std::move( call ) );
+            if( asyncOutput_ ) {
+                // spawn write thread that calls eclWriter.writeTimeStepSerial
+                WriterCall call( *this, timer, state, wellState, substep );
+                std::async( std::move( call ) );
+            }
+            else {
+                // just write the data to disk
+                writeTimeStepSerial( timer, state, wellState, substep );
+            }
         }
     }
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -259,7 +259,7 @@ namespace Opm
     {
         BlackoilOutputWriter& writer_;
         std::unique_ptr< SimulatorTimerInterface > timer_;
-        const SimulatorState state_;
+        const SimulationDataContainer state_;
         const WellState wellState_;
         const bool substep_;
 
@@ -267,7 +267,7 @@ namespace Opm
 
         explicit WriterCall( BlackoilOutputWriter& writer,
                              const SimulatorTimerInterface& timer,
-                             const SimulatorState& state,
+                             const SimulationDataContainer& state,
                              const WellState& wellState,
                              bool substep,
                              std::future< bool >&& asyncWait)
@@ -336,7 +336,7 @@ namespace Opm
     void
     BlackoilOutputWriter::
     writeTimeStepSerial(const SimulatorTimerInterface& timer,
-                        const SimulatorState& state,
+                        const SimulationDataContainer& state,
                         const WellState& wellState,
                         bool substep)
     {
@@ -372,54 +372,15 @@ namespace Opm
                 backupfile_.write( (const char *) &reportStep, sizeof(int) );
 
                 try {
-                    const BlackoilState& boState = dynamic_cast< const BlackoilState& > (state);
-                    backupfile_ << boState;
+                    backupfile_ << state;
 
                     const WellStateFullyImplicitBlackoil& boWellState = static_cast< const WellStateFullyImplicitBlackoil& > (wellState);
                     backupfile_ << boWellState;
                 }
                 catch ( const std::bad_cast& e )
                 {
-                    // store report step
-                    lastBackupReportStep_ = reportStep;
-                    // write resport step number
-                    backupfile_.write( (const char *) &reportStep, sizeof(int) );
-
-                    /*
-                    try {
-                        const BlackoilState& boState = dynamic_cast< const BlackoilState& > (state);
-                        backupfile_ << boState;
-
-                        const WellStateFullyImplicitBlackoil& boWellState = static_cast< const WellStateFullyImplicitBlackoil& > (wellState);
-                        backupfile_ << boWellState;
-                    }
-                    catch ( const std::bad_cast& e )
-                    {
-
-                    }
-                    */
-
-                    /*
-                    const WellStateFullyImplicitBlackoil* boWellState =
-                        dynamic_cast< const WellStateFullyImplicitBlackoil* > (&wellState);
-                    if( boWellState ) {
-                        backupfile_ << (*boWellState);
-                    }
-                    else
-                        OPM_THROW(std::logic_error,"cast to WellStateFullyImplicitBlackoil failed");
-                    */
-                    backupfile_ << std::flush;
                 }
 
-                /*
-                const WellStateFullyImplicitBlackoil* boWellState =
-                    dynamic_cast< const WellStateFullyImplicitBlackoil* > (&wellState);
-                if( boWellState ) {
-                    backupfile_ << (*boWellState);
-                }
-                else
-                    OPM_THROW(std::logic_error,"cast to WellStateFullyImplicitBlackoil failed");
-                */
                 backupfile_ << std::flush;
             }
         } // end backup

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -86,7 +86,7 @@ namespace Opm
         Opm::DataMap dm;
         dm["saturation"] = &state.saturation();
         dm["pressure"] = &state.pressure();
-        for (const auto& pair : state.cellData()) 
+        for (const auto& pair : state.cellData())
         {
             const std::string& name = pair.first;
             std::string key;
@@ -223,7 +223,7 @@ namespace Opm
 
         /** \copydoc Opm::OutputWriter::writeTimeStep */
         void writeTimeStepSerial(const SimulatorTimerInterface& timer,
-                                 const SimulatorState& reservoirState,
+                                 const SimulationDataContainer& reservoirState,
                                  const Opm::WellState& wellState,
                                  bool substep);
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -218,6 +218,12 @@ namespace Opm
                            const Opm::WellState& wellState,
                            bool substep = false);
 
+        /** \copydoc Opm::OutputWriter::writeTimeStep */
+        void writeTimeStepSerial(const SimulatorTimerInterface& timer,
+                                 const SimulatorState& reservoirState,
+                                 const Opm::WellState& wellState,
+                                 bool substep);
+
         /** \brief return output directory */
         const std::string& outputDirectory() const { return outputDir_; }
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -44,6 +44,7 @@
 #include <sstream>
 #include <iomanip>
 #include <fstream>
+#include <future>
 
 #include <boost/filesystem.hpp>
 
@@ -262,6 +263,7 @@ namespace Opm
         std::unique_ptr< EclipseWriter > eclWriter_;
         EclipseStateConstPtr eclipseState_;
         const bool asyncOutput_ ;
+        std::future< bool > asyncWait_;
     };
 
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -261,6 +261,7 @@ namespace Opm
         std::unique_ptr< OutputWriter  > matlabWriter_;
         std::unique_ptr< EclipseWriter > eclWriter_;
         EclipseStateConstPtr eclipseState_;
+        const bool asyncOutput_ ;
     };
 
 
@@ -293,7 +294,8 @@ namespace Opm
                                       parallelOutput_->numCells(),
                                       parallelOutput_->globalCell() )
                    : 0 ),
-        eclipseState_(eclipseState)
+        eclipseState_(eclipseState),
+        asyncOutput_( output_ ? param.getDefault("async_output", bool( false ) ) : false )
     {
         // For output.
         if (output_ && parallelOutput_->isIORank() ) {


### PR DESCRIPTION
This PR adds the possibility to spawn an extra thread for writing the output. I tested with Norne and SPE9 and the results look the same. However, it should be discussed if the cxx-11 feature std::async can be used or a similar implementation with OpenMP needs to be done (by somebody else). Right now the old state remains default, i.e. no async output.