### PR TITLE
making the interleaved solver works for blackoil polymer simulator.

### DIFF
--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
@@ -234,6 +234,8 @@ namespace Opm {
                                            const SolutionState& state,
                                            WellState& xw);
 
+        void updateEquationsScaling();
+
         void
         computeMassFlux(const int               actph ,
                         const V&                transi,

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
@@ -107,6 +107,7 @@ namespace Opm {
             if (!active_[Water]) {
                 OPM_THROW(std::logic_error, "Polymer must solved in water!\n");
             }
+            residual_.matbalscale.resize(fluid_.numPhases() + 1, 1.1169); // use the same as the water phase
             // If deck has polymer, residual_ should contain polymer equation.
             rq_.resize(fluid_.numPhases() + 1);
             residual_.material_balance_eq.resize(fluid_.numPhases() + 1, ADB::null());
@@ -338,6 +339,26 @@ namespace Opm {
         if (has_polymer_) {
             residual_.material_balance_eq[poly_pos_] = pvdt_ * (rq_[poly_pos_].accum[1] - rq_[poly_pos_].accum[0])
                                                + ops_.div*rq_[poly_pos_].mflux;
+        }
+
+
+        if (param_.update_equations_scaling_) {
+            updateEquationsScaling();
+        }
+
+    }
+
+
+
+
+
+    template <class Grid>
+    void BlackoilPolymerModel<Grid>::updateEquationsScaling()
+    {
+        Base::updateEquationsScaling();
+        if (has_polymer_) {
+            const int water_pos = fluid_.phaseUsage().phase_pos[Water];
+            residual_.matbalscale[poly_pos_] = residual_.matbalscale[water_pos];
         }
     }
 


### PR DESCRIPTION
Not ready for merging yet. 

Comparing with the direct solver, the interleaved solver gives about 14 times faster performance with the 3D_plyshlog test cases in opm-data and does not change the results. 

The scaling factor for the polymer equation currently takes the same scaling factor with the water equation. Not sure if it is the optimal one, while it is an okay one comparing with some other trivial options. 

The CPR solver does not work yet. 

There remains one compiling error though. No clue why it happens and comment will be appreciated. 

```
607 /home/kaib/OPM/debug/opm-autodiff/opm/autodiff/FlowMainPolymer.hpp:109:57: error: expected primary-expression before ‘>’ token
608                  solver_approach = param_.get<std::string>("solver_approach");
```