### PR TITLE
dune.module: add all modules which opm-autodiff depends on explicitly

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -10,4 +10,4 @@ Label: 2016.04-pre
 Maintainer: atgeirr@sintef.no
 MaintainerName: Atgeirr F. Rasmussen
 Url: http://opm-project.org
-Depends: opm-common opm-core dune-cornerpoint dune-istl (>=2.2)
+Depends: opm-common opm-parser opm-output opm-material opm-core dune-cornerpoint dune-istl (>=2.2)


### PR DESCRIPTION
this restores the ability to build opm-autodiff and all dependencies
using `dunecontrol`. Except for opm-common adding these dependencies
is not really required because they were inherited from other modules,
but stating them explicitly is good style IMO.