### PR TITLE
A first step towards Wells refactoring

### DIFF
--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -282,6 +282,7 @@ namespace Opm {
             const Wells& wells() const;
             bool wells_active_;
             const Wells*                    wells_;
+            const WellOps                   wops_;
             V well_perforation_densities_; //Density of each well perforation
             V well_perforation_pressure_diffs_; // Diff to bhp for each well perforation.
         };
@@ -301,7 +302,6 @@ namespace Opm {
         const std::vector<int>          canph_;
         const std::vector<int>          cells_;  // All grid cells
         HelperOps                       ops_;
-        const WellOps                   wops_;
         const bool has_disgas_;
         const bool has_vapoil_;
 
@@ -350,8 +350,6 @@ namespace Opm {
         bool wellsActive() const { return std_wells_.wells_active_; }
         // return true if wells are available on this process
         bool localWellsActive() const { return std_wells_.wells_ ? (std_wells_.wells_->number_of_wells > 0 ) : false; }
-        // return wells object
-        // const Wells& wells () const { assert( bool(std_wells_.wells_ != 0) ); return *(std_wells_.wells_); }
 
         // return the StandardWells object
         StandardWells& stdWells() { return std_wells_; }

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -276,13 +276,23 @@ namespace Opm {
             std::vector<int> well_cells;                  // the set of perforated cells
         };
 
+        struct StandardWells {
+            // keeping the underline, later they will be private members
+            StandardWells(const Wells* wells);
+            const Wells& wells() const;
+            bool wells_active_;
+            const Wells*                    wells_;
+            V well_perforation_densities_; //Density of each well perforation
+            V well_perforation_pressure_diffs_; // Diff to bhp for each well perforation.
+        };
+
         // ---------  Data members  ---------
 
         const Grid&         grid_;
         const BlackoilPropsAdInterface& fluid_;
         const DerivedGeology&           geo_;
         const RockCompressibility*      rock_comp_props_;
-        const Wells*                    wells_;
+        StandardWells                   std_wells_;
         VFPProperties                   vfp_properties_;
         const NewtonIterationBlackoilInterface&    linsolver_;
         // For each canonical phase -> true if active
@@ -305,8 +315,6 @@ namespace Opm {
         V isRs_;
         V isRv_;
         V isSg_;
-        V well_perforation_densities_; //Density of each well perforation
-        V well_perforation_pressure_diffs_; // Diff to bhp for each well perforation.
 
         LinearisedBlackoilResidual residual_;
 
@@ -339,11 +347,15 @@ namespace Opm {
         }
 
         // return true if wells are available in the reservoir
-        bool wellsActive() const { return wells_active_; }
+        bool wellsActive() const { return std_wells_.wells_active_; }
         // return true if wells are available on this process
-        bool localWellsActive() const { return wells_ ? (wells_->number_of_wells > 0 ) : false; }
+        bool localWellsActive() const { return std_wells_.wells_ ? (std_wells_.wells_->number_of_wells > 0 ) : false; }
         // return wells object
-        const Wells& wells () const { assert( bool(wells_ != 0) ); return *wells_; }
+        // const Wells& wells () const { assert( bool(std_wells_.wells_ != 0) ); return *(std_wells_.wells_); }
+
+        // return the StandardWells object
+        StandardWells& stdWells() { return std_wells_; }
+        const StandardWells& stdWells() const { return std_wells_; }
 
         int numWellVars() const;
 

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -307,7 +307,6 @@ namespace Opm {
 
         ModelParameters                 param_;
         bool use_threshold_pressure_;
-        bool wells_active_;
         V threshold_pressures_by_connection_;
 
         std::vector<ReservoirResidualQuant> rq_;

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -269,26 +269,42 @@ namespace Opm {
             ADB              mob;   // Phase mobility (per cell)
         };
 
-        struct WellOps {
-            WellOps(const Wells* wells);
-            Eigen::SparseMatrix<double> w2p;              // well -> perf (scatter)
-            Eigen::SparseMatrix<double> p2w;              // perf -> well (gather)
-            std::vector<int> well_cells;                  // the set of perforated cells
-        };
+        class StandardWells {
+        protected:
+            struct WellOps {
+                WellOps(const Wells* wells);
+                Eigen::SparseMatrix<double> w2p;              // well -> perf (scatter)
+                Eigen::SparseMatrix<double> p2w;              // perf -> well (gather)
+                std::vector<int> well_cells;                  // the set of perforated cells
+            };
 
-        struct StandardWells {
-            // keeping the underline, later they will be private members
+        public:
             StandardWells(const Wells* wells);
+
             const Wells& wells() const;
+
             // return true if wells are available in the reservoir
             bool wellsActive() const;
+            bool& wellsActive();
             // return true if wells are available on this process
             bool localWellsActive() const;
+
+            const WellOps& wellOps() const;
+
+            //Density of each well perforation
+            V& wellPerforationDensities();
+            const V& wellPerforationDensities() const;
+
+            // Diff to bhp for each well perforation.
+            V& wellPerforationPressureDiffs();
+            const V& wellPerforationPressureDiffs() const;
+
+        protected:
             bool wells_active_;
-            const Wells*                    wells_;
-            const WellOps                   wops_;
-            V well_perforation_densities_; //Density of each well perforation
-            V well_perforation_pressure_diffs_; // Diff to bhp for each well perforation.
+            const Wells*   wells_;
+            const WellOps  wops_;
+            V well_perforation_densities_;
+            V well_perforation_pressure_diffs_;
         };
 
         // ---------  Data members  ---------

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -280,6 +280,10 @@ namespace Opm {
             // keeping the underline, later they will be private members
             StandardWells(const Wells* wells);
             const Wells& wells() const;
+            // return true if wells are available in the reservoir
+            bool wellsActive() const;
+            // return true if wells are available on this process
+            bool localWellsActive() const;
             bool wells_active_;
             const Wells*                    wells_;
             const WellOps                   wops_;
@@ -345,10 +349,6 @@ namespace Opm {
             return static_cast<const Implementation&>(*this);
         }
 
-        // return true if wells are available in the reservoir
-        bool wellsActive() const { return std_wells_.wells_active_; }
-        // return true if wells are available on this process
-        bool localWellsActive() const { return std_wells_.wells_ ? (std_wells_.wells_->number_of_wells > 0 ) : false; }
 
         // return the StandardWells object
         StandardWells& stdWells() { return std_wells_; }

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -272,14 +272,14 @@ namespace Opm {
         class StandardWells {
         protected:
             struct WellOps {
-                WellOps(const Wells* wells);
+                explicit WellOps(const Wells* wells);
                 Eigen::SparseMatrix<double> w2p;              // well -> perf (scatter)
                 Eigen::SparseMatrix<double> p2w;              // perf -> well (gather)
                 std::vector<int> well_cells;                  // the set of perforated cells
             };
 
         public:
-            StandardWells(const Wells* wells);
+            explicit StandardWells(const Wells* wells);
 
             const Wells& wells() const;
 

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -285,7 +285,7 @@ namespace Opm {
 
             // return true if wells are available in the reservoir
             bool wellsActive() const;
-            bool& wellsActive();
+            void setWellsActive(const bool wells_active);
             // return true if wells are available on this process
             bool localWellsActive() const;
 
@@ -365,10 +365,18 @@ namespace Opm {
             return static_cast<const Implementation&>(*this);
         }
 
-
-        // return the StandardWells object
+        /// return the StandardWells object
         StandardWells& stdWells() { return std_wells_; }
         const StandardWells& stdWells() const { return std_wells_; }
+
+        /// return the Well struct in the StandardWells
+        const Wells& wells() const { return std_wells_.wells(); }
+
+        /// return true if wells are available in the reservoir
+        bool wellsActive() const { return std_wells_.wellsActive(); }
+
+        /// return true if wells are available on this process
+        bool localWellsActive() const { return std_wells_.localWellsActive(); }
 
         int numWellVars() const;
 

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -194,10 +194,8 @@ namespace detail {
                 // Only rank 0 does print to std::cout if terminal_output is enabled
                 terminal_output_ = (info.communicator().rank()==0);
             }
-            // int local_number_of_wells = std_wells_.wells_ ? std_wells_.wells_->number_of_wells : 0;
             int local_number_of_wells = stdWells().localWellsActive() ? stdWells().wells().number_of_wells : 0;
             int global_number_of_wells = info.communicator().sum(local_number_of_wells);
-            // std_wells_.wells_active_ = ( std_wells_.wells_ && global_number_of_wells > 0 );
             stdWells().wellsActive() = ( stdWells().localWellsActive() && global_number_of_wells > 0 );
             // Compute the global number of cells
             std::vector<int> v( Opm::AutoDiffGrid::numCells(grid_), 1);

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -482,11 +482,35 @@ namespace detail {
 
 
     template <class Grid, class Implementation>
+    bool
+    BlackoilModelBase<Grid, Implementation>::
+    StandardWells::wellsActive() const
+    {
+        return wells_active_;
+    }
+
+
+
+
+
+    template <class Grid, class Implementation>
+    bool
+    BlackoilModelBase<Grid, Implementation>::
+    StandardWells::localWellsActive() const
+    {
+        return wells_ ? (wells_->number_of_wells > 0 ) : false;
+    }
+
+
+
+
+
+    template <class Grid, class Implementation>
     int
     BlackoilModelBase<Grid, Implementation>::numWellVars() const
     {
         // For each well, we have a bhp variable, and one flux per phase.
-        const int nw = localWellsActive() ? stdWells().wells().number_of_wells : 0;
+        const int nw = stdWells().localWellsActive() ? stdWells().wells().number_of_wells : 0;
         return (numPhases() + 1) * nw;
     }
 
@@ -602,7 +626,7 @@ namespace detail {
     BlackoilModelBase<Grid, Implementation>::variableWellStateInitials(const WellState&     xw, std::vector<V>& vars0) const
     {
         // Initial well rates.
-        if ( localWellsActive() )
+        if ( stdWells().localWellsActive() )
         {
             // Need to reshuffle well rates, from phase running fastest
             // to wells running fastest.
@@ -993,7 +1017,7 @@ namespace detail {
 
         // -------- Well equations ----------
 
-        if ( ! wellsActive() ) {
+        if ( ! stdWells().wellsActive() ) {
             return;
         }
 
@@ -1124,7 +1148,7 @@ namespace detail {
                                                                                 const SolutionState&,
                                                                                 const WellState&)
     {
-        if ( !asImpl().localWellsActive() )
+        if ( !asImpl().stdWells().localWellsActive() )
         {
             // If there are no wells in the subdomain of the proces then
             // cq_s has zero size and will cause a segmentation fault below.
@@ -1152,7 +1176,7 @@ namespace detail {
     {
         // If we have wells, extract the mobilities and b-factors for
         // the well-perforated cells.
-        if (!asImpl().localWellsActive()) {
+        if (!asImpl().stdWells().localWellsActive()) {
             mob_perfcells.clear();
             b_perfcells.clear();
             return;
@@ -1181,7 +1205,7 @@ namespace detail {
                                                              V& aliveWells,
                                                              std::vector<ADB>& cq_s) const
     {
-        if( ! localWellsActive() ) return ;
+        if( ! stdWells().localWellsActive() ) return ;
 
         const int np = stdWells().wells().number_of_phases;
         const int nw = stdWells().wells().number_of_wells;
@@ -1329,7 +1353,7 @@ namespace detail {
                                                                                    const SolutionState& state,
                                                                                    WellState& xw) const
     {
-        if ( !asImpl().localWellsActive() )
+        if ( !asImpl().stdWells().localWellsActive() )
         {
             // If there are no wells in the subdomain of the proces then
             // cq_s has zero size and will cause a segmentation fault below.
@@ -1360,7 +1384,7 @@ namespace detail {
     void BlackoilModelBase<Grid, Implementation>::addWellFluxEq(const std::vector<ADB>& cq_s,
                                                                 const SolutionState& state)
     {
-        if( !asImpl().localWellsActive() )
+        if( !asImpl().stdWells().localWellsActive() )
         {
             // If there are no wells in the subdomain of the proces then
             // cq_s has zero size and will cause a segmentation fault below.
@@ -1517,7 +1541,7 @@ namespace detail {
     template <class Grid, class Implementation>
     bool BlackoilModelBase<Grid, Implementation>::isVFPActive() const
     {
-        if( ! localWellsActive() ) {
+        if( ! stdWells().localWellsActive() ) {
             return false;
         }
 
@@ -1549,7 +1573,7 @@ namespace detail {
     template <class Grid, class Implementation>
     void BlackoilModelBase<Grid, Implementation>::updateWellControls(WellState& xw) const
     {
-        if( ! localWellsActive() ) return ;
+        if( ! stdWells().localWellsActive() ) return ;
 
         std::string modestring[4] = { "BHP", "THP", "RESERVOIR_RATE", "SURFACE_RATE" };
         // Find, for each well, if any constraints are broken. If so,
@@ -1715,7 +1739,7 @@ namespace detail {
         std::vector<ADB> mob_perfcells_const(np, ADB::null());
         std::vector<ADB> b_perfcells_const(np, ADB::null());
 
-        if (asImpl().localWellsActive() ){
+        if (asImpl().stdWells().localWellsActive() ){
             // If there are non well in the sudomain of the process
             // thene mob_perfcells_const and b_perfcells_const would be empty
             for (int phase = 0; phase < np; ++phase) {
@@ -1746,7 +1770,7 @@ namespace detail {
             }
 
             ++it;
-            if( localWellsActive() )
+            if( stdWells().localWellsActive() )
             {
                 std::vector<ADB> eqs;
                 eqs.reserve(2);
@@ -1808,7 +1832,7 @@ namespace detail {
                                                           const WellState& xw,
                                                           const V& aliveWells)
     {
-        if( ! localWellsActive() ) return;
+        if( ! stdWells().localWellsActive() ) return;
 
         const int np = stdWells().wells().number_of_phases;
         const int nw = stdWells().wells().number_of_wells;
@@ -2308,7 +2332,7 @@ namespace detail {
                                                              WellState& well_state)
     {
 
-        if( localWellsActive() )
+        if( stdWells().localWellsActive() )
         {
             const int np = stdWells().wells().number_of_phases;
             const int nw = stdWells().wells().number_of_wells;

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -196,7 +196,7 @@ namespace detail {
             }
             int local_number_of_wells = localWellsActive() ? wells().number_of_wells : 0;
             int global_number_of_wells = info.communicator().sum(local_number_of_wells);
-            const bool wells_active = ( localWellsActive() && global_number_of_wells > 0 );
+            const bool wells_active = ( wells_arg && global_number_of_wells > 0 );
             stdWells().setWellsActive(wells_active);
             // Compute the global number of cells
             std::vector<int> v( Opm::AutoDiffGrid::numCells(grid_), 1);
@@ -205,8 +205,7 @@ namespace detail {
         }else
 #endif
         {
-            const bool wells_active = ( localWellsActive() && wells().number_of_wells > 0 );
-            stdWells().setWellsActive(wells_active);
+            stdWells().setWellsActive( localWellsActive() );
             global_nc_    =  Opm::AutoDiffGrid::numCells(grid_);
         }
     }

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -458,9 +458,9 @@ namespace detail {
 
     template <class Grid, class Implementation>
     BlackoilModelBase<Grid, Implementation>::
-    StandardWells::StandardWells(const Wells* wells)
-      : wells_(wells)
-      , wops_(wells)
+    StandardWells::StandardWells(const Wells* wells_arg)
+      : wells_(wells_arg)
+      , wops_(wells_arg)
     {
     }
 
@@ -1659,10 +1659,10 @@ namespace detail {
             case SURFACE_RATE:
                 // assign target value as initial guess for injectors and
                 // single phase producers (orat, grat, wrat)
-                const WellType& well_type = wells().type[w];
+                const WellType& well_type = stdWells().wells().type[w];
                 if (well_type == INJECTOR) {
                     for (int phase = 0; phase < np; ++phase) {
-                        const double& compi = wells().comp_frac[np * w + phase];
+                        const double& compi = stdWells().wells().comp_frac[np * w + phase];
                         if (compi > 0.0) {
                             xw.wellRates()[np*w + phase] = target * compi;
                         }

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -207,6 +207,8 @@ namespace Opm {
 
 
         using Base::stdWells;
+        using Base::wells;
+        using Base::wellsActive;
         using Base::updatePrimalVariableFromState;
         using Base::phaseCondition;
         using Base::fluidRvSat;

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -208,7 +208,6 @@ namespace Opm {
 
         using Base::stdWells;
         using Base::updatePrimalVariableFromState;
-        using Base::wellsActive;
         using Base::phaseCondition;
         using Base::fluidRvSat;
         using Base::fluidRsSat;

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -116,7 +116,6 @@ namespace Opm {
 
         // For non-segmented wells, it should be the density calculated with AVG or SEG way.
         // while usually SEG way by default.
-        using Base::well_perforation_densities_; //Density of each well perforation
         using Base::pvdt_;
         using Base::geo_;
         using Base::active_;
@@ -135,10 +134,6 @@ namespace Opm {
         using Base::cells_;
         using Base::param_;
         using Base::linsolver_;
-
-        // Diff to bhp for each well perforation. only for usual wells.
-        // For segmented wells, they are zeros.
-        using Base::well_perforation_pressure_diffs_;
 
         // Pressure correction due to the different depth of the perforation
         // and the cell center of the grid block
@@ -211,9 +206,7 @@ namespace Opm {
         MultiSegmentWellOps wops_ms_;
 
 
-        // return wells object
-        // TODO: remove this wells structure
-        using Base::wells;
+        using Base::stdWells;
         using Base::updatePrimalVariableFromState;
         using Base::wellsActive;
         using Base::phaseCondition;

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -359,7 +359,7 @@ namespace Opm {
     void BlackoilMultiSegmentModel<Grid>::computeWellConnectionPressures(const SolutionState& state,
                                                                          const WellState& xw)
     {
-        if( ! wellsActive() ) return ;
+        if( ! stdWells().wellsActive() ) return ;
 
         using namespace Opm::AutoDiffGrid;
         // 1. Compute properties required by computeConnectionPressureDelta().
@@ -621,7 +621,7 @@ namespace Opm {
 
         // -------- Well equations ----------
 
-        if ( ! wellsActive() ) {
+        if ( ! stdWells().wellsActive() ) {
             return;
         }
 
@@ -939,7 +939,7 @@ namespace Opm {
     template <class Grid>
     void BlackoilMultiSegmentModel<Grid>::updateWellControls(WellState& xw) const
     {
-        if( ! wellsActive() ) return ;
+        if( ! stdWells().wellsActive() ) return ;
 
         std::string modestring[4] = { "BHP", "THP", "RESERVOIR_RATE", "SURFACE_RATE" };
         // Find, for each well, if any constraints are broken. If so,

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -370,7 +370,7 @@ namespace Opm {
 
         std::vector<int>& well_cells = wops_ms_.well_cells;
 
-        well_perforation_densities_ = V::Zero(nperf_total);
+        stdWells().well_perforation_densities_ = V::Zero(nperf_total);
 
         const V perf_press = Eigen::Map<const V>(xw.perfPress().data(), nperf_total);
 
@@ -462,17 +462,17 @@ namespace Opm {
         // 2. Compute densities
         std::vector<double> cd =
                 WellDensitySegmented::computeConnectionDensities(
-                        wells(), xw, fluid_.phaseUsage(),
+                        stdWells().wells(), xw, fluid_.phaseUsage(),
                         b_perf, rsmax_perf, rvmax_perf, surf_dens_perf);
 
         // 3. Compute pressure deltas
         std::vector<double> cdp =
                 WellDensitySegmented::computeConnectionPressureDelta(
-                        wells(), perf_cell_depth, cd, grav);
+                        stdWells().wells(), perf_cell_depth, cd, grav);
 
         // 4. Store the results
-        well_perforation_densities_ = Eigen::Map<const V>(cd.data(), nperf_total); // This one is not useful for segmented wells at all
-        well_perforation_pressure_diffs_ = Eigen::Map<const V>(cdp.data(), nperf_total);
+        stdWells().well_perforation_densities_ = Eigen::Map<const V>(cd.data(), nperf_total); // This one is not useful for segmented wells at all
+        stdWells().well_perforation_pressure_diffs_ = Eigen::Map<const V>(cdp.data(), nperf_total);
 
         if ( !wops_ms_.has_multisegment_wells ) {
             well_perforation_cell_densities_ = V::Zero(nperf_total);
@@ -698,7 +698,7 @@ namespace Opm {
 
             // Compute drawdown.
             ADB h_nc = msperf_selector.select(well_segment_perforation_pressure_diffs_,
-                                              ADB::constant(well_perforation_pressure_diffs_));
+                                              ADB::constant(stdWells().well_perforation_pressure_diffs_));
             const V h_cj = msperf_selector.select(well_perforation_cell_pressure_diffs_, V::Zero(nperf));
 
             // Special handling for when we are called from solveWellEq().
@@ -765,7 +765,7 @@ namespace Opm {
             // TODO: although we can begin from the brutal force way)
 
             // TODO: stop using wells() here.
-            const DataBlock compi = Eigen::Map<const DataBlock>(wells().comp_frac, nw, np);
+            const DataBlock compi = Eigen::Map<const DataBlock>(stdWells().wells().comp_frac, nw, np);
             std::vector<ADB> wbq(np, ADB::null());
             ADB wbqt = ADB::constant(V::Zero(nseg));
 
@@ -862,7 +862,7 @@ namespace Opm {
         // we need th concept of preforation pressures
         xw.perfPress().resize(nperf_total, -1.e100);
 
-        const V& cdp = well_perforation_pressure_diffs_;
+        const V& cdp = stdWells().well_perforation_pressure_diffs_;
         int start_segment = 0;
         int start_perforation = 0;
         for (int i = 0; i < nw; ++i) {

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -359,7 +359,7 @@ namespace Opm {
     void BlackoilMultiSegmentModel<Grid>::computeWellConnectionPressures(const SolutionState& state,
                                                                          const WellState& xw)
     {
-        if( ! stdWells().wellsActive() ) return ;
+        if( ! wellsActive() ) return ;
 
         using namespace Opm::AutoDiffGrid;
         // 1. Compute properties required by computeConnectionPressureDelta().
@@ -462,13 +462,13 @@ namespace Opm {
         // 2. Compute densities
         std::vector<double> cd =
                 WellDensitySegmented::computeConnectionDensities(
-                        stdWells().wells(), xw, fluid_.phaseUsage(),
+                        wells(), xw, fluid_.phaseUsage(),
                         b_perf, rsmax_perf, rvmax_perf, surf_dens_perf);
 
         // 3. Compute pressure deltas
         std::vector<double> cdp =
                 WellDensitySegmented::computeConnectionPressureDelta(
-                        stdWells().wells(), perf_cell_depth, cd, grav);
+                        wells(), perf_cell_depth, cd, grav);
 
         // 4. Store the results
         stdWells().wellPerforationDensities() = Eigen::Map<const V>(cd.data(), nperf_total); // This one is not useful for segmented wells at all
@@ -621,7 +621,7 @@ namespace Opm {
 
         // -------- Well equations ----------
 
-        if ( ! stdWells().wellsActive() ) {
+        if ( ! wellsActive() ) {
             return;
         }
 
@@ -765,7 +765,7 @@ namespace Opm {
             // TODO: although we can begin from the brutal force way)
 
             // TODO: stop using wells() here.
-            const DataBlock compi = Eigen::Map<const DataBlock>(stdWells().wells().comp_frac, nw, np);
+            const DataBlock compi = Eigen::Map<const DataBlock>(wells().comp_frac, nw, np);
             std::vector<ADB> wbq(np, ADB::null());
             ADB wbqt = ADB::constant(V::Zero(nseg));
 
@@ -939,7 +939,7 @@ namespace Opm {
     template <class Grid>
     void BlackoilMultiSegmentModel<Grid>::updateWellControls(WellState& xw) const
     {
-        if( ! stdWells().wellsActive() ) return ;
+        if( ! wellsActive() ) return ;
 
         std::string modestring[4] = { "BHP", "THP", "RESERVOIR_RATE", "SURFACE_RATE" };
         // Find, for each well, if any constraints are broken. If so,

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -370,7 +370,7 @@ namespace Opm {
 
         std::vector<int>& well_cells = wops_ms_.well_cells;
 
-        stdWells().well_perforation_densities_ = V::Zero(nperf_total);
+        stdWells().wellPerforationDensities() = V::Zero(nperf_total);
 
         const V perf_press = Eigen::Map<const V>(xw.perfPress().data(), nperf_total);
 
@@ -471,8 +471,8 @@ namespace Opm {
                         stdWells().wells(), perf_cell_depth, cd, grav);
 
         // 4. Store the results
-        stdWells().well_perforation_densities_ = Eigen::Map<const V>(cd.data(), nperf_total); // This one is not useful for segmented wells at all
-        stdWells().well_perforation_pressure_diffs_ = Eigen::Map<const V>(cdp.data(), nperf_total);
+        stdWells().wellPerforationDensities() = Eigen::Map<const V>(cd.data(), nperf_total); // This one is not useful for segmented wells at all
+        stdWells().wellPerforationPressureDiffs() = Eigen::Map<const V>(cdp.data(), nperf_total);
 
         if ( !wops_ms_.has_multisegment_wells ) {
             well_perforation_cell_densities_ = V::Zero(nperf_total);
@@ -698,7 +698,7 @@ namespace Opm {
 
             // Compute drawdown.
             ADB h_nc = msperf_selector.select(well_segment_perforation_pressure_diffs_,
-                                              ADB::constant(stdWells().well_perforation_pressure_diffs_));
+                                              ADB::constant( stdWells().wellPerforationPressureDiffs() ));
             const V h_cj = msperf_selector.select(well_perforation_cell_pressure_diffs_, V::Zero(nperf));
 
             // Special handling for when we are called from solveWellEq().
@@ -862,7 +862,7 @@ namespace Opm {
         // we need th concept of preforation pressures
         xw.perfPress().resize(nperf_total, -1.e100);
 
-        const V& cdp = stdWells().well_perforation_pressure_diffs_;
+        const V& cdp = stdWells().wellPerforationPressureDiffs();
         int start_segment = 0;
         int start_perforation = 0;
         for (int i = 0; i < nw; ++i) {

--- a/opm/autodiff/BlackoilSolventModel.hpp
+++ b/opm/autodiff/BlackoilSolventModel.hpp
@@ -130,7 +130,6 @@ namespace Opm {
         // ---------  Protected methods  ---------
 
         // Need to declare Base members we want to use here.
-        using Base::wellsActive;
         using Base::stdWells;
         using Base::variableState;
         using Base::computeGasPressure;

--- a/opm/autodiff/BlackoilSolventModel.hpp
+++ b/opm/autodiff/BlackoilSolventModel.hpp
@@ -110,13 +110,11 @@ namespace Opm {
         using Base::fluid_;
         using Base::geo_;
         using Base::rock_comp_props_;
-        using Base::wells_;
         using Base::linsolver_;
         using Base::active_;
         using Base::canph_;
         using Base::cells_;
         using Base::ops_;
-        using Base::wops_;
         using Base::has_disgas_;
         using Base::has_vapoil_;
         using Base::param_;
@@ -124,7 +122,6 @@ namespace Opm {
         using Base::threshold_pressures_by_connection_;
         using Base::rq_;
         using Base::phaseCondition_;
-        using Base::well_perforation_pressure_diffs_;
         using Base::residual_;
         using Base::terminal_output_;
         using Base::primalVariable_;
@@ -134,7 +131,7 @@ namespace Opm {
 
         // Need to declare Base members we want to use here.
         using Base::wellsActive;
-        using Base::wells;
+        using Base::stdWells;
         using Base::variableState;
         using Base::computeGasPressure;
         using Base::applyThresholdPressures;

--- a/opm/autodiff/BlackoilSolventModel.hpp
+++ b/opm/autodiff/BlackoilSolventModel.hpp
@@ -131,6 +131,7 @@ namespace Opm {
 
         // Need to declare Base members we want to use here.
         using Base::stdWells;
+        using Base::wells;
         using Base::variableState;
         using Base::computeGasPressure;
         using Base::applyThresholdPressures;

--- a/opm/autodiff/BlackoilSolventModel_impl.hpp
+++ b/opm/autodiff/BlackoilSolventModel_impl.hpp
@@ -180,7 +180,7 @@ namespace Opm {
     BlackoilSolventModel<Grid>::variableStateExtractVars(const ReservoirState& x,
                                                          const std::vector<int>& indices,
                                                          std::vector<ADB>& vars) const
-    {         
+    {
         // This is more or less a copy of the base class. Refactoring is needed in the base class
         // to avoid unnecessary copying.
 
@@ -335,7 +335,7 @@ namespace Opm {
         Base::addWellContributionToMassBalanceEq(cq_s, state, xw);
 
         if (has_solvent_) {
-            const int nperf = wells().well_connpos[wells().number_of_wells];
+            const int nperf = stdWells().wells().well_connpos[stdWells().wells().number_of_wells];
             const int nc = Opm::AutoDiffGrid::numCells(grid_);
 
             const Opm::PhaseUsage& pu = fluid_.phaseUsage();
@@ -345,18 +345,18 @@ namespace Opm {
                              ? state.saturation[ pu.phase_pos[ Gas ] ]
                              : zero);
 
-            const std::vector<int> well_cells(wells().well_cells, wells().well_cells + nperf);
+            const std::vector<int> well_cells(stdWells().wells().well_cells, stdWells().wells().well_cells + nperf);
             Selector<double> zero_selector(ss.value() + sg.value(), Selector<double>::Zero);
             ADB F_solvent = subset(zero_selector.select(ss, ss / (ss + sg)),well_cells);
 
-            const int nw = wells().number_of_wells;
+            const int nw = stdWells().wells().number_of_wells;
             V injectedSolventFraction = Eigen::Map<const V>(&xw.solventFraction()[0], nperf);
 
             V isProducer = V::Zero(nperf);
             V ones = V::Constant(nperf,1.0);
             for (int w = 0; w < nw; ++w) {
-                if(wells().type[w] == PRODUCER) {
-                    for (int perf = wells().well_connpos[w]; perf < wells().well_connpos[w+1]; ++perf) {
+                if(stdWells().wells().type[w] == PRODUCER) {
+                    for (int perf = stdWells().wells().well_connpos[w]; perf < stdWells().wells().well_connpos[w+1]; ++perf) {
                         isProducer[perf] = 1;
                     }
                 }
@@ -394,16 +394,16 @@ namespace Opm {
         // 1. Compute properties required by computeConnectionPressureDelta().
         //    Note that some of the complexity of this part is due to the function
         //    taking std::vector<double> arguments, and not Eigen objects.
-        const int nperf = wells().well_connpos[wells().number_of_wells];
-        const int nw = wells().number_of_wells;
-        const std::vector<int> well_cells(wells().well_cells, wells().well_cells + nperf);
+        const int nperf = stdWells().wells().well_connpos[stdWells().wells().number_of_wells];
+        const int nw = stdWells().wells().number_of_wells;
+        const std::vector<int> well_cells(stdWells().wells().well_cells, stdWells().wells().well_cells + nperf);
 
         // Compute the average pressure in each well block
         const V perf_press = Eigen::Map<const V>(xw.perfPress().data(), nperf);
         V avg_press = perf_press*0;
         for (int w = 0; w < nw; ++w) {
-            for (int perf = wells().well_connpos[w]; perf < wells().well_connpos[w+1]; ++perf) {
-                const double p_above = perf == wells().well_connpos[w] ? state.bhp.value()[w] : perf_press[perf - 1];
+            for (int perf = stdWells().wells().well_connpos[w]; perf < stdWells().wells().well_connpos[w+1]; ++perf) {
+                const double p_above = perf == stdWells().wells().well_connpos[w] ? state.bhp.value()[w] : perf_press[perf - 1];
                 const double p_avg = (perf_press[perf] + p_above)/2;
                 avg_press[perf] = p_avg;
             }
@@ -480,8 +480,8 @@ namespace Opm {
                 V isProducer = V::Zero(nperf);
                 V ones = V::Constant(nperf,1.0);
                 for (int w = 0; w < nw; ++w) {
-                    if(wells().type[w] == PRODUCER) {
-                        for (int perf = wells().well_connpos[w]; perf < wells().well_connpos[w+1]; ++perf) {
+                    if(stdWells().wells().type[w] == PRODUCER) {
+                        for (int perf = stdWells().wells().well_connpos[w]; perf < stdWells().wells().well_connpos[w+1]; ++perf) {
                             isProducer[perf] = 1;
                         }
                     }

--- a/opm/autodiff/BlackoilSolventModel_impl.hpp
+++ b/opm/autodiff/BlackoilSolventModel_impl.hpp
@@ -389,8 +389,6 @@ namespace Opm {
                                                                                  std::vector<double>& rvmax_perf,
                                                                                  std::vector<double>& surf_dens_perf)
     {
-        if( ! stdWells().localWellsActive() ) return ;
-
         using namespace Opm::AutoDiffGrid;
         // 1. Compute properties required by computeConnectionPressureDelta().
         //    Note that some of the complexity of this part is due to the function

--- a/opm/autodiff/BlackoilSolventModel_impl.hpp
+++ b/opm/autodiff/BlackoilSolventModel_impl.hpp
@@ -335,7 +335,7 @@ namespace Opm {
         Base::addWellContributionToMassBalanceEq(cq_s, state, xw);
 
         if (has_solvent_) {
-            const int nperf = stdWells().wells().well_connpos[stdWells().wells().number_of_wells];
+            const int nperf = wells().well_connpos[wells().number_of_wells];
             const int nc = Opm::AutoDiffGrid::numCells(grid_);
 
             const Opm::PhaseUsage& pu = fluid_.phaseUsage();
@@ -345,18 +345,18 @@ namespace Opm {
                              ? state.saturation[ pu.phase_pos[ Gas ] ]
                              : zero);
 
-            const std::vector<int> well_cells(stdWells().wells().well_cells, stdWells().wells().well_cells + nperf);
+            const std::vector<int> well_cells(wells().well_cells, wells().well_cells + nperf);
             Selector<double> zero_selector(ss.value() + sg.value(), Selector<double>::Zero);
             ADB F_solvent = subset(zero_selector.select(ss, ss / (ss + sg)),well_cells);
 
-            const int nw = stdWells().wells().number_of_wells;
+            const int nw = wells().number_of_wells;
             V injectedSolventFraction = Eigen::Map<const V>(&xw.solventFraction()[0], nperf);
 
             V isProducer = V::Zero(nperf);
             V ones = V::Constant(nperf,1.0);
             for (int w = 0; w < nw; ++w) {
-                if(stdWells().wells().type[w] == PRODUCER) {
-                    for (int perf = stdWells().wells().well_connpos[w]; perf < stdWells().wells().well_connpos[w+1]; ++perf) {
+                if(wells().type[w] == PRODUCER) {
+                    for (int perf = wells().well_connpos[w]; perf < wells().well_connpos[w+1]; ++perf) {
                         isProducer[perf] = 1;
                     }
                 }
@@ -393,16 +393,16 @@ namespace Opm {
         // 1. Compute properties required by computeConnectionPressureDelta().
         //    Note that some of the complexity of this part is due to the function
         //    taking std::vector<double> arguments, and not Eigen objects.
-        const int nperf = stdWells().wells().well_connpos[stdWells().wells().number_of_wells];
-        const int nw = stdWells().wells().number_of_wells;
-        const std::vector<int> well_cells(stdWells().wells().well_cells, stdWells().wells().well_cells + nperf);
+        const int nperf = wells().well_connpos[wells().number_of_wells];
+        const int nw = wells().number_of_wells;
+        const std::vector<int> well_cells(wells().well_cells, wells().well_cells + nperf);
 
         // Compute the average pressure in each well block
         const V perf_press = Eigen::Map<const V>(xw.perfPress().data(), nperf);
         V avg_press = perf_press*0;
         for (int w = 0; w < nw; ++w) {
-            for (int perf = stdWells().wells().well_connpos[w]; perf < stdWells().wells().well_connpos[w+1]; ++perf) {
-                const double p_above = perf == stdWells().wells().well_connpos[w] ? state.bhp.value()[w] : perf_press[perf - 1];
+            for (int perf = wells().well_connpos[w]; perf < wells().well_connpos[w+1]; ++perf) {
+                const double p_above = perf == wells().well_connpos[w] ? state.bhp.value()[w] : perf_press[perf - 1];
                 const double p_avg = (perf_press[perf] + p_above)/2;
                 avg_press[perf] = p_avg;
             }
@@ -479,8 +479,8 @@ namespace Opm {
                 V isProducer = V::Zero(nperf);
                 V ones = V::Constant(nperf,1.0);
                 for (int w = 0; w < nw; ++w) {
-                    if(stdWells().wells().type[w] == PRODUCER) {
-                        for (int perf = stdWells().wells().well_connpos[w]; perf < stdWells().wells().well_connpos[w+1]; ++perf) {
+                    if(wells().type[w] == PRODUCER) {
+                        for (int perf = wells().well_connpos[w]; perf < wells().well_connpos[w+1]; ++perf) {
                             isProducer[perf] = 1;
                         }
                     }
@@ -764,7 +764,7 @@ namespace Opm {
         Base::extractWellPerfProperties(state, mob_perfcells, b_perfcells);
         if (has_solvent_) {
             int gas_pos = fluid_.phaseUsage().phase_pos[Gas];
-            const std::vector<int>& well_cells = wops_.well_cells;
+            const std::vector<int>& well_cells = stdWells().wellOps().well_cells;
             const int nperf = well_cells.size();
             // Gas and solvent is combinded and solved together
             // The input in the well equation is then the

--- a/opm/autodiff/BlackoilSolventModel_impl.hpp
+++ b/opm/autodiff/BlackoilSolventModel_impl.hpp
@@ -389,6 +389,7 @@ namespace Opm {
                                                                                  std::vector<double>& rvmax_perf,
                                                                                  std::vector<double>& surf_dens_perf)
     {
+        if( ! stdWells().localWellsActive() ) return ;
 
         using namespace Opm::AutoDiffGrid;
         // 1. Compute properties required by computeConnectionPressureDelta().

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
@@ -179,7 +179,6 @@ namespace Opm {
 
         // Need to declare Base members we want to use here.
         using Base::stdWells;
-        using Base::wellsActive;
         using Base::variableState;
         using Base::computePressures;
         using Base::computeGasPressure;

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
@@ -179,6 +179,8 @@ namespace Opm {
 
         // Need to declare Base members we want to use here.
         using Base::stdWells;
+        using Base::wells;
+        using Base::wellsActive;
         using Base::variableState;
         using Base::computePressures;
         using Base::computeGasPressure;

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
@@ -158,13 +158,11 @@ namespace Opm {
         using Base::fluid_;
         using Base::geo_;
         using Base::rock_comp_props_;
-        using Base::wells_;
         using Base::linsolver_;
         using Base::active_;
         using Base::canph_;
         using Base::cells_;
         using Base::ops_;
-        using Base::wops_;
         using Base::has_disgas_;
         using Base::has_vapoil_;
         using Base::param_;
@@ -172,7 +170,6 @@ namespace Opm {
         using Base::threshold_pressures_by_connection_;
         using Base::rq_;
         using Base::phaseCondition_;
-        using Base::well_perforation_pressure_diffs_;
         using Base::residual_;
         using Base::terminal_output_;
         using Base::primalVariable_;
@@ -181,8 +178,8 @@ namespace Opm {
         // ---------  Protected methods  ---------
 
         // Need to declare Base members we want to use here.
+        using Base::stdWells;
         using Base::wellsActive;
-        using Base::wells;
         using Base::variableState;
         using Base::computePressures;
         using Base::computeGasPressure;

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
@@ -731,8 +731,8 @@ namespace Opm {
         ADB b_perfcells = subset(rq_[water_pos].b, well_cells);
 
         const ADB& p_perfcells = subset(state.pressure, well_cells);
-        const V& cdp = stdWells().well_perforation_pressure_diffs_;
-        const ADB perfpressure = (stdWells().wops_.w2p * state.bhp) + cdp;
+        const V& cdp = stdWells().wellPerforationPressureDiffs();
+        const ADB perfpressure = (stdWells().wellOps().w2p * state.bhp) + cdp;
         // Pressure drawdown (also used to determine direction of flow)
         const ADB drawdown =  p_perfcells - perfpressure;
 

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
@@ -384,8 +384,8 @@ namespace Opm {
             const ADB mc = computeMc(state);
             const int nc = xw.polymerInflow().size();
             const V polyin = Eigen::Map<const V>(xw.polymerInflow().data(), nc);
-            const int nperf = wells().well_connpos[wells().number_of_wells];
-            const std::vector<int> well_cells(wells().well_cells, wells().well_cells + nperf);
+            const int nperf = stdWells().wells().well_connpos[stdWells().wells().number_of_wells];
+            const std::vector<int> well_cells(stdWells().wells().well_cells, stdWells().wells().well_cells + nperf);
             const V poly_in_perf = subset(polyin, well_cells);
             const V poly_mc_perf = subset(mc.value(), well_cells);
             const ADB& cq_s_water = cq_s[fluid_.phaseUsage().phase_pos[Water]];
@@ -531,12 +531,12 @@ namespace Opm {
 
         V aliveWells;
 
-        const int np = wells().number_of_phases;
+        const int np = stdWells().wells().number_of_phases;
         std::vector<ADB> cq_s(np, ADB::null());
 
-        const int nw = wells().number_of_wells;
-        const int nperf = wells().well_connpos[nw];
-        const std::vector<int> well_cells(wells().well_cells, wells().well_cells + nperf);
+        const int nw = stdWells().wells().number_of_wells;
+        const int nperf = stdWells().wells().well_connpos[nw];
+        const std::vector<int> well_cells(stdWells().wells().well_cells, stdWells().wells().well_cells + nperf);
 
         std::vector<ADB> mob_perfcells(np, ADB::null());
         std::vector<ADB> b_perfcells(np, ADB::null());
@@ -712,9 +712,9 @@ namespace Opm {
     {
         if( ! wellsActive() ) return ;
 
-        const int nw = wells().number_of_wells;
-        const int nperf = wells().well_connpos[nw];
-        const std::vector<int> well_cells(wells().well_cells, wells().well_cells + nperf);
+        const int nw = stdWells().wells().number_of_wells;
+        const int nperf = stdWells().wells().well_connpos[nw];
+        const std::vector<int> well_cells(stdWells().wells().well_cells, stdWells().wells().well_cells + nperf);
 
         water_vel_wells.resize(cq_sw.size());
         std::copy(cq_sw.value().data(), cq_sw.value().data() + cq_sw.size(), water_vel_wells.begin());
@@ -731,8 +731,8 @@ namespace Opm {
         ADB b_perfcells = subset(rq_[water_pos].b, well_cells);
 
         const ADB& p_perfcells = subset(state.pressure, well_cells);
-        const V& cdp = well_perforation_pressure_diffs_;
-        const ADB perfpressure = (wops_.w2p * state.bhp) + cdp;
+        const V& cdp = stdWells().well_perforation_pressure_diffs_;
+        const ADB perfpressure = (stdWells().wops_.w2p * state.bhp) + cdp;
         // Pressure drawdown (also used to determine direction of flow)
         const ADB drawdown =  p_perfcells - perfpressure;
 

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
@@ -384,8 +384,8 @@ namespace Opm {
             const ADB mc = computeMc(state);
             const int nc = xw.polymerInflow().size();
             const V polyin = Eigen::Map<const V>(xw.polymerInflow().data(), nc);
-            const int nperf = stdWells().wells().well_connpos[stdWells().wells().number_of_wells];
-            const std::vector<int> well_cells(stdWells().wells().well_cells, stdWells().wells().well_cells + nperf);
+            const int nperf = wells().well_connpos[wells().number_of_wells];
+            const std::vector<int> well_cells(wells().well_cells, wells().well_cells + nperf);
             const V poly_in_perf = subset(polyin, well_cells);
             const V poly_mc_perf = subset(mc.value(), well_cells);
             const ADB& cq_s_water = cq_s[fluid_.phaseUsage().phase_pos[Water]];
@@ -525,18 +525,18 @@ namespace Opm {
         assembleMassBalanceEq(state);
 
         // -------- Well equations ----------
-        if ( ! stdWells().wellsActive() ) {
+        if ( ! wellsActive() ) {
             return;
         }
 
         V aliveWells;
 
-        const int np = stdWells().wells().number_of_phases;
+        const int np = wells().number_of_phases;
         std::vector<ADB> cq_s(np, ADB::null());
 
-        const int nw = stdWells().wells().number_of_wells;
-        const int nperf = stdWells().wells().well_connpos[nw];
-        const std::vector<int> well_cells(stdWells().wells().well_cells, stdWells().wells().well_cells + nperf);
+        const int nw = wells().number_of_wells;
+        const int nperf = wells().well_connpos[nw];
+        const std::vector<int> well_cells(wells().well_cells, wells().well_cells + nperf);
 
         std::vector<ADB> mob_perfcells(np, ADB::null());
         std::vector<ADB> b_perfcells(np, ADB::null());
@@ -710,11 +710,11 @@ namespace Opm {
     BlackoilPolymerModel<Grid>::computeWaterShearVelocityWells(const SolutionState& state, WellState& xw, const ADB& cq_sw,
                                                                std::vector<double>& water_vel_wells, std::vector<double>& visc_mult_wells)
     {
-        if( ! stdWells().wellsActive() ) return ;
+        if( ! wellsActive() ) return ;
 
-        const int nw = stdWells().wells().number_of_wells;
-        const int nperf = stdWells().wells().well_connpos[nw];
-        const std::vector<int> well_cells(stdWells().wells().well_cells, stdWells().wells().well_cells + nperf);
+        const int nw = wells().number_of_wells;
+        const int nperf = wells().well_connpos[nw];
+        const std::vector<int> well_cells(wells().well_cells, wells().well_cells + nperf);
 
         water_vel_wells.resize(cq_sw.size());
         std::copy(cq_sw.value().data(), cq_sw.value().data() + cq_sw.size(), water_vel_wells.begin());

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
@@ -525,7 +525,7 @@ namespace Opm {
         assembleMassBalanceEq(state);
 
         // -------- Well equations ----------
-        if ( ! wellsActive() ) {
+        if ( ! stdWells().wellsActive() ) {
             return;
         }
 
@@ -710,7 +710,7 @@ namespace Opm {
     BlackoilPolymerModel<Grid>::computeWaterShearVelocityWells(const SolutionState& state, WellState& xw, const ADB& cq_sw,
                                                                std::vector<double>& water_vel_wells, std::vector<double>& visc_mult_wells)
     {
-        if( ! wellsActive() ) return ;
+        if( ! stdWells().wellsActive() ) return ;
 
         const int nw = stdWells().wells().number_of_wells;
         const int nperf = stdWells().wells().well_connpos[nw];


### PR DESCRIPTION
We introduce a `StandardWells` class to handle the current well model we are using, which will be distinguished with the `MultisegmentWells` and other possible well models later in the future. Different well models will be treated separately eventually. 

It is just the very first step, more PRs will come later. 



It is tested with Flow, Flow_polymer, Flow_multisegment and Flow_solvent. It is tested with Norne and SPE9 for Flow.  For other simulators, one example for each. It does not change any results. 